### PR TITLE
Enable rustfmt

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,1 +1,1 @@
-disable_all_formatting = true
+edition = "2024"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ rust-version = "1.94"
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/wjv/lx"
-version = "0.10.0-pre.2"
+version = "0.10.0-feat.issue11"
 
 [[bin]]
 name = "lx"

--- a/src/config/classes.rs
+++ b/src/config/classes.rs
@@ -6,7 +6,6 @@ use std::collections::HashMap;
 use super::error::ConfigError;
 use super::store::config;
 
-
 /// Return the compiled-in file-type class definitions.
 ///
 /// These correspond to the categories in `src/info/filetype.rs`.
@@ -17,55 +16,90 @@ pub fn compiled_classes() -> HashMap<String, Vec<String>> {
     }
 
     HashMap::from([
-        ("image".into(), gl(&[
-            "png", "jfi", "jfif", "jif", "jpe", "jpeg", "jpg", "gif", "bmp",
-            "tiff", "tif", "ppm", "pgm", "pbm", "pnm", "webp", "raw", "arw",
-            "svg", "stl", "eps", "dvi", "ps", "cbr", "jpf", "cbz", "xpm",
-            "ico", "cr2", "orf", "nef", "heif", "avif", "jxl", "j2k", "jp2",
-            "j2c", "jpx",
-        ])),
-        ("video".into(), gl(&[
-            "avi", "flv", "m2v", "m4v", "mkv", "mov", "mp4", "mpeg",
-            "mpg", "ogm", "ogv", "vob", "wmv", "webm", "m2ts", "heic",
-        ])),
-        ("music".into(), gl(&[
-            "aac", "m4a", "mp3", "ogg", "wma", "mka", "opus",
-        ])),
-        ("lossless".into(), gl(&[
-            "alac", "ape", "flac", "wav",
-        ])),
-        ("crypto".into(), gl(&[
-            "asc", "enc", "gpg", "pgp", "sig", "signature", "pfx", "p12",
-        ])),
-        ("document".into(), gl(&[
-            "djvu", "doc", "docx", "dvi", "eml", "eps", "fotd", "key",
-            "keynote", "numbers", "odp", "odt", "pages", "pdf", "ppt",
-            "pptx", "rtf", "xls", "xlsx",
-        ])),
-        ("compressed".into(), gl(&[
-            "zip", "tar", "Z", "z", "gz", "bz2", "a", "ar", "7z",
-            "iso", "dmg", "tc", "rar", "par", "tgz", "xz", "txz",
-            "lz", "tlz", "lzma", "deb", "rpm", "zst", "lz4", "cpio",
-        ])),
-        ("compiled".into(), gl(&[
-            "class", "elc", "hi", "o", "pyc", "zwc", "ko",
-        ])),
-        ("temp".into(), gl(&[
-            "tmp", "swp", "swo", "swn", "bak", "bkp", "bk",
-        ])),
-        ("immediate".into(), vec![
-            "Makefile".into(), "Cargo.toml".into(), "SConstruct".into(),
-            "CMakeLists.txt".into(), "build.gradle".into(), "pom.xml".into(),
-            "Rakefile".into(), "package.json".into(), "Gruntfile.js".into(),
-            "Gruntfile.coffee".into(), "BUILD".into(), "BUILD.bazel".into(),
-            "WORKSPACE".into(), "build.xml".into(), "Podfile".into(),
-            "webpack.config.js".into(), "meson.build".into(),
-            "composer.json".into(), "RoboFile.php".into(), "PKGBUILD".into(),
-            "Justfile".into(), "Procfile".into(), "Dockerfile".into(),
-            "Containerfile".into(), "Vagrantfile".into(), "Brewfile".into(),
-            "Gemfile".into(), "Pipfile".into(), "build.sbt".into(),
-            "mix.exs".into(), "bsconfig.json".into(), "tsconfig.json".into(),
-        ]),
+        (
+            "image".into(),
+            gl(&[
+                "png", "jfi", "jfif", "jif", "jpe", "jpeg", "jpg", "gif", "bmp", "tiff", "tif",
+                "ppm", "pgm", "pbm", "pnm", "webp", "raw", "arw", "svg", "stl", "eps", "dvi", "ps",
+                "cbr", "jpf", "cbz", "xpm", "ico", "cr2", "orf", "nef", "heif", "avif", "jxl",
+                "j2k", "jp2", "j2c", "jpx",
+            ]),
+        ),
+        (
+            "video".into(),
+            gl(&[
+                "avi", "flv", "m2v", "m4v", "mkv", "mov", "mp4", "mpeg", "mpg", "ogm", "ogv",
+                "vob", "wmv", "webm", "m2ts", "heic",
+            ]),
+        ),
+        (
+            "music".into(),
+            gl(&["aac", "m4a", "mp3", "ogg", "wma", "mka", "opus"]),
+        ),
+        ("lossless".into(), gl(&["alac", "ape", "flac", "wav"])),
+        (
+            "crypto".into(),
+            gl(&["asc", "enc", "gpg", "pgp", "sig", "signature", "pfx", "p12"]),
+        ),
+        (
+            "document".into(),
+            gl(&[
+                "djvu", "doc", "docx", "dvi", "eml", "eps", "fotd", "key", "keynote", "numbers",
+                "odp", "odt", "pages", "pdf", "ppt", "pptx", "rtf", "xls", "xlsx",
+            ]),
+        ),
+        (
+            "compressed".into(),
+            gl(&[
+                "zip", "tar", "Z", "z", "gz", "bz2", "a", "ar", "7z", "iso", "dmg", "tc", "rar",
+                "par", "tgz", "xz", "txz", "lz", "tlz", "lzma", "deb", "rpm", "zst", "lz4", "cpio",
+            ]),
+        ),
+        (
+            "compiled".into(),
+            gl(&["class", "elc", "hi", "o", "pyc", "zwc", "ko"]),
+        ),
+        (
+            "temp".into(),
+            gl(&["tmp", "swp", "swo", "swn", "bak", "bkp", "bk"]),
+        ),
+        (
+            "immediate".into(),
+            vec![
+                "Makefile".into(),
+                "Cargo.toml".into(),
+                "SConstruct".into(),
+                "CMakeLists.txt".into(),
+                "build.gradle".into(),
+                "pom.xml".into(),
+                "Rakefile".into(),
+                "package.json".into(),
+                "Gruntfile.js".into(),
+                "Gruntfile.coffee".into(),
+                "BUILD".into(),
+                "BUILD.bazel".into(),
+                "WORKSPACE".into(),
+                "build.xml".into(),
+                "Podfile".into(),
+                "webpack.config.js".into(),
+                "meson.build".into(),
+                "composer.json".into(),
+                "RoboFile.php".into(),
+                "PKGBUILD".into(),
+                "Justfile".into(),
+                "Procfile".into(),
+                "Dockerfile".into(),
+                "Containerfile".into(),
+                "Vagrantfile".into(),
+                "Brewfile".into(),
+                "Gemfile".into(),
+                "Pipfile".into(),
+                "build.sbt".into(),
+                "mix.exs".into(),
+                "bsconfig.json".into(),
+                "tsconfig.json".into(),
+            ],
+        ),
     ])
 }
 
@@ -86,7 +120,6 @@ pub fn all_class_names() -> Vec<String> {
     names.sort();
     names
 }
-
 
 // ── --show-class output ─────────────────────────────────────────
 
@@ -133,7 +166,11 @@ pub fn show_class(name: &str) -> Result<(), ConfigError> {
     } else {
         let mut names: Vec<_> = classes.keys().collect();
         names.sort();
-        let candidates = names.iter().map(|s| s.as_str()).collect::<Vec<_>>().join(", ");
+        let candidates = names
+            .iter()
+            .map(|s| s.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
         Err(ConfigError::NotFound {
             kind: "class",
             kind_plural: "classes",

--- a/src/config/error.rs
+++ b/src/config/error.rs
@@ -6,7 +6,6 @@ use thiserror::Error;
 
 use super::schema::CONFIG_VERSION;
 
-
 /// Errors that can occur when loading or resolving configuration.
 #[derive(Debug, Error)]
 pub enum ConfigError {
@@ -27,8 +26,10 @@ pub enum ConfigError {
     },
 
     /// The config file uses an older format and needs upgrading.
-    #[error("config file {path} uses version {version} format.\n\
-             Run `lx --upgrade-config` to migrate it to version {CONFIG_VERSION}.")]
+    #[error(
+        "config file {path} uses version {version} format.\n\
+             Run `lx --upgrade-config` to migrate it to version {CONFIG_VERSION}."
+    )]
     NeedsUpgrade { path: PathBuf, version: String },
 
     /// Personality inheritance forms a cycle.
@@ -74,6 +75,9 @@ pub(super) trait IoResultExt<T> {
 
 impl<T> IoResultExt<T> for std::io::Result<T> {
     fn with_path(self, path: impl Into<PathBuf>) -> Result<T, ConfigError> {
-        self.map_err(|source| ConfigError::Io { path: path.into(), source })
+        self.map_err(|source| ConfigError::Io {
+            path: path.into(),
+            source,
+        })
     }
 }

--- a/src/config/formats.rs
+++ b/src/config/formats.rs
@@ -6,22 +6,45 @@ use std::collections::HashMap;
 use super::error::ConfigError;
 use super::store::config;
 
-
 /// The compiled-in format definitions as column name strings.
 fn compiled_formats() -> HashMap<String, Vec<String>> {
     HashMap::from([
-        ("long".into(), vec![
-            "permissions".into(), "size".into(), "user".into(), "modified".into(),
-        ]),
-        ("long2".into(), vec![
-            "permissions".into(), "size".into(), "user".into(), "group".into(),
-            "modified".into(), "vcs".into(),
-        ]),
-        ("long3".into(), vec![
-            "permissions".into(), "links".into(), "size".into(), "blocks".into(),
-            "user".into(), "group".into(), "modified".into(), "changed".into(),
-            "created".into(), "accessed".into(), "vcs".into(),
-        ]),
+        (
+            "long".into(),
+            vec![
+                "permissions".into(),
+                "size".into(),
+                "user".into(),
+                "modified".into(),
+            ],
+        ),
+        (
+            "long2".into(),
+            vec![
+                "permissions".into(),
+                "size".into(),
+                "user".into(),
+                "group".into(),
+                "modified".into(),
+                "vcs".into(),
+            ],
+        ),
+        (
+            "long3".into(),
+            vec![
+                "permissions".into(),
+                "links".into(),
+                "size".into(),
+                "blocks".into(),
+                "user".into(),
+                "group".into(),
+                "modified".into(),
+                "changed".into(),
+                "created".into(),
+                "accessed".into(),
+                "vcs".into(),
+            ],
+        ),
     ])
 }
 
@@ -40,7 +63,6 @@ pub fn resolve_formats() -> HashMap<String, Vec<String>> {
     formats
 }
 
-
 // ── --show-format output ────────────────────────────────────────
 
 /// Print a single format definition as copy-pasteable TOML.
@@ -58,7 +80,11 @@ pub fn show_format(name: &str) -> Result<(), ConfigError> {
     } else {
         let mut names: Vec<_> = formats.keys().collect();
         names.sort();
-        let candidates = names.iter().map(|s| s.as_str()).collect::<Vec<_>>().join(", ");
+        let candidates = names
+            .iter()
+            .map(|s| s.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
         Err(ConfigError::NotFound {
             kind: "format",
             kind_plural: "formats",

--- a/src/config/init.rs
+++ b/src/config/init.rs
@@ -6,7 +6,6 @@ use std::path::PathBuf;
 use super::error::{ConfigError, IoResultExt};
 use super::load::{default_config_toml, home_dir};
 
-
 /// The default path for `--init-config` to write to.
 pub fn init_config_path() -> PathBuf {
     home_dir()
@@ -25,9 +24,7 @@ pub fn init_config_path() -> PathBuf {
 pub fn write_init_config(path: &PathBuf) -> Result<(), ConfigError> {
     if path.exists() {
         // The path is added by with_path() — don't repeat it here.
-        let err = std::io::Error::other(
-            "already exists; remove it first or edit it directly",
-        );
+        let err = std::io::Error::other("already exists; remove it first or edit it directly");
         return Err(err).with_path(path);
     }
     fs::write(path, default_config_toml()).with_path(path)

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -19,7 +19,6 @@ use log::*;
 use super::error::{ConfigError, IoResultExt};
 use super::schema::{ACCEPTED_VERSIONS, Config};
 
-
 /// Search for a config file and return its path, or `None`.
 pub fn find_config_path() -> Option<PathBuf> {
     // 1. Explicit env var.
@@ -49,11 +48,7 @@ pub fn find_config_path() -> Option<PathBuf> {
     // 3. XDG_CONFIG_HOME/lx/config.toml
     let xdg = env::var("XDG_CONFIG_HOME")
         .map(PathBuf::from)
-        .unwrap_or_else(|_| {
-            home_dir()
-                .map(|h| h.join(".config"))
-                .unwrap_or_default()
-        });
+        .unwrap_or_else(|_| home_dir().map(|h| h.join(".config")).unwrap_or_default());
     let p = xdg.join("lx").join("config.toml");
     if p.is_file() {
         debug!("Config from XDG: {}", p.display());
@@ -72,7 +67,6 @@ pub fn find_config_path() -> Option<PathBuf> {
 
     None
 }
-
 
 /// Find the drop-in config directory.
 ///
@@ -98,11 +92,7 @@ pub(super) fn find_drop_in_dir(main_config: Option<&Path>) -> Option<PathBuf> {
     // Also check the XDG location (covers ~/.lxconfig.toml users).
     let xdg = env::var("XDG_CONFIG_HOME")
         .map(PathBuf::from)
-        .unwrap_or_else(|_| {
-            home_dir()
-                .map(|h| h.join(".config"))
-                .unwrap_or_default()
-        });
+        .unwrap_or_else(|_| home_dir().map(|h| h.join(".config")).unwrap_or_default());
     let d = xdg.join("lx").join("conf.d");
     if d.is_dir() {
         return Some(d);
@@ -137,17 +127,15 @@ fn load_drop_ins(dir: &Path) -> Vec<(PathBuf, Config)> {
     let mut fragments = Vec::new();
     for path in entries {
         match fs::read_to_string(&path) {
-            Ok(contents) => {
-                match toml::from_str::<Config>(&contents) {
-                    Ok(cfg) => {
-                        debug!("conf.d: loaded {}", path.display());
-                        fragments.push((path, cfg));
-                    }
-                    Err(e) => {
-                        warn!("conf.d: parse error in {}: {e}", path.display());
-                    }
+            Ok(contents) => match toml::from_str::<Config>(&contents) {
+                Ok(cfg) => {
+                    debug!("conf.d: loaded {}", path.display());
+                    fragments.push((path, cfg));
                 }
-            }
+                Err(e) => {
+                    warn!("conf.d: parse error in {}: {e}", path.display());
+                }
+            },
             Err(e) => {
                 warn!("conf.d: failed to read {}: {e}", path.display());
             }
@@ -175,8 +163,10 @@ pub(super) fn try_load_config() -> Result<Option<Config>, ConfigError> {
             });
         }
 
-        let cfg: Config = toml::from_str(&contents)
-            .map_err(|source| ConfigError::Parse { path: path.clone(), source })?;
+        let cfg: Config = toml::from_str(&contents).map_err(|source| ConfigError::Parse {
+            path: path.clone(),
+            source,
+        })?;
 
         // Warn if when blocks are used but version is still 0.3.
         if version == "0.3" {
@@ -223,20 +213,18 @@ pub(super) fn detect_config_version(contents: &str) -> &str {
                     "0.2" => "0.2",
                     "0.3" => "0.3",
                     "0.4" => "0.4",
-                    _ => val,  // unknown version — will fail the check
+                    _ => val, // unknown version — will fail the check
                 };
             }
         }
     }
-    "0.1"  // no version field → legacy
+    "0.1" // no version field → legacy
 }
-
 
 /// The default config as a commented TOML string, for `--init-config`.
 pub fn default_config_toml() -> &'static str {
     include_str!("../../lxconfig.default.toml")
 }
-
 
 // ── [[when]] block support ──────────────────────────────────────
 
@@ -286,7 +274,7 @@ theme = \"lx-24bit\"\n\
     let insert_at = match insert_after {
         Some(i) => i,
         None if in_default => lines.len(),
-        None => return contents.to_string(),  // no [personality.default]
+        None => return contents.to_string(), // no [personality.default]
     };
 
     let mut result = String::new();
@@ -312,13 +300,11 @@ theme = \"lx-24bit\"\n\
 /// expected string as a glob pattern if it contains glob metacharacters.
 pub(super) fn match_string(actual: &str, expected: &str) -> bool {
     if expected.contains(['*', '?', '[']) {
-        glob::Pattern::new(expected)
-            .is_ok_and(|pat| pat.matches(actual))
+        glob::Pattern::new(expected).is_ok_and(|pat| pat.matches(actual))
     } else {
         actual == expected
     }
 }
-
 
 // ── home_dir helper ─────────────────────────────────────────────
 
@@ -326,7 +312,6 @@ pub(super) fn match_string(actual: &str, expected: &str) -> bool {
 pub(super) fn home_dir() -> Option<PathBuf> {
     env::var_os("HOME").map(PathBuf::from)
 }
-
 
 #[cfg(test)]
 mod when_match_test {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -34,18 +34,18 @@
 //! - [`show`] — `--show-config`: human-readable overview.
 //! - [`upgrade`] — `--upgrade-config`: schema version migration.
 
-mod error;
-mod store;
-mod settings;
-mod schema;
-mod load;
-mod personality;
-mod themes;
-mod styles;
 mod classes;
+mod error;
 mod formats;
 mod init;
+mod load;
+mod personality;
+mod schema;
+mod settings;
 mod show;
+mod store;
+mod styles;
+mod themes;
 mod upgrade;
 
 // ── Public re-exports ───────────────────────────────────────────
@@ -67,16 +67,15 @@ pub use self::schema::{Config, StyleDef, ThemeDef};
 pub use self::load::find_config_path;
 
 pub use self::personality::{
-    all_personality_names,
-    dump_personality,
-    dump_personality_all,
-    resolve_personality,
+    all_personality_names, dump_personality, dump_personality_all, resolve_personality,
     save_personality_as,
 };
 
 pub use self::themes::{all_theme_names, dump_theme, dump_theme_all, is_builtin_theme};
 
-pub use self::styles::{all_style_names, compiled_exa_style, dump_style, dump_style_all, resolve_style};
+pub use self::styles::{
+    all_style_names, compiled_exa_style, dump_style, dump_style_all, resolve_style,
+};
 
 pub use self::classes::{all_class_names, resolve_classes, show_class, show_class_all};
 

--- a/src/config/personality.rs
+++ b/src/config/personality.rs
@@ -12,7 +12,6 @@ use super::load::{find_config_path, find_drop_in_dir};
 use super::schema::{ConditionalOverride, PersonalityDef};
 use super::store::config;
 
-
 /// Look up a personality by name, resolving inheritance.
 ///
 /// Config-defined personalities take priority over compiled-in ones.
@@ -40,7 +39,7 @@ pub fn resolve_personality(name: &str) -> Result<Option<PersonalityDef>, ConfigE
         // Look up: config first, then compiled-in.
         let Some(def) = lookup_personality(pname) else {
             if chain.is_empty() {
-                return Ok(None);  // top-level personality not found
+                return Ok(None); // top-level personality not found
             }
             return Err(ConfigError::MissingParent {
                 child: visited[visited.len() - 2].clone(),
@@ -85,9 +84,10 @@ pub fn resolve_personality(name: &str) -> Result<Option<PersonalityDef>, ConfigE
 /// Look up a single personality definition by name (no inheritance).
 fn lookup_personality(name: &str) -> Option<PersonalityDef> {
     if let Some(cfg) = config()
-        && let Some(p) = cfg.personality.get(name) {
-            return Some(p.clone());
-        }
+        && let Some(p) = cfg.personality.get(name)
+    {
+        return Some(p.clone());
+    }
     compiled_personality(name)
 }
 
@@ -117,23 +117,24 @@ fn compiled_personality(name: &str) -> Option<PersonalityDef> {
             ]),
             when: vec![
                 ConditionalOverride {
-                    env: HashMap::from([
-                        ("TERM".into(), toml::Value::String("*-256color".into())),
-                    ]),
-                    settings: HashMap::from([
-                        ("theme".into(), toml::Value::String("lx-256".into())),
-                    ]),
+                    env: HashMap::from([("TERM".into(), toml::Value::String("*-256color".into()))]),
+                    settings: HashMap::from([(
+                        "theme".into(),
+                        toml::Value::String("lx-256".into()),
+                    )]),
                 },
                 ConditionalOverride {
-                    env: HashMap::from([
-                        ("COLORTERM".into(), toml::Value::Array(vec![
+                    env: HashMap::from([(
+                        "COLORTERM".into(),
+                        toml::Value::Array(vec![
                             toml::Value::String("truecolor".into()),
                             toml::Value::String("24bit".into()),
-                        ])),
-                    ]),
-                    settings: HashMap::from([
-                        ("theme".into(), toml::Value::String("lx-24bit".into())),
-                    ]),
+                        ]),
+                    )]),
+                    settings: HashMap::from([(
+                        "theme".into(),
+                        toml::Value::String("lx-24bit".into()),
+                    )]),
                 },
             ],
             ..Default::default()
@@ -145,9 +146,7 @@ fn compiled_personality(name: &str) -> Option<PersonalityDef> {
         "ll" => Some(PersonalityDef {
             inherits: Some("lx".into()),
             format: Some("long2".into()),
-            settings: HashMap::from([
-                ("group-dirs".into(), Str("first".into())),
-            ]),
+            settings: HashMap::from([("group-dirs".into(), Str("first".into()))]),
             ..Default::default()
         }),
         "lll" => Some(PersonalityDef {
@@ -162,9 +161,7 @@ fn compiled_personality(name: &str) -> Option<PersonalityDef> {
         }),
         "la" => Some(PersonalityDef {
             inherits: Some("ll".into()),
-            settings: HashMap::from([
-                ("all".into(), Boolean(true)),
-            ]),
+            settings: HashMap::from([("all".into(), Boolean(true))]),
             ..Default::default()
         }),
         "tree" => Some(PersonalityDef {
@@ -187,19 +184,14 @@ fn compiled_personality(name: &str) -> Option<PersonalityDef> {
     }
 }
 
-
 // ── --dump-personality output ───────────────────────────────────
 
 /// Names of all compiled-in personalities.
-const COMPILED_PERSONALITIES: &[&str] = &[
-    "default", "lx", "ll", "lll", "la", "tree", "ls",
-];
+const COMPILED_PERSONALITIES: &[&str] = &["default", "lx", "ll", "lll", "la", "tree", "ls"];
 
 /// Return the names of all known personalities (compiled-in + config).
 pub fn all_personality_names() -> Vec<String> {
-    let mut names: Vec<String> = COMPILED_PERSONALITIES.iter()
-        .map(|s| (*s).into())
-        .collect();
+    let mut names: Vec<String> = COMPILED_PERSONALITIES.iter().map(|s| (*s).into()).collect();
     if let Some(cfg) = config() {
         for name in cfg.personality.keys() {
             if !names.iter().any(|n| n == name) {
@@ -225,7 +217,8 @@ fn format_personality_toml(name: &str) -> Option<String> {
         lines.push(format!("format = \"{format}\""));
     }
     if let Some(ref columns) = def.columns {
-        let entries: Vec<String> = columns.to_csv()
+        let entries: Vec<String> = columns
+            .to_csv()
             .split(',')
             .map(|s| format!("\"{}\"", s.trim()))
             .collect();
@@ -275,13 +268,14 @@ pub fn dump_personality_all() {
     let mut first = true;
     for name in &names {
         if let Some(toml) = format_personality_toml(name) {
-            if !first { println!(); }
+            if !first {
+                println!();
+            }
             println!("{toml}");
             first = false;
         }
     }
 }
-
 
 // ── --save-as=NAME ──────────────────────────────────────────────
 
@@ -306,7 +300,10 @@ pub fn save_personality_as(
 
     // Build TOML lines.
     let mut lines = vec![
-        format!("# Generated by lx --save-as on {}", Local::now().format("%Y-%m-%d")),
+        format!(
+            "# Generated by lx --save-as on {}",
+            Local::now().format("%Y-%m-%d")
+        ),
         String::new(),
         format!("[personality.{name}]"),
     ];
@@ -333,17 +330,16 @@ pub fn save_personality_as(
     let toml_content = lines.join("\n");
 
     // Find or create the conf.d/ directory.
-    let conf_dir = find_drop_in_dir(find_config_path().as_deref())
-        .unwrap_or_else(|| {
-            // No config file exists; use the XDG default location.
-            let xdg = std::env::var("XDG_CONFIG_HOME")
-                .map(PathBuf::from)
-                .unwrap_or_else(|_| {
-                    let home = std::env::var("HOME").expect("HOME not set");
-                    PathBuf::from(home).join(".config")
-                });
-            xdg.join("lx").join("conf.d")
-        });
+    let conf_dir = find_drop_in_dir(find_config_path().as_deref()).unwrap_or_else(|| {
+        // No config file exists; use the XDG default location.
+        let xdg = std::env::var("XDG_CONFIG_HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| {
+                let home = std::env::var("HOME").expect("HOME not set");
+                PathBuf::from(home).join(".config")
+            });
+        xdg.join("lx").join("conf.d")
+    });
 
     std::fs::create_dir_all(&conf_dir).with_path(&conf_dir)?;
 
@@ -353,7 +349,11 @@ pub fn save_personality_as(
     if file_path.exists() {
         let backup = file_path.with_extension("toml.bak");
         std::fs::rename(&file_path, &backup).with_path(&file_path)?;
-        eprintln!("lx: backed up {} → {}", file_path.display(), backup.display());
+        eprintln!(
+            "lx: backed up {} → {}",
+            file_path.display(),
+            backup.display()
+        );
     }
 
     std::fs::write(&file_path, &toml_content).with_path(&file_path)?;

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -14,7 +14,6 @@ use serde::Deserialize;
 
 use super::settings::settings_to_args;
 
-
 // ── Config schema versioning ────────────────────────────────────
 
 /// The current config schema version.
@@ -27,7 +26,6 @@ pub const CONFIG_VERSION: &str = "0.6";
 /// setting is `time = "..."` (gone in 0.5), which triggers a warning
 /// and is ignored if found in 0.3/0.4 files.
 pub(super) const ACCEPTED_VERSIONS: &[&str] = &["0.3", "0.4", "0.5", "0.6"];
-
 
 // ── Top-level config ────────────────────────────────────────────
 
@@ -66,14 +64,23 @@ impl Config {
     /// Merge a drop-in fragment into this config.  Each named entry
     /// in the fragment overrides the same-named entry in `self`.
     pub(super) fn merge(&mut self, other: Config) {
-        for (k, v) in other.format    { self.format.insert(k, v); }
-        for (k, v) in other.personality { self.personality.insert(k, v); }
-        for (k, v) in other.theme     { self.theme.insert(k, v); }
-        for (k, v) in other.style     { self.style.insert(k, v); }
-        for (k, v) in other.class     { self.class.insert(k, v); }
+        for (k, v) in other.format {
+            self.format.insert(k, v);
+        }
+        for (k, v) in other.personality {
+            self.personality.insert(k, v);
+        }
+        for (k, v) in other.theme {
+            self.theme.insert(k, v);
+        }
+        for (k, v) in other.style {
+            self.style.insert(k, v);
+        }
+        for (k, v) in other.class {
+            self.class.insert(k, v);
+        }
     }
 }
-
 
 // ── ThemeDef ────────────────────────────────────────────────────
 
@@ -105,7 +112,6 @@ pub struct ThemeDef {
     pub ui: HashMap<String, String>,
 }
 
-
 // ── StyleDef ────────────────────────────────────────────────────
 
 /// A named file colour style set under `[style.NAME]`.
@@ -127,7 +133,6 @@ pub struct StyleDef {
     #[serde(flatten)]
     pub patterns: HashMap<String, String>,
 }
-
 
 // ── ConditionalOverride ─────────────────────────────────────────
 
@@ -186,7 +191,6 @@ impl ConditionalOverride {
     }
 }
 
-
 // ── PersonalityDef ──────────────────────────────────────────────
 
 /// A personality bundles format, columns, and settings.
@@ -242,7 +246,6 @@ impl PersonalityDef {
     }
 }
 
-
 // ── StringOrList ────────────────────────────────────────────────
 
 /// A value that can be either a TOML string (comma-separated) or a
@@ -265,7 +268,8 @@ impl StringOrList {
 
 impl<'de> Deserialize<'de> for StringOrList {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where D: serde::Deserializer<'de>,
+    where
+        D: serde::Deserializer<'de>,
     {
         use serde::de;
 
@@ -282,7 +286,10 @@ impl<'de> Deserialize<'de> for StringOrList {
                 Ok(StringOrList::Str(v.to_string()))
             }
 
-            fn visit_seq<A: de::SeqAccess<'de>>(self, mut seq: A) -> Result<StringOrList, A::Error> {
+            fn visit_seq<A: de::SeqAccess<'de>>(
+                self,
+                mut seq: A,
+            ) -> Result<StringOrList, A::Error> {
                 let mut v = Vec::new();
                 while let Some(s) = seq.next_element::<String>()? {
                     v.push(s);

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -10,7 +10,6 @@ use std::ffi::OsString;
 
 use log::*;
 
-
 /// How a TOML value maps to a CLI argument.
 pub(crate) enum SettingKind {
     /// String value: `--flag=VALUE`
@@ -31,6 +30,7 @@ pub(crate) struct SettingDef {
 /// Master table of all config keys that map to CLI flags.
 ///
 /// Adding a new flag to lx = adding one entry here.
+#[rustfmt::skip]
 pub(crate) static SETTING_FLAGS: &[SettingDef] = &[
     // display options
     SettingDef { key: "oneline",       flag: "--oneline",        kind: SettingKind::Bool },
@@ -163,18 +163,18 @@ fn removed_setting_hint(key: &str) -> Option<&'static str> {
         "time" => Some(
             "the `time` setting was removed in config version 0.5; \
              use `modified`, `changed`, `accessed`, or `created` \
-             (each a boolean) to add timestamp columns"
+             (each a boolean) to add timestamp columns",
         ),
         "numeric" => Some(
             "the `numeric` setting was removed in config version 0.5; \
              UID and GID are now first-class columns. Use \
              `uid = true, gid = true, no-user = true, no-group = true` \
-             for the old `-n` behaviour, or pick whichever columns you want"
+             for the old `-n` behaviour, or pick whichever columns you want",
         ),
         "colour-scale" | "color-scale" => Some(
             "the `colour-scale` setting was removed in config version 0.6; \
              use `gradient = \"all\"` (default) or \"none\"/\"size\"/\"date\". \
-             Run `lx --upgrade-config` to migrate automatically"
+             Run `lx --upgrade-config` to migrate automatically",
         ),
         _ => None,
     }
@@ -182,7 +182,10 @@ fn removed_setting_hint(key: &str) -> Option<&'static str> {
 
 /// Convert a settings map (from `[defaults]` or `[personality.*]`)
 /// into synthetic CLI arguments.  Unknown keys are warned about.
-pub(super) fn settings_to_args(settings: &HashMap<String, toml::Value>, context: &str) -> Vec<OsString> {
+pub(super) fn settings_to_args(
+    settings: &HashMap<String, toml::Value>,
+    context: &str,
+) -> Vec<OsString> {
     let mut args = Vec::new();
 
     for (key, value) in settings {
@@ -228,7 +231,9 @@ pub(super) fn settings_to_args(settings: &HashMap<String, toml::Value>, context:
                             if let toml::Value::String(s) = item {
                                 parts.push(s.as_str().to_owned());
                             } else {
-                                warn!("Expected string in array for '{key}' in {context}; ignoring element");
+                                warn!(
+                                    "Expected string in array for '{key}' in {context}; ignoring element"
+                                );
                             }
                         }
                         if parts.is_empty() {
@@ -247,7 +252,9 @@ pub(super) fn settings_to_args(settings: &HashMap<String, toml::Value>, context:
                 let n = match value {
                     toml::Value::Integer(n) => *n,
                     toml::Value::String(s) => {
-                        if let Ok(n) = s.parse::<i64>() { n } else {
+                        if let Ok(n) = s.parse::<i64>() {
+                            n
+                        } else {
                             warn!("Expected integer for '{key}' in {context}; ignoring");
                             continue;
                         }

--- a/src/config/show.rs
+++ b/src/config/show.rs
@@ -14,7 +14,6 @@ use super::store::config;
 use super::styles::resolve_style;
 use super::themes::is_builtin_theme;
 
-
 /// Display the active configuration to stdout.
 ///
 /// Shows the resolved personality, format, theme, style, and classes,
@@ -23,10 +22,10 @@ pub fn show_config(personality_name: &str, activated_by: &str, cli_theme_overrid
     // Styling consistent with --help: yellow bold headers, cyan bold
     // literals/names, green values/paths, dimmed for source annotations.
     let heading = Style::new().bold().fg(Color::Yellow);
-    let label   = Style::new().bold();
-    let name    = Style::new().bold().fg(Color::Cyan);
-    let value   = Style::new().fg(Color::Green);
-    let dimmed  = Style::new().dimmed();
+    let label = Style::new().bold();
+    let name = Style::new().bold().fg(Color::Cyan);
+    let value = Style::new().fg(Color::Green);
+    let dimmed = Style::new().dimmed();
 
     let config_path = find_config_path();
     let cfg = config();
@@ -36,13 +35,26 @@ pub fn show_config(personality_name: &str, activated_by: &str, cli_theme_overrid
 
     // Config file.
     match &config_path {
-        Some(p) => println!("{} {}", label.paint("Config file:"), value.paint(p.display().to_string())),
-        None    => println!("{} {}", label.paint("Config file:"), dimmed.paint("(none)")),
+        Some(p) => println!(
+            "{} {}",
+            label.paint("Config file:"),
+            value.paint(p.display().to_string())
+        ),
+        None => println!("{} {}", label.paint("Config file:"), dimmed.paint("(none)")),
     }
-    println!("{} {}", label.paint("Config version:"), value.paint(CONFIG_VERSION));
+    println!(
+        "{} {}",
+        label.paint("Config version:"),
+        value.paint(CONFIG_VERSION)
+    );
     if let Some(cfg) = cfg
-        && !cfg.drop_in_paths.is_empty() {
-        println!("{} {} file(s) from conf.d/", label.paint("Drop-ins:"), value.paint(cfg.drop_in_paths.len().to_string()));
+        && !cfg.drop_in_paths.is_empty()
+    {
+        println!(
+            "{} {} file(s) from conf.d/",
+            label.paint("Drop-ins:"),
+            value.paint(cfg.drop_in_paths.len().to_string())
+        );
         for p in &cfg.drop_in_paths {
             println!("  {}", dimmed.paint(p.display().to_string()));
         }
@@ -50,14 +62,22 @@ pub fn show_config(personality_name: &str, activated_by: &str, cli_theme_overrid
     println!();
 
     // Personality.
-    println!("{} {}", label.paint("Personality:"), name.paint(personality_name));
+    println!(
+        "{} {}",
+        label.paint("Personality:"),
+        name.paint(personality_name)
+    );
     let source = if cfg.is_some_and(|c| c.personality.contains_key(personality_name)) {
         "config"
     } else {
         "builtin"
     };
     println!("  {} {}", label.paint("source:"), dimmed.paint(source));
-    println!("  {} {}", label.paint("activated by:"), dimmed.paint(activated_by));
+    println!(
+        "  {} {}",
+        label.paint("activated by:"),
+        dimmed.paint(activated_by)
+    );
 
     if let Ok(Some(p)) = resolve_personality(personality_name) {
         if let Some(ref inherits) = p.inherits {
@@ -67,14 +87,22 @@ pub fn show_config(personality_name: &str, activated_by: &str, cli_theme_overrid
             println!("  {} {}", label.paint("format:"), name.paint(fmt));
         }
         if let Some(ref cols) = p.columns {
-            println!("  {} {}", label.paint("columns:"), value.paint(cols.to_csv()));
+            println!(
+                "  {} {}",
+                label.paint("columns:"),
+                value.paint(cols.to_csv())
+            );
         }
         if !p.settings.is_empty() {
-            println!("  {}",label.paint("settings:"));
+            println!("  {}", label.paint("settings:"));
             let mut keys: Vec<_> = p.settings.keys().collect();
             keys.sort();
             for key in keys {
-                println!("    {} = {}", name.paint(key), value.paint(p.settings[key].to_string()));
+                println!(
+                    "    {} = {}",
+                    name.paint(key),
+                    value.paint(p.settings[key].to_string())
+                );
             }
         }
     }
@@ -86,9 +114,15 @@ pub fn show_config(personality_name: &str, activated_by: &str, cli_theme_overrid
         resolve_personality(personality_name)
             .ok()
             .flatten()
-            .and_then(|p| p.settings.get("theme").and_then(|v| {
-                if let toml::Value::String(s) = v { Some(s.clone()) } else { None }
-            }))
+            .and_then(|p| {
+                p.settings.get("theme").and_then(|v| {
+                    if let toml::Value::String(s) = v {
+                        Some(s.clone())
+                    } else {
+                        None
+                    }
+                })
+            })
     });
 
     if let Some(ref tname) = theme_name {
@@ -103,16 +137,22 @@ pub fn show_config(personality_name: &str, activated_by: &str, cli_theme_overrid
         println!("  {} {}", label.paint("source:"), dimmed.paint(source));
 
         if is_builtin_theme(tname) {
-            println!("  {} {} {}", label.paint("use-style:"), name.paint("exa"), dimmed.paint("(implicit)"));
+            println!(
+                "  {} {} {}",
+                label.paint("use-style:"),
+                name.paint("exa"),
+                dimmed.paint("(implicit)")
+            );
         } else if let Some(cfg) = cfg
-            && let Some(theme) = cfg.theme.get(tname) {
-                if let Some(ref inherits) = theme.inherits {
-                    println!("  {} {}", label.paint("inherits:"), name.paint(inherits));
-                }
-                if let Some(ref style) = theme.use_style {
-                    println!("  {} {}", label.paint("use-style:"), name.paint(style));
-                }
+            && let Some(theme) = cfg.theme.get(tname)
+        {
+            if let Some(ref inherits) = theme.inherits {
+                println!("  {} {}", label.paint("inherits:"), name.paint(inherits));
             }
+            if let Some(ref style) = theme.use_style {
+                println!("  {} {}", label.paint("use-style:"), name.paint(style));
+            }
+        }
     } else {
         println!("{} {}", label.paint("Theme:"), dimmed.paint("(none)"));
     }
@@ -146,7 +186,11 @@ pub fn show_config(personality_name: &str, activated_by: &str, cli_theme_overrid
                 let mut keys: Vec<_> = style.classes.keys().collect();
                 keys.sort();
                 for key in keys {
-                    println!("    {} = {}", name.paint(key), value.paint(format!("\"{}\"", style.classes[key])));
+                    println!(
+                        "    {} = {}",
+                        name.paint(key),
+                        value.paint(format!("\"{}\"", style.classes[key]))
+                    );
                 }
             }
             if !style.patterns.is_empty() {
@@ -154,7 +198,11 @@ pub fn show_config(personality_name: &str, activated_by: &str, cli_theme_overrid
                 let mut keys: Vec<_> = style.patterns.keys().collect();
                 keys.sort();
                 for key in keys {
-                    println!("    {} = {}", name.paint(format!("\"{key}\"")), value.paint(format!("\"{}\"", style.patterns[key])));
+                    println!(
+                        "    {} = {}",
+                        name.paint(format!("\"{key}\"")),
+                        value.paint(format!("\"{}\"", style.patterns[key]))
+                    );
                 }
             }
         }
@@ -165,7 +213,11 @@ pub fn show_config(personality_name: &str, activated_by: &str, cli_theme_overrid
 
     // Classes.
     let classes = resolve_classes();
-    println!("{} {} defined", label.paint("Classes:"), value.paint(classes.len().to_string()));
+    println!(
+        "{} {} defined",
+        label.paint("Classes:"),
+        value.paint(classes.len().to_string())
+    );
     let mut names: Vec<_> = classes.keys().collect();
     names.sort();
     for cname in names {
@@ -175,9 +227,12 @@ pub fn show_config(personality_name: &str, activated_by: &str, cli_theme_overrid
             "builtin"
         };
         let patterns = &classes[cname];
-        println!("  {} {}: {} patterns",
-            name.paint(cname), dimmed.paint(format!("({source})")),
-            value.paint(patterns.len().to_string()));
+        println!(
+            "  {} {}: {} patterns",
+            name.paint(cname),
+            dimmed.paint(format!("({source})")),
+            value.paint(patterns.len().to_string())
+        );
     }
     println!();
 

--- a/src/config/store.rs
+++ b/src/config/store.rs
@@ -10,7 +10,6 @@ use super::error::ConfigError;
 use super::load::try_load_config;
 use super::schema::Config;
 
-
 /// Storage for the user's configuration.
 ///
 /// Populated once by `init_config()` early in `try_main()`, then read

--- a/src/config/styles.rs
+++ b/src/config/styles.rs
@@ -7,7 +7,6 @@ use super::error::ConfigError;
 use super::schema::StyleDef;
 use super::store::config;
 
-
 /// Return the compiled-in "exa" style definition.
 ///
 /// This maps the built-in file-type classes to their default colours,
@@ -15,16 +14,16 @@ use super::store::config;
 pub fn compiled_exa_style() -> StyleDef {
     StyleDef {
         classes: HashMap::from([
-            ("temp".into(),       "38;5;244".into()),
-            ("immediate".into(),  "bold underline yellow".into()),
-            ("image".into(),      "38;5;133".into()),
-            ("video".into(),      "38;5;135".into()),
-            ("music".into(),      "38;5;92".into()),
-            ("lossless".into(),   "38;5;93".into()),
-            ("crypto".into(),     "38;5;109".into()),
-            ("document".into(),   "38;5;105".into()),
+            ("temp".into(), "38;5;244".into()),
+            ("immediate".into(), "bold underline yellow".into()),
+            ("image".into(), "38;5;133".into()),
+            ("video".into(), "38;5;135".into()),
+            ("music".into(), "38;5;92".into()),
+            ("lossless".into(), "38;5;93".into()),
+            ("crypto".into(), "38;5;109".into()),
+            ("document".into(), "38;5;105".into()),
             ("compressed".into(), "red".into()),
-            ("compiled".into(),   "38;5;137".into()),
+            ("compiled".into(), "38;5;137".into()),
         ]),
         patterns: HashMap::new(),
     }
@@ -33,15 +32,15 @@ pub fn compiled_exa_style() -> StyleDef {
 /// Look up a style by name: config first, then compiled-in "exa".
 pub fn resolve_style(name: &str) -> Option<StyleDef> {
     if let Some(cfg) = config()
-        && let Some(s) = cfg.style.get(name) {
-            return Some(s.clone());
-        }
+        && let Some(s) = cfg.style.get(name)
+    {
+        return Some(s.clone());
+    }
     match name {
         "exa" => Some(compiled_exa_style()),
         _ => None,
     }
 }
-
 
 // ── --dump-style output ─────────────────────────────────────────
 
@@ -107,7 +106,9 @@ pub fn dump_style_all() {
     let mut first = true;
     for name in &names {
         if let Some(toml) = format_style_toml(name) {
-            if !first { println!(); }
+            if !first {
+                println!();
+            }
             println!("{toml}");
             first = false;
         }

--- a/src/config/themes.rs
+++ b/src/config/themes.rs
@@ -8,7 +8,6 @@
 use super::error::ConfigError;
 use super::store::config;
 
-
 /// Names of the compiled-in themes that don't live in any config
 /// file.  These are always resolvable by `--theme=NAME` and appear
 /// in the `--dump-theme` listing.
@@ -18,7 +17,6 @@ pub const BUILTIN_THEMES: &[&str] = &["exa", "lx-256", "lx-24bit"];
 pub fn is_builtin_theme(name: &str) -> bool {
     BUILTIN_THEMES.contains(&name)
 }
-
 
 // ── --dump-theme output ─────────────────────────────────────────
 
@@ -70,11 +68,15 @@ fn format_theme_toml(name: &str) -> Option<String> {
     // pull the date keys out, sort them by (bulk vs per-column, then
     // tier index), and re-insert them as a contiguous block at the
     // alphabetical position where plain `date` would fall.
-    let (mut date_keys, mut other_keys): (Vec<_>, Vec<_>) = theme.ui.keys()
+    let (mut date_keys, mut other_keys): (Vec<_>, Vec<_>) = theme
+        .ui
+        .keys()
         .partition(|k| k.as_str() == "date" || k.starts_with("date-"));
     other_keys.sort();
     date_keys.sort_by(|a, b| {
-        date_sort_key(a).cmp(&date_sort_key(b)).then_with(|| a.cmp(b))
+        date_sort_key(a)
+            .cmp(&date_sort_key(b))
+            .then_with(|| a.cmp(b))
     });
 
     // Build the date block with blank-line separators between
@@ -134,9 +136,7 @@ fn format_theme_toml(name: &str) -> Option<String> {
 /// Non-date keys return `(u8::MAX, 0)`; the caller is expected not
 /// to pass them.
 fn date_sort_key(key: &str) -> (u8, u8) {
-    const TIERS: [&str; 8] = [
-        "", "now", "today", "week", "month", "year", "old", "flat",
-    ];
+    const TIERS: [&str; 8] = ["", "now", "today", "week", "month", "year", "old", "flat"];
     const COLS: [&str; 4] = ["modified", "accessed", "changed", "created"];
 
     if key == "date" {
@@ -195,7 +195,9 @@ pub fn dump_theme_all() {
     let mut first = true;
     for name in &names {
         if let Some(toml) = format_theme_toml(name) {
-            if !first { println!(); }
+            if !first {
+                println!();
+            }
             println!("{toml}");
             first = false;
         }

--- a/src/config/upgrade.rs
+++ b/src/config/upgrade.rs
@@ -20,7 +20,6 @@ use super::error::{ConfigError, IoResultExt};
 use super::load::{detect_config_version, inject_auto_select_blocks};
 use super::schema::CONFIG_VERSION;
 
-
 /// Upgrade an older config file to the current format.
 pub fn upgrade_config(path: &PathBuf) -> Result<(), ConfigError> {
     let contents = fs::read_to_string(path).with_path(path)?;
@@ -39,10 +38,7 @@ pub fn upgrade_config(path: &PathBuf) -> Result<(), ConfigError> {
             if !trimmed.contains('=') {
                 continue;
             }
-            if !warned_time
-                && trimmed.starts_with("time")
-                && !trimmed.starts_with("time-style")
-            {
+            if !warned_time && trimmed.starts_with("time") && !trimmed.starts_with("time-style") {
                 eprintln!(
                     "lx: warning: `time = \"...\"` is removed in config \
                      version 0.5; use `modified`, `changed`, `accessed`, \
@@ -91,10 +87,7 @@ pub fn upgrade_config(path: &PathBuf) -> Result<(), ConfigError> {
                 || l.starts_with("env.COLORTERM ")
                 || l.starts_with("env.COLORTERM=")
         });
-        if version == "0.5"
-            && updated.contains("[personality.default]")
-            && !has_term_detection
-        {
+        if version == "0.5" && updated.contains("[personality.default]") && !has_term_detection {
             updated = inject_auto_select_blocks(&updated);
             eprintln!(
                 "Note: added auto-selection [[when]] blocks to \
@@ -121,13 +114,18 @@ pub fn upgrade_config(path: &PathBuf) -> Result<(), ConfigError> {
         fs::write(path, &updated).with_path(path)?;
 
         eprintln!("Original config saved to {}", backup.display());
-        eprintln!("Upgraded {} from version {version} to {CONFIG_VERSION}", path.display());
+        eprintln!(
+            "Upgraded {} from version {version} to {CONFIG_VERSION}",
+            path.display()
+        );
         return Ok(());
     }
 
     // Parse with the permissive legacy struct (handles all old formats).
-    let legacy: LegacyConfig = toml::from_str(&contents)
-        .map_err(|source| ConfigError::Parse { path: path.clone(), source })?;
+    let legacy: LegacyConfig = toml::from_str(&contents).map_err(|source| ConfigError::Parse {
+        path: path.clone(),
+        source,
+    })?;
 
     let mut out = String::new();
     writeln!(out, "version = \"{CONFIG_VERSION}\"").unwrap();
@@ -136,7 +134,8 @@ pub fn upgrade_config(path: &PathBuf) -> Result<(), ConfigError> {
     if !legacy.format.is_empty() {
         out.push_str("\n[format]\n");
         for (name, columns) in &legacy.format {
-            let cols = columns.iter()
+            let cols = columns
+                .iter()
                 .map(|c| format!("\"{c}\""))
                 .collect::<Vec<_>>()
                 .join(", ");
@@ -171,7 +170,7 @@ pub fn upgrade_config(path: &PathBuf) -> Result<(), ConfigError> {
     // Personalities (preserved as-is, except lx handled above for 0.1).
     for (name, settings) in &legacy.personality {
         if version == "0.1" && name == "lx" {
-            continue;  // already handled above
+            continue; // already handled above
         }
         writeln!(out, "\n[personality.{name}]").unwrap();
         for (key, value) in settings {
@@ -187,7 +186,10 @@ pub fn upgrade_config(path: &PathBuf) -> Result<(), ConfigError> {
     fs::write(path, &out).with_path(path)?;
 
     eprintln!("Original config saved to {}", backup.display());
-    eprintln!("Upgraded {} from version {version} to {CONFIG_VERSION}", path.display());
+    eprintln!(
+        "Upgraded {} from version {version} to {CONFIG_VERSION}",
+        path.display()
+    );
     eprintln!("Note: comments were not preserved. You may want to review the result.");
 
     Ok(())
@@ -214,13 +216,14 @@ fn rewrite_colour_scale_to_gradient(contents: &str) -> (String, usize) {
         // Strip the trailing newline for matching, then add it back.
         let (body, newline) = match line.strip_suffix('\n') {
             Some(b) => (b, "\n"),
-            None    => (line, ""),
+            None => (line, ""),
         };
         let trimmed = body.trim_start();
         let indent_len = body.len() - trimmed.len();
         let indent = &body[..indent_len];
 
-        let key_match = trimmed.strip_prefix("colour-scale")
+        let key_match = trimmed
+            .strip_prefix("colour-scale")
             .or_else(|| trimmed.strip_prefix("color-scale"));
 
         if let Some(rest) = key_match {
@@ -233,7 +236,7 @@ fn rewrite_colour_scale_to_gradient(contents: &str) -> (String, usize) {
                 // Strip an optional trailing comment.
                 let (val_with_quotes, comment) = match value_part.find('#') {
                     Some(i) => (value_part[..i].trim_end(), &value_part[i..]),
-                    None    => (value_part.trim_end(), ""),
+                    None => (value_part.trim_end(), ""),
                 };
                 let stripped = val_with_quotes
                     .trim_start_matches(['"', '\''])
@@ -263,7 +266,6 @@ fn rewrite_colour_scale_to_gradient(contents: &str) -> (String, usize) {
     (out, count)
 }
 
-
 /// Legacy config structure for migration.  Uses raw TOML tables
 /// so we can round-trip key-value pairs without losing data.
 #[derive(Debug, Default, Deserialize)]
@@ -279,16 +281,14 @@ struct LegacyConfig {
     personality: HashMap<String, HashMap<String, toml::Value>>,
 }
 
-
 #[cfg(test)]
 mod rewrite_test {
     use super::rewrite_colour_scale_to_gradient;
 
     #[test]
     fn rewrites_none() {
-        let (out, n) = rewrite_colour_scale_to_gradient(
-            "[personality.default]\ncolour-scale = \"none\"\n"
-        );
+        let (out, n) =
+            rewrite_colour_scale_to_gradient("[personality.default]\ncolour-scale = \"none\"\n");
         assert_eq!(n, 1);
         assert!(out.contains("gradient = \"none\""));
         assert!(!out.contains("colour-scale"));
@@ -296,45 +296,39 @@ mod rewrite_test {
 
     #[test]
     fn rewrites_16_to_all() {
-        let (out, n) = rewrite_colour_scale_to_gradient(
-            "[personality.default]\ncolour-scale = \"16\"\n"
-        );
+        let (out, n) =
+            rewrite_colour_scale_to_gradient("[personality.default]\ncolour-scale = \"16\"\n");
         assert_eq!(n, 1);
         assert!(out.contains("gradient = \"all\""));
     }
 
     #[test]
     fn rewrites_256_to_all() {
-        let (out, n) = rewrite_colour_scale_to_gradient(
-            "[personality.default]\ncolour-scale = \"256\"\n"
-        );
+        let (out, n) =
+            rewrite_colour_scale_to_gradient("[personality.default]\ncolour-scale = \"256\"\n");
         assert_eq!(n, 1);
         assert!(out.contains("gradient = \"all\""));
     }
 
     #[test]
     fn rewrites_color_scale_alias() {
-        let (out, n) = rewrite_colour_scale_to_gradient(
-            "[personality.default]\ncolor-scale = \"none\"\n"
-        );
+        let (out, n) =
+            rewrite_colour_scale_to_gradient("[personality.default]\ncolor-scale = \"none\"\n");
         assert_eq!(n, 1);
         assert!(out.contains("gradient = \"none\""));
     }
 
     #[test]
     fn preserves_indent_and_trailing_comment() {
-        let (out, n) = rewrite_colour_scale_to_gradient(
-            "  colour-scale = \"16\"   # nice gradient\n"
-        );
+        let (out, n) =
+            rewrite_colour_scale_to_gradient("  colour-scale = \"16\"   # nice gradient\n");
         assert_eq!(n, 1);
         assert!(out.contains("  gradient = \"all\" # nice gradient"));
     }
 
     #[test]
     fn does_not_rewrite_unknown_value() {
-        let (out, n) = rewrite_colour_scale_to_gradient(
-            "colour-scale = \"surprise\"\n"
-        );
+        let (out, n) = rewrite_colour_scale_to_gradient("colour-scale = \"surprise\"\n");
         assert_eq!(n, 0);
         assert!(out.contains("colour-scale"));
     }

--- a/src/fs/dir.rs
+++ b/src/fs/dir.rs
@@ -1,14 +1,13 @@
 use crate::fs::feature::VcsCache;
 use crate::fs::fields::VcsStatus;
-use std::io;
 use std::fs;
+use std::io;
 use std::path::{Path, PathBuf};
 use std::slice::Iter as SliceIter;
 
 use log::*;
 
 use crate::fs::File;
-
 
 /// A directory entry: path plus the file type obtained cheaply from `readdir`.
 pub struct DirEntry {
@@ -23,7 +22,6 @@ pub struct DirEntry {
 /// check the existence of surrounding files, then highlight themselves
 /// accordingly. (See `File#get_source_files`)
 pub struct Dir {
-
     /// A vector of the files that have been read from this directory.
     contents: Vec<DirEntry>,
 
@@ -32,7 +30,6 @@ pub struct Dir {
 }
 
 impl Dir {
-
     /// Create a new Dir object filled with all the files in the directory
     /// pointed to by the given path. Fails if the directory can’t be read, or
     /// isn’t actually a directory, or if there’s an IO error that occurs at
@@ -45,23 +42,33 @@ impl Dir {
         info!("Reading directory {}", path.display());
 
         let contents = fs::read_dir(&path)?
-                          .map(|result| result.map(|entry| {
-                              let file_type = entry.file_type().ok();
-                              DirEntry { path: entry.path(), file_type }
-                          }))
-                          .collect::<Result<_, _>>()?;
+            .map(|result| {
+                result.map(|entry| {
+                    let file_type = entry.file_type().ok();
+                    DirEntry {
+                        path: entry.path(),
+                        file_type,
+                    }
+                })
+            })
+            .collect::<Result<_, _>>()?;
 
         Ok(Self { contents, path })
     }
 
     /// Produce an iterator of IO results of trying to read all the files in
     /// this directory.
-    pub fn files<'dir, 'ig>(&'dir self, dots: DotFilter, git: Option<&'ig dyn VcsCache>, git_ignoring: bool) -> Files<'dir, 'ig> {
+    pub fn files<'dir, 'ig>(
+        &'dir self,
+        dots: DotFilter,
+        git: Option<&'ig dyn VcsCache>,
+        git_ignoring: bool,
+    ) -> Files<'dir, 'ig> {
         Files {
-            inner:     self.contents.iter(),
-            dir:       self,
-            dotfiles:  dots.shows_dotfiles(),
-            dots:      dots.dots(),
+            inner: self.contents.iter(),
+            dir: self,
+            dotfiles: dots.shows_dotfiles(),
+            dots: dots.dots(),
             git,
             git_ignoring,
         }
@@ -78,10 +85,8 @@ impl Dir {
     }
 }
 
-
 /// Iterator over reading the contents of a directory as `File` objects.
 pub struct Files<'dir, 'ig> {
-
     /// The internal iterator over the entries that have been read already.
     inner: SliceIter<'dir, DirEntry>,
 
@@ -117,37 +122,40 @@ impl<'dir> Files<'dir, '_> {
             if let Some(entry) = self.inner.next() {
                 let path = &entry.path;
                 let filename = File::filename(path);
-                if ! self.dotfiles && filename.starts_with('.') {
+                if !self.dotfiles && filename.starts_with('.') {
                     continue;
                 }
 
                 // Also hide _prefix files on Windows because it's used by old applications
                 // as an alternative to dot-prefix files.
                 #[cfg(windows)]
-                if ! self.dotfiles && filename.starts_with('_') {
+                if !self.dotfiles && filename.starts_with('_') {
                     continue;
                 }
 
                 if self.git_ignoring {
                     let git_status = self.git.map(|g| g.get(path, false)).unwrap_or_default();
                     if git_status.unstaged == VcsStatus::Ignored {
-                         continue;
+                        continue;
                     }
 
                     // Hide VCS metadata directories for compiled-in backends.
                     // Use the cached file type from readdir if available.
-                    let is_dir = entry.file_type
+                    let is_dir = entry
+                        .file_type
                         .map_or_else(|| path.is_dir(), |ft| ft.is_dir());
                     if is_dir && is_vcs_dir(&filename) {
                         continue;
                     }
                 }
 
-                return Some(File::from_args(path.clone(), self.dir, filename, entry.file_type)
-                                 .map_err(|e| (path.clone(), e)))
+                return Some(
+                    File::from_args(path.clone(), self.dir, filename, entry.file_type)
+                        .map_err(|e| (path.clone(), e)),
+                );
             }
 
-            return None
+            return None;
         }
     }
 }
@@ -155,7 +163,6 @@ impl<'dir> Files<'dir, '_> {
 /// The dot directories that need to be listed before actual files, if any.
 /// If these aren’t being printed, then `FilesNext` is used to skip them.
 enum DotsNext {
-
     /// List the `.` directory next.
     Dot,
 
@@ -173,31 +180,24 @@ impl<'dir> Iterator for Files<'dir, '_> {
         match self.dots {
             DotsNext::Dot => {
                 self.dots = DotsNext::DotDot;
-                Some(File::new_aa_current(self.dir)
-                          .map_err(|e| (Path::new(".").to_path_buf(), e)))
+                Some(File::new_aa_current(self.dir).map_err(|e| (Path::new(".").to_path_buf(), e)))
             }
 
             DotsNext::DotDot => {
                 self.dots = DotsNext::Files;
-                Some(File::new_aa_parent(self.parent(), self.dir)
-                          .map_err(|e| (self.parent(), e)))
+                Some(File::new_aa_parent(self.parent(), self.dir).map_err(|e| (self.parent(), e)))
             }
 
-            DotsNext::Files => {
-                self.next_visible_file()
-            }
+            DotsNext::Files => self.next_visible_file(),
         }
     }
 }
 
-
 /// Usually files in Unix use a leading dot to be hidden or visible, but two
 /// entries in particular are “extra-hidden”: `.` and `..`, which only become
 /// visible after an extra `-a` option.
-#[derive(PartialEq, Eq, Debug, Copy, Clone)]
-#[derive(Default)]
+#[derive(PartialEq, Eq, Debug, Copy, Clone, Default)]
 pub enum DotFilter {
-
     /// Shows files, dotfiles, and `.` and `..`.
     DotfilesAndDots,
 
@@ -209,30 +209,31 @@ pub enum DotFilter {
     JustFiles,
 }
 
-
 /// Whether a directory name is a VCS metadata directory that should be
 /// hidden by `--vcs-ignore`.  Only includes directories for VCS backends
 /// that are compiled in.
 fn is_vcs_dir(name: &str) -> bool {
     #[cfg(feature = "git")]
-    if name == ".git" { return true; }
+    if name == ".git" {
+        return true;
+    }
 
     #[cfg(feature = "jj")]
-    if name == ".jj" { return true; }
+    if name == ".jj" {
+        return true;
+    }
 
     // Suppress unused-variable warning when no VCS features are enabled.
     let _ = name;
     false
 }
 
-
 impl DotFilter {
-
     /// Whether this filter should show dotfiles in a listing.
     fn shows_dotfiles(self) -> bool {
         match self {
-            Self::JustFiles       => false,
-            Self::Dotfiles        => true,
+            Self::JustFiles => false,
+            Self::Dotfiles => true,
             Self::DotfilesAndDots => true,
         }
     }
@@ -240,9 +241,9 @@ impl DotFilter {
     /// Whether this filter should add dot directories to a listing.
     fn dots(self) -> DotsNext {
         match self {
-            Self::JustFiles        => DotsNext::Files,
-            Self::Dotfiles         => DotsNext::Files,
-            Self::DotfilesAndDots  => DotsNext::Dot,
+            Self::JustFiles => DotsNext::Files,
+            Self::Dotfiles => DotsNext::Files,
+            Self::DotfilesAndDots => DotsNext::Dot,
         }
     }
 }

--- a/src/fs/dir_action.rs
+++ b/src/fs/dir_action.rs
@@ -21,7 +21,6 @@
 /// directories inline, with their contents immediately underneath.
 #[derive(PartialEq, Eq, Debug, Copy, Clone)]
 pub enum DirAction {
-
     /// This directory should be listed along with the regular files, instead
     /// of having its contents queried.
     AsFile,
@@ -37,30 +36,27 @@ pub enum DirAction {
 }
 
 impl DirAction {
-
     /// Gets the recurse options, if this dir action has any.
     pub fn recurse_options(self) -> Option<RecurseOptions> {
         match self {
-            Self::Recurse(o)  => Some(o),
-            _                 => None,
+            Self::Recurse(o) => Some(o),
+            _ => None,
         }
     }
 
     /// Whether to treat directories as regular files or not.
     pub fn treat_dirs_as_files(self) -> bool {
         match self {
-            Self::AsFile      => true,
-            Self::Recurse(o)  => o.tree,
-            Self::List        => false,
+            Self::AsFile => true,
+            Self::Recurse(o) => o.tree,
+            Self::List => false,
         }
     }
 }
 
-
 /// The options that determine how to recurse into a directory.
 #[derive(PartialEq, Eq, Debug, Copy, Clone)]
 pub struct RecurseOptions {
-
     /// Whether recursion should be done as a tree or as multiple individual
     /// views of files.
     pub tree: bool,
@@ -71,12 +67,11 @@ pub struct RecurseOptions {
 }
 
 impl RecurseOptions {
-
     /// Returns whether a directory of the given depth would be too deep.
     pub fn is_too_deep(self, depth: usize) -> bool {
         match self.max_depth {
-            None     => false,
-            Some(d)  => d <= depth
+            None => false,
+            Some(d) => d <= depth,
         }
     }
 }

--- a/src/fs/feature/git.rs
+++ b/src/fs/feature/git.rs
@@ -10,13 +10,11 @@ use log::*;
 
 use crate::fs::fields as f;
 
-
 /// A **Git cache** is assembled based on the user’s input arguments.
 ///
 /// This uses vectors to avoid the overhead of hashing: it’s not worth it when the
 /// expected number of Git repositories per lx invocation is 0 or 1...
 pub struct GitCache {
-
     /// A list of discovered Git repositories and their paths.
     repos: Vec<GitRepo>,
 
@@ -30,19 +28,23 @@ impl super::VcsCache for GitCache {
     }
 
     fn get(&self, path: &Path, prefix_lookup: bool) -> f::VcsFileStatus {
-        self.repos.iter()
+        self.repos
+            .iter()
             .find(|e| e.has_path(path))
             .map(|repo| repo.search(path, prefix_lookup))
             .unwrap_or_default()
     }
 
-    fn header_name(&self) -> &'static str { "Git" }
+    fn header_name(&self) -> &'static str {
+        "Git"
+    }
 }
 
 use std::iter::FromIterator;
 impl FromIterator<PathBuf> for GitCache {
     fn from_iter<I>(iter: I) -> Self
-    where I: IntoIterator<Item=PathBuf>
+    where
+        I: IntoIterator<Item = PathBuf>,
     {
         let iter = iter.into_iter();
         let mut git = Self {
@@ -52,16 +54,20 @@ impl FromIterator<PathBuf> for GitCache {
 
         for path in iter {
             if git.misses.contains(&path) {
-                debug!("Skipping {} because it already came back Gitless", path.display());
-            }
-            else if git.repos.iter().any(|e| e.has_path(&path)) {
+                debug!(
+                    "Skipping {} because it already came back Gitless",
+                    path.display()
+                );
+            } else if git.repos.iter().any(|e| e.has_path(&path)) {
                 debug!("Skipping {} because we already queried it", path.display());
-            }
-            else {
+            } else {
                 match GitRepo::discover(path) {
                     Ok(r) => {
                         if let Some(r2) = git.repos.iter_mut().find(|e| e.has_workdir(&r.workdir)) {
-                            debug!("Adding to existing repo (workdir matches with {})", r2.workdir.display());
+                            debug!(
+                                "Adding to existing repo (workdir matches with {})",
+                                r2.workdir.display()
+                            );
                             r2.extra_paths.push(r.original_path);
                             continue;
                         }
@@ -80,10 +86,8 @@ impl FromIterator<PathBuf> for GitCache {
     }
 }
 
-
 /// A **Git repository** is one we’ve discovered somewhere on the filesystem.
 pub struct GitRepo {
-
     /// The queryable contents of the repository: either a `git2` repo, or the
     /// cached results from when we queried it last time.
     contents: Mutex<GitContents>,
@@ -104,11 +108,8 @@ pub struct GitRepo {
 
 /// A repository’s queried state.
 enum GitContents {
-
     /// All the interesting Git stuff goes through this.
-    Before {
-        repo: git2::Repository,
-    },
+    Before { repo: git2::Repository },
 
     /// Temporary value used in `repo_to_statuses` so we can move the
     /// repository out of the `Before` variant.
@@ -116,13 +117,10 @@ enum GitContents {
 
     /// The data we’ve extracted from the repository, but only after we’ve
     /// actually done so.
-    After {
-        statuses: Git,
-    },
+    After { statuses: Git },
 }
 
 impl GitRepo {
-
     /// Searches through this repository for a path (to a file or directory,
     /// depending on the prefix-lookup flag) and returns its Git status.
     ///
@@ -138,11 +136,17 @@ impl GitRepo {
 
         let mut contents = self.contents.lock().unwrap();
         if let GitContents::After { ref statuses } = *contents {
-            debug!("Git repo {} has been found in cache", self.workdir.display());
+            debug!(
+                "Git repo {} has been found in cache",
+                self.workdir.display()
+            );
             return statuses.status(index, prefix_lookup);
         }
 
-        debug!("Querying Git repo {} for the first time", self.workdir.display());
+        debug!(
+            "Querying Git repo {} for the first time",
+            self.workdir.display()
+        );
         let repo = replace(&mut *contents, GitContents::Processing).inner_repo();
         let statuses = repo_to_statuses(&repo, &self.workdir);
         let result = statuses.status(index, prefix_lookup);
@@ -157,7 +161,8 @@ impl GitRepo {
 
     /// Whether this repository cares about the given path at all.
     fn has_path(&self, path: &Path) -> bool {
-        path.starts_with(&self.original_path) || self.extra_paths.iter().any(|e| path.starts_with(e))
+        path.starts_with(&self.original_path)
+            || self.extra_paths.iter().any(|e| path.starts_with(e))
     }
 
     /// Searches for a Git repository at any point above the given path.
@@ -175,15 +180,18 @@ impl GitRepo {
         if let Some(workdir) = repo.workdir() {
             let workdir = workdir.to_path_buf();
             let contents = Mutex::new(GitContents::Before { repo });
-            Ok(Self { contents, workdir, original_path: path, extra_paths: Vec::new() })
-        }
-        else {
+            Ok(Self {
+                contents,
+                workdir,
+                original_path: path,
+                extra_paths: Vec::new(),
+            })
+        } else {
             warn!("Repository has no workdir?");
             Err(path)
         }
     }
 }
-
 
 impl GitContents {
     /// Assumes that the repository hasn’t been queried, and extracts it
@@ -192,8 +200,7 @@ impl GitContents {
     fn inner_repo(self) -> git2::Repository {
         if let Self::Before { repo } = self {
             repo
-        }
-        else {
+        } else {
             unreachable!("Tried to extract a non-Repository")
         }
     }
@@ -206,7 +213,10 @@ impl GitContents {
 fn repo_to_statuses(repo: &git2::Repository, workdir: &Path) -> Git {
     let mut statuses = Vec::new();
 
-    info!("Getting Git statuses for repo with workdir {}", workdir.display());
+    info!(
+        "Getting Git statuses for repo with workdir {}",
+        workdir.display()
+    );
     match repo.statuses(None) {
         Ok(es) => {
             for e in es.iter() {
@@ -236,20 +246,21 @@ fn repo_to_statuses(repo: &git2::Repository, workdir: &Path) -> Git {
 // Even inserting another logging line immediately afterwards doesn’t make it
 // look any faster.
 
-
 /// Container of Git statuses for all the files in this folder’s Git repository.
 struct Git {
     statuses: Vec<(PathBuf, git2::Status)>,
 }
 
 impl Git {
-
     /// Get either the file or directory status for the given path.
     /// “Prefix lookup” means that it should report an aggregate status of all
     /// paths starting with the given prefix (in other words, a directory).
     fn status(&self, index: &Path, prefix_lookup: bool) -> f::Git {
-        if prefix_lookup { self.dir_status(index) }
-                    else { self.file_status(index) }
+        if prefix_lookup {
+            self.dir_status(index)
+        } else {
+            self.file_status(index)
+        }
     }
 
     /// Get the user-facing status of a file.
@@ -258,11 +269,15 @@ impl Git {
     fn file_status(&self, file: &Path) -> f::Git {
         let path = reorient(file);
 
-        let s = self.statuses.iter()
-            .filter(|p| if p.1 == git2::Status::IGNORED {
-                path.starts_with(&p.0)
-            } else {
-                p.0 == path
+        let s = self
+            .statuses
+            .iter()
+            .filter(|p| {
+                if p.1 == git2::Status::IGNORED {
+                    path.starts_with(&p.0)
+                } else {
+                    p.0 == path
+                }
             })
             .fold(git2::Status::empty(), |a, b| a | b.1);
 
@@ -279,11 +294,15 @@ impl Git {
     fn dir_status(&self, dir: &Path) -> f::Git {
         let path = reorient(dir);
 
-        let s = self.statuses.iter()
-            .filter(|p| if p.1 == git2::Status::IGNORED {
-                path.starts_with(&p.0)
-            } else {
-                p.0.starts_with(&path)
+        let s = self
+            .statuses
+            .iter()
+            .filter(|p| {
+                if p.1 == git2::Status::IGNORED {
+                    path.starts_with(&p.0)
+                } else {
+                    p.0.starts_with(&path)
+                }
             })
             .fold(git2::Status::empty(), |a, b| a | b.1);
 
@@ -292,7 +311,6 @@ impl Git {
         f::Git { staged, unstaged }
     }
 }
-
 
 /// Converts a path to an absolute path based on the current directory.
 /// Paths need to be absolute for them to be compared properly, otherwise
@@ -304,8 +322,8 @@ fn reorient(path: &Path) -> PathBuf {
 
     // TODO: I’m not 100% on this func tbh
     let path = match current_dir() {
-        Err(_)   => Path::new(".").join(path),
-        Ok(dir)  => dir.join(path),
+        Err(_) => Path::new(".").join(path),
+        Ok(dir) => dir.join(path),
     };
 
     path.canonicalize().unwrap_or(path)
@@ -315,21 +333,25 @@ fn reorient(path: &Path) -> PathBuf {
 fn reorient(path: &Path) -> PathBuf {
     let unc_path = path.canonicalize().unwrap();
     // On Windows UNC path is returned. We need to strip the prefix for it to work.
-    let normal_path = unc_path.as_os_str().to_str().unwrap().trim_left_matches("\\\\?\\");
+    let normal_path = unc_path
+        .as_os_str()
+        .to_str()
+        .unwrap()
+        .trim_left_matches("\\\\?\\");
     return PathBuf::from(normal_path);
 }
 
 /// The character to display if the file has been modified, but not staged.
 fn working_tree_status(status: git2::Status) -> f::GitStatus {
     match status {
-        s if s.contains(git2::Status::WT_NEW)         => f::GitStatus::New,
-        s if s.contains(git2::Status::WT_MODIFIED)    => f::GitStatus::Modified,
-        s if s.contains(git2::Status::WT_DELETED)     => f::GitStatus::Deleted,
-        s if s.contains(git2::Status::WT_RENAMED)     => f::GitStatus::Renamed,
-        s if s.contains(git2::Status::WT_TYPECHANGE)  => f::GitStatus::TypeChange,
-        s if s.contains(git2::Status::IGNORED)        => f::GitStatus::Ignored,
-        s if s.contains(git2::Status::CONFLICTED)     => f::GitStatus::Conflicted,
-        _                                             => f::GitStatus::NotModified,
+        s if s.contains(git2::Status::WT_NEW) => f::GitStatus::New,
+        s if s.contains(git2::Status::WT_MODIFIED) => f::GitStatus::Modified,
+        s if s.contains(git2::Status::WT_DELETED) => f::GitStatus::Deleted,
+        s if s.contains(git2::Status::WT_RENAMED) => f::GitStatus::Renamed,
+        s if s.contains(git2::Status::WT_TYPECHANGE) => f::GitStatus::TypeChange,
+        s if s.contains(git2::Status::IGNORED) => f::GitStatus::Ignored,
+        s if s.contains(git2::Status::CONFLICTED) => f::GitStatus::Conflicted,
+        _ => f::GitStatus::NotModified,
     }
 }
 
@@ -337,11 +359,11 @@ fn working_tree_status(status: git2::Status) -> f::GitStatus {
 /// has been staged.
 fn index_status(status: git2::Status) -> f::GitStatus {
     match status {
-        s if s.contains(git2::Status::INDEX_NEW)         => f::GitStatus::New,
-        s if s.contains(git2::Status::INDEX_MODIFIED)    => f::GitStatus::Modified,
-        s if s.contains(git2::Status::INDEX_DELETED)     => f::GitStatus::Deleted,
-        s if s.contains(git2::Status::INDEX_RENAMED)     => f::GitStatus::Renamed,
-        s if s.contains(git2::Status::INDEX_TYPECHANGE)  => f::GitStatus::TypeChange,
-        _                                                => f::GitStatus::NotModified,
+        s if s.contains(git2::Status::INDEX_NEW) => f::GitStatus::New,
+        s if s.contains(git2::Status::INDEX_MODIFIED) => f::GitStatus::Modified,
+        s if s.contains(git2::Status::INDEX_DELETED) => f::GitStatus::Deleted,
+        s if s.contains(git2::Status::INDEX_RENAMED) => f::GitStatus::Renamed,
+        s if s.contains(git2::Status::INDEX_TYPECHANGE) => f::GitStatus::TypeChange,
+        _ => f::GitStatus::NotModified,
     }
 }

--- a/src/fs/feature/jj.rs
+++ b/src/fs/feature/jj.rs
@@ -17,11 +17,10 @@ use log::*;
 use crate::fs::fields as f;
 
 use jj_lib::config::StackedConfig;
+use jj_lib::matchers::EverythingMatcher;
 use jj_lib::repo::Repo;
 use jj_lib::settings::UserSettings;
 use jj_lib::workspace::{self, Workspace};
-use jj_lib::matchers::EverythingMatcher;
-
 
 /// A cache of per-file jj status, built using the jj-lib crate.
 pub struct JjCache {
@@ -58,7 +57,11 @@ impl JjCache {
         } else {
             let p = probe.parent().unwrap_or(Path::new("."));
             // An empty parent (from a bare filename like "foo.txt") means cwd.
-            let p = if p.as_os_str().is_empty() { Path::new(".") } else { p };
+            let p = if p.as_os_str().is_empty() {
+                Path::new(".")
+            } else {
+                p
+            };
             p.canonicalize().unwrap_or_else(|_| p.to_path_buf())
         };
 
@@ -82,7 +85,9 @@ impl JjCache {
                 Ok(ws) => break ws,
                 Err(e) => {
                     debug!("jj: Workspace::load({}) failed: {e}", search_dir.display());
-                    if let Some(parent) = search_dir.parent() { search_dir = parent } else {
+                    if let Some(parent) = search_dir.parent() {
+                        search_dir = parent
+                    } else {
                         debug!("jj: no jj workspace found");
                         return None;
                     }
@@ -108,7 +113,9 @@ impl JjCache {
             }
         };
 
-        let wc_commit_id = if let Some(id) = repo.view().get_wc_commit_id(ws.workspace_name()) { id.clone() } else {
+        let wc_commit_id = if let Some(id) = repo.view().get_wc_commit_id(ws.workspace_name()) {
+            id.clone()
+        } else {
             warn!("jj: no working copy commit");
             return Some(Self::empty(workdir));
         };
@@ -189,9 +196,17 @@ impl JjCache {
         // (works for both colocated and non-colocated repos).
         let git_repo = Self::open_git_repo(&workdir).map(Mutex::new);
 
-        debug!("jj cache: {} file statuses, {} tracked files",
-               statuses.len(), tracked.len());
-        Some(Self { statuses, tracked, git_repo, workdir })
+        debug!(
+            "jj cache: {} file statuses, {} tracked files",
+            statuses.len(),
+            tracked.len()
+        );
+        Some(Self {
+            statuses,
+            tracked,
+            git_repo,
+            workdir,
+        })
     }
 
     /// Create an empty cache (used for error fallback paths).
@@ -242,7 +257,6 @@ impl JjCache {
     }
 }
 
-
 impl super::VcsCache for JjCache {
     fn has_anything_for(&self, path: &Path) -> bool {
         let abs = if path.is_absolute() {
@@ -275,7 +289,10 @@ impl super::VcsCache for JjCache {
                     worst_change = worse_status(worst_change, status);
                 }
             }
-            f::VcsFileStatus { staged: worst_change, unstaged: worst_change }
+            f::VcsFileStatus {
+                staged: worst_change,
+                unstaged: worst_change,
+            }
         } else {
             // Single file: change status + tracking/ignore status.
 
@@ -289,7 +306,9 @@ impl super::VcsCache for JjCache {
                 };
             }
 
-            let change = self.statuses.get(&abs)
+            let change = self
+                .statuses
+                .get(&abs)
                 .copied()
                 .unwrap_or(f::VcsStatus::NotModified);
 
@@ -300,26 +319,30 @@ impl super::VcsCache for JjCache {
                 f::VcsStatus::Untracked
             };
 
-            f::VcsFileStatus { staged: change, unstaged: tracking }
+            f::VcsFileStatus {
+                staged: change,
+                unstaged: tracking,
+            }
         }
     }
 
-    fn header_name(&self) -> &'static str { "JJ" }
+    fn header_name(&self) -> &'static str {
+        "JJ"
+    }
 }
-
 
 fn worse_status(a: f::VcsStatus, b: f::VcsStatus) -> f::VcsStatus {
     fn rank(s: f::VcsStatus) -> u8 {
         match s {
             f::VcsStatus::NotModified => 0,
-            f::VcsStatus::Ignored    => 1,
-            f::VcsStatus::Untracked  => 2,
-            f::VcsStatus::Copied     => 3,
-            f::VcsStatus::Renamed    => 4,
+            f::VcsStatus::Ignored => 1,
+            f::VcsStatus::Untracked => 2,
+            f::VcsStatus::Copied => 3,
+            f::VcsStatus::Renamed => 4,
             f::VcsStatus::TypeChange => 5,
-            f::VcsStatus::Modified   => 6,
-            f::VcsStatus::New        => 7,
-            f::VcsStatus::Deleted    => 8,
+            f::VcsStatus::Modified => 6,
+            f::VcsStatus::New => 7,
+            f::VcsStatus::Deleted => 8,
             f::VcsStatus::Conflicted => 9,
         }
     }

--- a/src/fs/feature/mod.rs
+++ b/src/fs/feature/mod.rs
@@ -16,9 +16,10 @@ pub trait VcsCache: Sync {
     fn get(&self, path: &Path, prefix_lookup: bool) -> f::VcsFileStatus;
 
     /// The name to display in the column header (e.g. "Git", "JJ").
-    fn header_name(&self) -> &'static str { "VCS" }
+    fn header_name(&self) -> &'static str {
+        "VCS"
+    }
 }
-
 
 #[cfg(feature = "git")]
 pub mod git;
@@ -28,14 +29,15 @@ pub mod git {
     use std::iter::FromIterator;
     use std::path::{Path, PathBuf};
 
-    use crate::fs::fields as f;
     use super::VcsCache;
+    use crate::fs::fields as f;
 
     pub struct GitCache;
 
     impl FromIterator<PathBuf> for GitCache {
         fn from_iter<I>(_iter: I) -> Self
-        where I: IntoIterator<Item=PathBuf>
+        where
+            I: IntoIterator<Item = PathBuf>,
         {
             Self
         }
@@ -52,7 +54,6 @@ pub mod git {
     }
 }
 
-
 #[cfg(feature = "jj")]
 pub mod jj;
 
@@ -60,8 +61,8 @@ pub mod jj;
 pub mod jj {
     use std::path::{Path, PathBuf};
 
-    use crate::fs::fields as f;
     use super::VcsCache;
+    use crate::fs::fields as f;
 
     pub struct JjCache;
 

--- a/src/fs/feature/xattr.rs
+++ b/src/fs/feature/xattr.rs
@@ -1,13 +1,11 @@
 //! Extended attribute support for Darwin and Linux systems.
 
-#![allow(trivial_casts)]  // for ARM
+#![allow(trivial_casts)] // for ARM
 
 use std::io;
 use std::path::Path;
 
-
 pub const ENABLED: bool = cfg!(any(target_os = "macos", target_os = "linux"));
-
 
 pub trait FileAttributes {
     fn attributes(&self) -> io::Result<Vec<Attribute>>;
@@ -40,7 +38,6 @@ impl FileAttributes for Path {
     }
 }
 
-
 /// Whether the platform lister should chase symlinks when reading
 /// extended attributes.  Both variants are matched by the macOS and
 /// Linux `Lister` impls (the Linux path picks between
@@ -64,7 +61,6 @@ pub struct Attribute {
     pub size: usize,
 }
 
-
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 pub fn has_attrs(lister: &lister::Lister, path: &Path) -> io::Result<bool> {
     use std::cmp::Ordering;
@@ -76,9 +72,9 @@ pub fn has_attrs(lister: &lister::Lister, path: &Path) -> io::Result<bool> {
 
     let bufsize = lister.listxattr_first(&c_path);
     match bufsize.cmp(&0) {
-        Ordering::Less     => Err(io::Error::last_os_error()),
-        Ordering::Equal    => Ok(false),
-        Ordering::Greater  => Ok(true),
+        Ordering::Less => Err(io::Error::last_os_error()),
+        Ordering::Equal => Ok(false),
+        Ordering::Greater => Ok(true),
     }
 }
 
@@ -93,27 +89,28 @@ pub fn list_attrs(lister: &lister::Lister, path: &Path) -> io::Result<Vec<Attrib
 
     let bufsize = lister.listxattr_first(&c_path);
     match bufsize.cmp(&0) {
-        Ordering::Less     => return Err(io::Error::last_os_error()),
-        Ordering::Equal    => return Ok(Vec::new()),
-        Ordering::Greater  => {},
+        Ordering::Less => return Err(io::Error::last_os_error()),
+        Ordering::Equal => return Ok(Vec::new()),
+        Ordering::Greater => {}
     }
 
     let mut buf = vec![0_u8; bufsize as usize];
     let err = lister.listxattr_second(&c_path, &mut buf, bufsize);
 
     match err.cmp(&0) {
-        Ordering::Less     => return Err(io::Error::last_os_error()),
-        Ordering::Equal    => return Ok(Vec::new()),
-        Ordering::Greater  => {},
+        Ordering::Less => return Err(io::Error::last_os_error()),
+        Ordering::Equal => return Ok(Vec::new()),
+        Ordering::Greater => {}
     }
 
     let mut names = Vec::new();
     if err > 0 {
         // End indices of the attribute names
         // the buffer contains 0-terminated c-strings
-        let idx = buf.iter().enumerate().filter_map(|(i, v)|
-            if *v == 0 { Some(i) } else { None }
-        );
+        let idx = buf
+            .iter()
+            .enumerate()
+            .filter_map(|(i, v)| if *v == 0 { Some(i) } else { None });
         let mut start = 0;
 
         for end in idx {
@@ -134,11 +131,10 @@ pub fn list_attrs(lister: &lister::Lister, path: &Path) -> io::Result<Vec<Attrib
     Ok(names)
 }
 
-
 #[cfg(target_os = "macos")]
 mod lister {
     use super::FollowSymlinks;
-    use libc::{c_int, size_t, ssize_t, c_char, c_void};
+    use libc::{c_char, c_int, c_void, size_t, ssize_t};
     use std::ffi::CString;
     use std::ptr;
 
@@ -167,8 +163,8 @@ mod lister {
     impl Lister {
         pub fn new(do_follow: FollowSymlinks) -> Self {
             let c_flags: c_int = match do_follow {
-                FollowSymlinks::Yes  => 0x0001,
-                FollowSymlinks::No   => 0x0000,
+                FollowSymlinks::Yes => 0x0001,
+                FollowSymlinks::No => 0x0000,
             };
 
             Self { c_flags }
@@ -179,17 +175,15 @@ mod lister {
         }
 
         pub fn listxattr_first(&self, c_path: &CString) -> ssize_t {
-            unsafe {
-                listxattr(
-                    c_path.as_ptr(),
-                    ptr::null_mut(),
-                    0,
-                    self.c_flags,
-                )
-            }
+            unsafe { listxattr(c_path.as_ptr(), ptr::null_mut(), 0, self.c_flags) }
         }
 
-        pub fn listxattr_second(&self, c_path: &CString, buf: &mut Vec<u8>, bufsize: ssize_t) -> ssize_t {
+        pub fn listxattr_second(
+            &self,
+            c_path: &CString,
+            buf: &mut Vec<u8>,
+            bufsize: ssize_t,
+        ) -> ssize_t {
             unsafe {
                 listxattr(
                     c_path.as_ptr(),
@@ -215,26 +209,17 @@ mod lister {
     }
 }
 
-
 #[cfg(target_os = "linux")]
 mod lister {
-    use std::ffi::CString;
-    use libc::{size_t, ssize_t, c_char, c_void};
     use super::FollowSymlinks;
+    use libc::{c_char, c_void, size_t, ssize_t};
+    use std::ffi::CString;
     use std::ptr;
 
     unsafe extern "C" {
-        fn listxattr(
-            path: *const c_char,
-            list: *mut c_char,
-            size: size_t,
-        ) -> ssize_t;
+        fn listxattr(path: *const c_char, list: *mut c_char, size: size_t) -> ssize_t;
 
-        fn llistxattr(
-            path: *const c_char,
-            list: *mut c_char,
-            size: size_t,
-        ) -> ssize_t;
+        fn llistxattr(path: *const c_char, list: *mut c_char, size: size_t) -> ssize_t;
 
         fn getxattr(
             path: *const c_char,
@@ -266,23 +251,22 @@ mod lister {
 
         pub fn listxattr_first(&self, c_path: &CString) -> ssize_t {
             let listxattr = match self.follow_symlinks {
-                FollowSymlinks::Yes  => listxattr,
-                FollowSymlinks::No   => llistxattr,
+                FollowSymlinks::Yes => listxattr,
+                FollowSymlinks::No => llistxattr,
             };
 
-            unsafe {
-                listxattr(
-                    c_path.as_ptr().cast(),
-                    ptr::null_mut(),
-                    0,
-                )
-            }
+            unsafe { listxattr(c_path.as_ptr().cast(), ptr::null_mut(), 0) }
         }
 
-        pub fn listxattr_second(&self, c_path: &CString, buf: &mut Vec<u8>, bufsize: ssize_t) -> ssize_t {
+        pub fn listxattr_second(
+            &self,
+            c_path: &CString,
+            buf: &mut Vec<u8>,
+            bufsize: ssize_t,
+        ) -> ssize_t {
             let listxattr = match self.follow_symlinks {
-                FollowSymlinks::Yes  => listxattr,
-                FollowSymlinks::No   => llistxattr,
+                FollowSymlinks::Yes => listxattr,
+                FollowSymlinks::No => llistxattr,
             };
 
             unsafe {
@@ -296,8 +280,8 @@ mod lister {
 
         pub fn getxattr(&self, c_path: &CString, buf: &[u8]) -> ssize_t {
             let getxattr = match self.follow_symlinks {
-                FollowSymlinks::Yes  => getxattr,
-                FollowSymlinks::No   => lgetxattr,
+                FollowSymlinks::Yes => getxattr,
+                FollowSymlinks::No => lgetxattr,
             };
 
             unsafe {

--- a/src/fs/fields.rs
+++ b/src/fs/fields.rs
@@ -15,7 +15,6 @@
 #![allow(non_camel_case_types)]
 #![allow(clippy::struct_excessive_bools)]
 
-
 /// The type of a file’s block count.
 pub type blkcnt_t = u64;
 
@@ -28,10 +27,8 @@ pub type ino_t = u64;
 /// The type of a file’s number of links.
 pub type nlink_t = u64;
 
-
 /// The type of a file’s user ID.
 pub type uid_t = u32;
-
 
 /// The file’s base type, which gets displayed in the very first column of the
 /// details output.
@@ -59,37 +56,36 @@ impl Type {
     }
 }
 
-
 /// The file’s Unix permission bitfield, with one entry per bit.
 #[derive(Copy, Clone)]
 pub struct Permissions {
-    pub user_read:      bool,
-    pub user_write:     bool,
-    pub user_execute:   bool,
+    pub user_read: bool,
+    pub user_write: bool,
+    pub user_execute: bool,
 
-    pub group_read:     bool,
-    pub group_write:    bool,
-    pub group_execute:  bool,
+    pub group_read: bool,
+    pub group_write: bool,
+    pub group_execute: bool,
 
-    pub other_read:     bool,
-    pub other_write:    bool,
-    pub other_execute:  bool,
+    pub other_read: bool,
+    pub other_write: bool,
+    pub other_execute: bool,
 
-    pub sticky:         bool,
-    pub setgid:         bool,
-    pub setuid:         bool,
+    pub sticky: bool,
+    pub setgid: bool,
+    pub setuid: bool,
 }
 
 /// The file's `FileAttributes` field, available only on Windows.
 #[cfg(windows)]
 #[derive(Copy, Clone)]
 pub struct Attributes {
-    pub archive:         bool,
-    pub directory:       bool,
-    pub readonly:        bool,
-    pub hidden:          bool,
-    pub system:          bool,
-    pub reparse_point:   bool,
+    pub archive: bool,
+    pub directory: bool,
+    pub readonly: bool,
+    pub hidden: bool,
+    pub system: bool,
+    pub reparse_point: bool,
 }
 
 /// The three pieces of information that are displayed as a single column in
@@ -97,14 +93,13 @@ pub struct Attributes {
 /// little more compressed.
 #[derive(Copy, Clone)]
 pub struct PermissionsPlus {
-    pub file_type:   Type,
+    pub file_type: Type,
     #[cfg(unix)]
     pub permissions: Permissions,
     #[cfg(windows)]
-    pub attributes:  Attributes,
-    pub xattrs:      bool,
+    pub attributes: Attributes,
+    pub xattrs: bool,
 }
-
 
 /// The permissions encoded as octal values
 #[derive(Copy, Clone)]
@@ -120,7 +115,6 @@ pub struct OctalPermissions {
 /// block count specifically for this case.
 #[derive(Copy, Clone)]
 pub struct Links {
-
     /// The actual link count.
     pub count: nlink_t,
 
@@ -128,25 +122,21 @@ pub struct Links {
     pub multiple: bool,
 }
 
-
 /// A file’s inode. Every directory entry on a Unix filesystem has an inode,
 /// including directories and links, so this is applicable to everything lx
 /// can deal with.
 #[derive(Copy, Clone)]
 pub struct Inode(pub ino_t);
 
-
 /// The number of blocks that a file takes up on the filesystem, if any.
 #[derive(Copy, Clone)]
 pub enum Blocks {
-
     /// This file has the given number of blocks.
     Some(blkcnt_t),
 
     /// This file isn’t of a type that can take up blocks.
     None,
 }
-
 
 /// The ID of the user that owns a file. This will only ever be a number;
 /// looking up the username is done in the `display` module.
@@ -157,12 +147,10 @@ pub struct User(pub uid_t);
 #[derive(Copy, Clone)]
 pub struct Group(pub gid_t);
 
-
 /// A file’s size, in bytes. This is usually formatted by the `unit_prefix`
 /// crate into something human-readable.
 #[derive(Copy, Clone)]
 pub enum Size {
-
     /// This file has a defined size.
     Some(u64),
 
@@ -197,13 +185,10 @@ pub struct DeviceIDs {
     pub minor: u8,
 }
 
-
-
 /// A file’s status in a VCS repository.  Backend-agnostic: used for both
 /// git and jj.
 #[derive(PartialEq, Eq, Copy, Clone)]
 pub enum VcsStatus {
-
     /// This file hasn’t changed since the last commit.
     NotModified,
 
@@ -235,13 +220,12 @@ pub enum VcsStatus {
     Untracked,
 }
 
-
 /// A file’s complete VCS status.  For git this has separate staged and
 /// unstaged status; for jj (which has no staging area) both fields hold
 /// the same value.
 #[derive(Copy, Clone)]
 pub struct VcsFileStatus {
-    pub staged:   VcsStatus,
+    pub staged: VcsStatus,
     pub unstaged: VcsStatus,
 }
 
@@ -259,7 +243,6 @@ impl Default for VcsFileStatus {
 pub type Git = VcsFileStatus;
 pub type GitStatus = VcsStatus;
 
-
 /// BSD/macOS file flags from `st_flags` (see `chflags(1)`).
 ///
 /// On platforms without `st_flags`, the flags value is always 0.
@@ -269,47 +252,47 @@ pub struct FileFlags(pub u32);
 impl FileFlags {
     /// Well-known BSD file flag bits.
     // User flags (UF_*)
-    pub const UF_NODUMP:     u32 = 0x0000_0001;
-    pub const UF_IMMUTABLE:  u32 = 0x0000_0002;
-    pub const UF_APPEND:     u32 = 0x0000_0004;
-    pub const UF_OPAQUE:     u32 = 0x0000_0008;
-    pub const UF_NOUNLINK:   u32 = 0x0000_0010;  // FreeBSD
-    pub const UF_COMPRESSED: u32 = 0x0000_0020;  // macOS/FreeBSD
-    pub const UF_TRACKED:    u32 = 0x0000_0040;  // FreeBSD
-    pub const UF_SYSTEM:     u32 = 0x0000_0080;  // FreeBSD: Windows system bit
-    pub const UF_SPARSE:     u32 = 0x0000_0100;  // FreeBSD
-    pub const UF_OFFLINE:    u32 = 0x0000_0200;  // FreeBSD
-    pub const UF_REPARSE:    u32 = 0x0000_0400;  // FreeBSD: Windows reparse point
-    pub const UF_ARCHIVE:    u32 = 0x0000_0800;  // FreeBSD: user archive
-    pub const UF_READONLY:   u32 = 0x0000_1000;  // FreeBSD: Windows readonly
-    pub const UF_HIDDEN:     u32 = 0x0000_8000;  // macOS/FreeBSD
+    pub const UF_NODUMP: u32 = 0x0000_0001;
+    pub const UF_IMMUTABLE: u32 = 0x0000_0002;
+    pub const UF_APPEND: u32 = 0x0000_0004;
+    pub const UF_OPAQUE: u32 = 0x0000_0008;
+    pub const UF_NOUNLINK: u32 = 0x0000_0010; // FreeBSD
+    pub const UF_COMPRESSED: u32 = 0x0000_0020; // macOS/FreeBSD
+    pub const UF_TRACKED: u32 = 0x0000_0040; // FreeBSD
+    pub const UF_SYSTEM: u32 = 0x0000_0080; // FreeBSD: Windows system bit
+    pub const UF_SPARSE: u32 = 0x0000_0100; // FreeBSD
+    pub const UF_OFFLINE: u32 = 0x0000_0200; // FreeBSD
+    pub const UF_REPARSE: u32 = 0x0000_0400; // FreeBSD: Windows reparse point
+    pub const UF_ARCHIVE: u32 = 0x0000_0800; // FreeBSD: user archive
+    pub const UF_READONLY: u32 = 0x0000_1000; // FreeBSD: Windows readonly
+    pub const UF_HIDDEN: u32 = 0x0000_8000; // macOS/FreeBSD
     // System flags (SF_*)
-    pub const SF_ARCHIVED:   u32 = 0x0001_0000;
-    pub const SF_IMMUTABLE:  u32 = 0x0002_0000;
-    pub const SF_APPEND:     u32 = 0x0004_0000;
-    pub const SF_NOUNLINK:   u32 = 0x0010_0000;  // FreeBSD
-    pub const SF_SNAPSHOT:   u32 = 0x0020_0000;  // FreeBSD
+    pub const SF_ARCHIVED: u32 = 0x0001_0000;
+    pub const SF_IMMUTABLE: u32 = 0x0002_0000;
+    pub const SF_APPEND: u32 = 0x0004_0000;
+    pub const SF_NOUNLINK: u32 = 0x0010_0000; // FreeBSD
+    pub const SF_SNAPSHOT: u32 = 0x0020_0000; // FreeBSD
 
     // Linux file attributes (FS_IOC_GETFLAGS) — different bit layout.
-    pub const FS_SECRM:       u32 = 0x0000_0001;
-    pub const FS_UNRM:        u32 = 0x0000_0002;
-    pub const FS_COMPR:       u32 = 0x0000_0004;
-    pub const FS_SYNC:        u32 = 0x0000_0008;
-    pub const FS_IMMUTABLE:   u32 = 0x0000_0010;
-    pub const FS_APPEND:      u32 = 0x0000_0020;
-    pub const FS_NODUMP:      u32 = 0x0000_0040;
-    pub const FS_NOATIME:     u32 = 0x0000_0080;
-    pub const FS_ENCRYPT:     u32 = 0x0000_0800;
-    pub const FS_JOURNAL:     u32 = 0x0000_4000;
-    pub const FS_NOTAIL:      u32 = 0x0000_8000;
-    pub const FS_DIRSYNC:     u32 = 0x0001_0000;
-    pub const FS_TOPDIR:      u32 = 0x0002_0000;
-    pub const FS_EXTENT:      u32 = 0x0008_0000;
-    pub const FS_VERITY:      u32 = 0x0010_0000;
-    pub const FS_NOCOW:       u32 = 0x0080_0000;
-    pub const FS_DAX:         u32 = 0x0200_0000;
+    pub const FS_SECRM: u32 = 0x0000_0001;
+    pub const FS_UNRM: u32 = 0x0000_0002;
+    pub const FS_COMPR: u32 = 0x0000_0004;
+    pub const FS_SYNC: u32 = 0x0000_0008;
+    pub const FS_IMMUTABLE: u32 = 0x0000_0010;
+    pub const FS_APPEND: u32 = 0x0000_0020;
+    pub const FS_NODUMP: u32 = 0x0000_0040;
+    pub const FS_NOATIME: u32 = 0x0000_0080;
+    pub const FS_ENCRYPT: u32 = 0x0000_0800;
+    pub const FS_JOURNAL: u32 = 0x0000_4000;
+    pub const FS_NOTAIL: u32 = 0x0000_8000;
+    pub const FS_DIRSYNC: u32 = 0x0001_0000;
+    pub const FS_TOPDIR: u32 = 0x0002_0000;
+    pub const FS_EXTENT: u32 = 0x0008_0000;
+    pub const FS_VERITY: u32 = 0x0010_0000;
+    pub const FS_NOCOW: u32 = 0x0080_0000;
+    pub const FS_DAX: u32 = 0x0200_0000;
     pub const FS_PROJINHERIT: u32 = 0x2000_0000;
-    pub const FS_CASEFOLD:    u32 = 0x4000_0000;
+    pub const FS_CASEFOLD: u32 = 0x4000_0000;
 
     /// Return a short string representation of the flags.
     /// Returns "-" if no flags are set.
@@ -326,50 +309,126 @@ impl FileFlags {
         #[cfg(any(target_os = "macos", target_os = "freebsd"))]
         {
             // BSD user flags — names match chflags(1).
-            if self.0 & Self::UF_NODUMP     != 0 { parts.push("nodump"); }
-            if self.0 & Self::UF_IMMUTABLE  != 0 { parts.push("uchg"); }
-            if self.0 & Self::UF_APPEND     != 0 { parts.push("uappnd"); }
-            if self.0 & Self::UF_OPAQUE     != 0 { parts.push("opaque"); }
-            if self.0 & Self::UF_NOUNLINK   != 0 { parts.push("uunlnk"); }
-            if self.0 & Self::UF_COMPRESSED != 0 { parts.push("compressed"); }
-            if self.0 & Self::UF_TRACKED    != 0 { parts.push("tracked"); }
-            if self.0 & Self::UF_SYSTEM     != 0 { parts.push("system"); }
-            if self.0 & Self::UF_SPARSE     != 0 { parts.push("sparse"); }
-            if self.0 & Self::UF_OFFLINE    != 0 { parts.push("offline"); }
-            if self.0 & Self::UF_REPARSE    != 0 { parts.push("reparse"); }
-            if self.0 & Self::UF_ARCHIVE    != 0 { parts.push("uarch"); }
-            if self.0 & Self::UF_READONLY   != 0 { parts.push("rdonly"); }
-            if self.0 & Self::UF_HIDDEN     != 0 { parts.push("hidden"); }
+            if self.0 & Self::UF_NODUMP != 0 {
+                parts.push("nodump");
+            }
+            if self.0 & Self::UF_IMMUTABLE != 0 {
+                parts.push("uchg");
+            }
+            if self.0 & Self::UF_APPEND != 0 {
+                parts.push("uappnd");
+            }
+            if self.0 & Self::UF_OPAQUE != 0 {
+                parts.push("opaque");
+            }
+            if self.0 & Self::UF_NOUNLINK != 0 {
+                parts.push("uunlnk");
+            }
+            if self.0 & Self::UF_COMPRESSED != 0 {
+                parts.push("compressed");
+            }
+            if self.0 & Self::UF_TRACKED != 0 {
+                parts.push("tracked");
+            }
+            if self.0 & Self::UF_SYSTEM != 0 {
+                parts.push("system");
+            }
+            if self.0 & Self::UF_SPARSE != 0 {
+                parts.push("sparse");
+            }
+            if self.0 & Self::UF_OFFLINE != 0 {
+                parts.push("offline");
+            }
+            if self.0 & Self::UF_REPARSE != 0 {
+                parts.push("reparse");
+            }
+            if self.0 & Self::UF_ARCHIVE != 0 {
+                parts.push("uarch");
+            }
+            if self.0 & Self::UF_READONLY != 0 {
+                parts.push("rdonly");
+            }
+            if self.0 & Self::UF_HIDDEN != 0 {
+                parts.push("hidden");
+            }
             // BSD system flags
-            if self.0 & Self::SF_ARCHIVED   != 0 { parts.push("arch"); }
-            if self.0 & Self::SF_IMMUTABLE  != 0 { parts.push("schg"); }
-            if self.0 & Self::SF_APPEND     != 0 { parts.push("sappnd"); }
-            if self.0 & Self::SF_NOUNLINK   != 0 { parts.push("sunlnk"); }
-            if self.0 & Self::SF_SNAPSHOT   != 0 { parts.push("snapshot"); }
+            if self.0 & Self::SF_ARCHIVED != 0 {
+                parts.push("arch");
+            }
+            if self.0 & Self::SF_IMMUTABLE != 0 {
+                parts.push("schg");
+            }
+            if self.0 & Self::SF_APPEND != 0 {
+                parts.push("sappnd");
+            }
+            if self.0 & Self::SF_NOUNLINK != 0 {
+                parts.push("sunlnk");
+            }
+            if self.0 & Self::SF_SNAPSHOT != 0 {
+                parts.push("snapshot");
+            }
         }
 
         #[cfg(target_os = "linux")]
         {
             // Linux attributes — names match chattr(1) conventions.
-            if self.0 & Self::FS_SECRM       != 0 { parts.push("secrm"); }
-            if self.0 & Self::FS_UNRM        != 0 { parts.push("unrm"); }
-            if self.0 & Self::FS_COMPR       != 0 { parts.push("compr"); }
-            if self.0 & Self::FS_SYNC        != 0 { parts.push("sync"); }
-            if self.0 & Self::FS_IMMUTABLE   != 0 { parts.push("immutable"); }
-            if self.0 & Self::FS_APPEND      != 0 { parts.push("append"); }
-            if self.0 & Self::FS_NODUMP      != 0 { parts.push("nodump"); }
-            if self.0 & Self::FS_NOATIME     != 0 { parts.push("noatime"); }
-            if self.0 & Self::FS_ENCRYPT     != 0 { parts.push("encrypt"); }
-            if self.0 & Self::FS_JOURNAL     != 0 { parts.push("journal"); }
-            if self.0 & Self::FS_NOTAIL      != 0 { parts.push("notail"); }
-            if self.0 & Self::FS_DIRSYNC     != 0 { parts.push("dirsync"); }
-            if self.0 & Self::FS_TOPDIR      != 0 { parts.push("topdir"); }
-            if self.0 & Self::FS_EXTENT      != 0 { parts.push("extent"); }
-            if self.0 & Self::FS_VERITY      != 0 { parts.push("verity"); }
-            if self.0 & Self::FS_NOCOW       != 0 { parts.push("nocow"); }
-            if self.0 & Self::FS_DAX         != 0 { parts.push("dax"); }
-            if self.0 & Self::FS_PROJINHERIT != 0 { parts.push("projinherit"); }
-            if self.0 & Self::FS_CASEFOLD    != 0 { parts.push("casefold"); }
+            if self.0 & Self::FS_SECRM != 0 {
+                parts.push("secrm");
+            }
+            if self.0 & Self::FS_UNRM != 0 {
+                parts.push("unrm");
+            }
+            if self.0 & Self::FS_COMPR != 0 {
+                parts.push("compr");
+            }
+            if self.0 & Self::FS_SYNC != 0 {
+                parts.push("sync");
+            }
+            if self.0 & Self::FS_IMMUTABLE != 0 {
+                parts.push("immutable");
+            }
+            if self.0 & Self::FS_APPEND != 0 {
+                parts.push("append");
+            }
+            if self.0 & Self::FS_NODUMP != 0 {
+                parts.push("nodump");
+            }
+            if self.0 & Self::FS_NOATIME != 0 {
+                parts.push("noatime");
+            }
+            if self.0 & Self::FS_ENCRYPT != 0 {
+                parts.push("encrypt");
+            }
+            if self.0 & Self::FS_JOURNAL != 0 {
+                parts.push("journal");
+            }
+            if self.0 & Self::FS_NOTAIL != 0 {
+                parts.push("notail");
+            }
+            if self.0 & Self::FS_DIRSYNC != 0 {
+                parts.push("dirsync");
+            }
+            if self.0 & Self::FS_TOPDIR != 0 {
+                parts.push("topdir");
+            }
+            if self.0 & Self::FS_EXTENT != 0 {
+                parts.push("extent");
+            }
+            if self.0 & Self::FS_VERITY != 0 {
+                parts.push("verity");
+            }
+            if self.0 & Self::FS_NOCOW != 0 {
+                parts.push("nocow");
+            }
+            if self.0 & Self::FS_DAX != 0 {
+                parts.push("dax");
+            }
+            if self.0 & Self::FS_PROJINHERIT != 0 {
+                parts.push("projinherit");
+            }
+            if self.0 & Self::FS_CASEFOLD != 0 {
+                parts.push("casefold");
+            }
         }
 
         if parts.is_empty() {
@@ -380,7 +439,6 @@ impl FileFlags {
         }
     }
 }
-
 
 /// Per-directory VCS repository status, for the `--vcs-repos` column.
 #[derive(Debug, Clone)]

--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -23,7 +23,6 @@ use crate::fs::fields as f;
 static DIR_SIZE_CACHE: LazyLock<Mutex<HashMap<(u64, u64), u64>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
-
 /// A **File** is a wrapper around one of Rust’s `PathBuf` values, along with
 /// associated data about the file.
 ///
@@ -32,7 +31,6 @@ static DIR_SIZE_CACHE: LazyLock<Mutex<HashMap<(u64, u64), u64>>> =
 /// information queried at least once, so it makes sense to do all this at the
 /// start and hold on to all the information.
 pub struct File<'dir> {
-
     /// The filename portion of this file’s path, including the extension.
     ///
     /// This is used to compare against certain filenames (such as checking if
@@ -91,13 +89,19 @@ pub struct File<'dir> {
 }
 
 impl<'dir> File<'dir> {
-    pub fn from_args<PD, FN>(path: PathBuf, parent_dir: PD, filename: FN, known_file_type: Option<std::fs::FileType>) -> io::Result<File<'dir>>
-    where PD: Into<Option<&'dir Dir>>,
-          FN: Into<Option<String>>
+    pub fn from_args<PD, FN>(
+        path: PathBuf,
+        parent_dir: PD,
+        filename: FN,
+        known_file_type: Option<std::fs::FileType>,
+    ) -> io::Result<File<'dir>>
+    where
+        PD: Into<Option<&'dir Dir>>,
+        FN: Into<Option<String>>,
     {
         let parent_dir = parent_dir.into();
-        let name       = filename.into().unwrap_or_else(|| File::filename(&path));
-        let ext        = File::ext(&path);
+        let name = filename.into().unwrap_or_else(|| File::filename(&path));
+        let ext = File::ext(&path);
         let is_all_all = false;
 
         // If the caller provides a file type (from readdir's d_type), use
@@ -112,32 +116,59 @@ impl<'dir> File<'dir> {
             (ft, std::sync::OnceLock::from(md))
         };
 
-        Ok(File { name, ext, path, file_type, metadata, parent_dir, is_all_all, cached_total_size: std::sync::OnceLock::new() })
+        Ok(File {
+            name,
+            ext,
+            path,
+            file_type,
+            metadata,
+            parent_dir,
+            is_all_all,
+            cached_total_size: std::sync::OnceLock::new(),
+        })
     }
 
     pub fn new_aa_current(parent_dir: &'dir Dir) -> io::Result<File<'dir>> {
-        let path       = parent_dir.path.clone();
-        let ext        = File::ext(&path);
+        let path = parent_dir.path.clone();
+        let ext = File::ext(&path);
 
         debug!("Statting file {}", path.display());
-        let md         = std::fs::symlink_metadata(&path)?;
-        let file_type  = md.file_type();
+        let md = std::fs::symlink_metadata(&path)?;
+        let file_type = md.file_type();
         let is_all_all = true;
         let parent_dir = Some(parent_dir);
 
-        Ok(File { path, parent_dir, file_type, metadata: std::sync::OnceLock::from(md), ext, name: ".".into(), is_all_all, cached_total_size: std::sync::OnceLock::new() })
+        Ok(File {
+            path,
+            parent_dir,
+            file_type,
+            metadata: std::sync::OnceLock::from(md),
+            ext,
+            name: ".".into(),
+            is_all_all,
+            cached_total_size: std::sync::OnceLock::new(),
+        })
     }
 
     pub fn new_aa_parent(path: PathBuf, parent_dir: &'dir Dir) -> io::Result<File<'dir>> {
-        let ext        = File::ext(&path);
+        let ext = File::ext(&path);
 
         debug!("Statting file {}", path.display());
-        let md         = std::fs::symlink_metadata(&path)?;
-        let file_type  = md.file_type();
+        let md = std::fs::symlink_metadata(&path)?;
+        let file_type = md.file_type();
         let is_all_all = true;
         let parent_dir = Some(parent_dir);
 
-        Ok(File { path, parent_dir, file_type, metadata: std::sync::OnceLock::from(md), ext, name: "..".into(), is_all_all, cached_total_size: std::sync::OnceLock::new() })
+        Ok(File {
+            path,
+            parent_dir,
+            file_type,
+            metadata: std::sync::OnceLock::from(md),
+            ext,
+            name: "..".into(),
+            is_all_all,
+            cached_total_size: std::sync::OnceLock::new(),
+        })
     }
 
     /// A file’s name is derived from its string. This needs to handle directories
@@ -146,8 +177,7 @@ impl<'dir> File<'dir> {
     pub fn filename(path: &Path) -> String {
         if let Some(back) = path.components().next_back() {
             back.as_os_str().to_string_lossy().to_string()
-        }
-        else {
+        } else {
             // use the path as fallback
             error!("Path {} has no last component", path.display());
             path.display().to_string()
@@ -165,9 +195,7 @@ impl<'dir> File<'dir> {
     fn ext(path: &Path) -> Option<String> {
         let name = path.file_name().map(|f| f.to_string_lossy().to_string())?;
 
-        name.rfind('.')
-            .map(|p| name[p + 1 ..]
-            .to_ascii_lowercase())
+        name.rfind('.').map(|p| name[p + 1..].to_ascii_lowercase())
     }
 
     /// Lazily obtain the file's full metadata, performing a stat call only
@@ -178,8 +206,7 @@ impl<'dir> File<'dir> {
     pub fn metadata(&self) -> &std::fs::Metadata {
         self.metadata.get_or_init(|| {
             debug!("Lazy-statting file {}", self.path.display());
-            std::fs::symlink_metadata(&self.path)
-                .expect("metadata for known-existing file")
+            std::fs::symlink_metadata(&self.path).expect("metadata for known-existing file")
         })
     }
 
@@ -222,10 +249,10 @@ impl<'dir> File<'dir> {
         #[cfg(feature = "git")]
         {
             if let Ok(repo) = git2::Repository::open(path) {
-                let clean = repo.statuses(None)
-                    .map(|s| s.is_empty())
-                    .unwrap_or(true);
-                let branch = repo.head().ok()
+                let clean = repo.statuses(None).map(|s| s.is_empty()).unwrap_or(true);
+                let branch = repo
+                    .head()
+                    .ok()
                     .and_then(|h| h.shorthand().map(String::from));
                 return (clean, branch);
             }
@@ -286,10 +313,11 @@ impl<'dir> File<'dir> {
     /// be stat'd.
     pub fn deref_link(&mut self) {
         if self.is_link()
-            && let Ok(target_meta) = std::fs::metadata(&self.path) {
-                self.file_type = target_meta.file_type();
-                self.metadata = std::sync::OnceLock::from(target_meta);
-            }
+            && let Ok(target_meta) = std::fs::metadata(&self.path)
+        {
+            self.file_type = target_meta.file_type();
+            self.metadata = std::sync::OnceLock::from(target_meta);
+        }
     }
 
     /// Whether this file is a named pipe on the filesystem.
@@ -316,21 +344,17 @@ impl<'dir> File<'dir> {
         self.file_type.is_socket()
     }
 
-
     /// Re-prefixes the path pointed to by this file, if it’s a symlink, to
     /// make it an absolute path that can be accessed from whichever
     /// directory lx is being run from.
     fn reorient_target_path(&self, path: &Path) -> PathBuf {
         if path.is_absolute() {
             path.to_path_buf()
-        }
-        else if let Some(dir) = self.parent_dir {
+        } else if let Some(dir) = self.parent_dir {
             dir.join(path)
-        }
-        else if let Some(parent) = self.path.parent() {
+        } else if let Some(parent) = self.path.parent() {
             parent.join(path)
-        }
-        else {
+        } else {
             self.path.join(path)
         }
     }
@@ -346,15 +370,14 @@ impl<'dir> File<'dir> {
     /// existed. If this file cannot be read at all, returns the error that
     /// we got when we tried to read it.
     pub fn link_target(&self) -> FileTarget<'dir> {
-
         // We need to be careful to treat the path actually pointed to by
         // this file — which could be absolute or relative — to the path
         // we actually look up and turn into a `File` — which needs to be
         // absolute to be accessible from any directory.
         debug!("Reading link {}", self.path.display());
         let path = match std::fs::read_link(&self.path) {
-            Ok(p)   => p,
-            Err(e)  => return FileTarget::Err(e),
+            Ok(p) => p,
+            Err(e) => return FileTarget::Err(e),
         };
 
         let absolute_path = self.reorient_target_path(&path);
@@ -363,10 +386,19 @@ impl<'dir> File<'dir> {
         // follow links.
         match std::fs::metadata(&absolute_path) {
             Ok(metadata) => {
-                let ext  = File::ext(&path);
+                let ext = File::ext(&path);
                 let name = File::filename(&path);
                 let file_type = metadata.file_type();
-                let file = File { parent_dir: None, path, ext, file_type, metadata: std::sync::OnceLock::from(metadata), name, is_all_all: false, cached_total_size: std::sync::OnceLock::new() };
+                let file = File {
+                    parent_dir: None,
+                    path,
+                    ext,
+                    file_type,
+                    metadata: std::sync::OnceLock::from(metadata),
+                    name,
+                    is_all_all: false,
+                    cached_total_size: std::sync::OnceLock::new(),
+                };
                 FileTarget::Ok(Box::new(file))
             }
             Err(e) => {
@@ -406,8 +438,7 @@ impl<'dir> File<'dir> {
     pub fn blocks(&self) -> f::Blocks {
         if self.is_file() || self.is_link() {
             f::Blocks::Some(self.metadata().blocks())
-        }
-        else {
+        } else {
             f::Blocks::None
         }
     }
@@ -440,9 +471,7 @@ impl<'dir> File<'dir> {
         };
 
         let mut flags: libc::c_long = 0;
-        let ret = unsafe {
-            libc::ioctl(file.as_raw_fd(), FS_IOC_GETFLAGS, &mut flags)
-        };
+        let ret = unsafe { libc::ioctl(file.as_raw_fd(), FS_IOC_GETFLAGS, &mut flags) };
         if ret < 0 {
             return f::FileFlags(0);
         }
@@ -479,8 +508,7 @@ impl<'dir> File<'dir> {
     pub fn size(&self) -> f::Size {
         if self.is_directory() {
             f::Size::None
-        }
-        else if self.is_char_device() || self.is_block_device() {
+        } else if self.is_char_device() || self.is_block_device() {
             let device_ids = self.metadata().rdev().to_be_bytes();
 
             // In C-land, getting the major and minor device IDs is done with
@@ -491,8 +519,7 @@ impl<'dir> File<'dir> {
                 major: device_ids[6],
                 minor: device_ids[7],
             })
-        }
-        else {
+        } else {
             f::Size::Some(self.metadata().len())
         }
     }
@@ -501,8 +528,7 @@ impl<'dir> File<'dir> {
     pub fn size(&self) -> f::Size {
         if self.is_directory() {
             f::Size::None
-        }
-        else {
+        } else {
             f::Size::Some(self.metadata().len())
         }
     }
@@ -543,33 +569,36 @@ impl<'dir> File<'dir> {
         // Check the (dev, ino) cache before walking.
         #[cfg(unix)]
         if let Some(key) = cache_key
-            && let Some(&cached) = DIR_SIZE_CACHE.lock().unwrap().get(&key) {
-                return cached;
-            }
+            && let Some(&cached) = DIR_SIZE_CACHE.lock().unwrap().get(&key)
+        {
+            return cached;
+        }
 
         let entries: Vec<_> = match std::fs::read_dir(path) {
             Ok(e) => e.filter_map(std::result::Result::ok).collect(),
             Err(_) => return 0,
         };
 
-        let size: u64 = entries.par_iter().map(|entry| {
-            let Ok(ft) = entry.file_type() else { return 0 };
+        let size: u64 = entries
+            .par_iter()
+            .map(|entry| {
+                let Ok(ft) = entry.file_type() else { return 0 };
 
-            if ft.is_dir() {
-                // Extract (dev, ino) from the entry's metadata for
-                // the recursive call — avoids an extra stat.
-                #[cfg(unix)]
-                let child_key = entry.metadata().ok()
-                    .map(|m| (m.dev(), m.ino()));
-                #[cfg(not(unix))]
-                let child_key = None;
-                Self::dir_total_size(&entry.path(), child_key)
-            } else if ft.is_file() {
-                entry.metadata().map(|m| m.len()).unwrap_or(0)
-            } else {
-                0
-            }
-        }).sum();
+                if ft.is_dir() {
+                    // Extract (dev, ino) from the entry's metadata for
+                    // the recursive call — avoids an extra stat.
+                    #[cfg(unix)]
+                    let child_key = entry.metadata().ok().map(|m| (m.dev(), m.ino()));
+                    #[cfg(not(unix))]
+                    let child_key = None;
+                    Self::dir_total_size(&entry.path(), child_key)
+                } else if ft.is_file() {
+                    entry.metadata().map(|m| m.len()).unwrap_or(0)
+                } else {
+                    0
+                }
+            })
+            .sum();
 
         // Store in cache for future lookups.
         #[cfg(unix)]
@@ -598,8 +627,7 @@ impl<'dir> File<'dir> {
 
             let duration = Duration::new(sec.unsigned_abs(), nanosec.unsigned_abs() as u32);
             Some(UNIX_EPOCH - duration)
-        }
-        else {
+        } else {
             let duration = Duration::new(sec as u64, nanosec as u32);
             Some(UNIX_EPOCH + duration)
         }
@@ -607,7 +635,7 @@ impl<'dir> File<'dir> {
 
     #[cfg(windows)]
     pub fn changed_time(&self) -> Option<SystemTime> {
-        return self.modified_time()
+        return self.modified_time();
     }
 
     /// This file’s last accessed timestamp, if available on this platform.
@@ -629,26 +657,19 @@ impl<'dir> File<'dir> {
     pub fn type_char(&self) -> f::Type {
         if self.is_file() {
             f::Type::File
-        }
-        else if self.is_directory() {
+        } else if self.is_directory() {
             f::Type::Directory
-        }
-        else if self.is_pipe() {
+        } else if self.is_pipe() {
             f::Type::Pipe
-        }
-        else if self.is_link() {
+        } else if self.is_link() {
             f::Type::Link
-        }
-        else if self.is_char_device() {
+        } else if self.is_char_device() {
             f::Type::CharDevice
-        }
-        else if self.is_block_device() {
+        } else if self.is_block_device() {
             f::Type::BlockDevice
-        }
-        else if self.is_socket() {
+        } else if self.is_socket() {
             f::Type::Socket
-        }
-        else {
+        } else {
             f::Type::Special
         }
     }
@@ -657,11 +678,9 @@ impl<'dir> File<'dir> {
     pub fn type_char(&self) -> f::Type {
         if self.is_file() {
             f::Type::File
-        }
-        else if self.is_directory() {
+        } else if self.is_directory() {
             f::Type::Directory
-        }
-        else {
+        } else {
             f::Type::Special
         }
     }
@@ -682,21 +701,21 @@ impl<'dir> File<'dir> {
         let has_bit = |bit| bits & bit == bit;
 
         f::Permissions {
-            user_read:      has_bit(modes::USER_READ),
-            user_write:     has_bit(modes::USER_WRITE),
-            user_execute:   has_bit(modes::USER_EXECUTE),
+            user_read: has_bit(modes::USER_READ),
+            user_write: has_bit(modes::USER_WRITE),
+            user_execute: has_bit(modes::USER_EXECUTE),
 
-            group_read:     has_bit(modes::GROUP_READ),
-            group_write:    has_bit(modes::GROUP_WRITE),
-            group_execute:  has_bit(modes::GROUP_EXECUTE),
+            group_read: has_bit(modes::GROUP_READ),
+            group_write: has_bit(modes::GROUP_WRITE),
+            group_execute: has_bit(modes::GROUP_EXECUTE),
 
-            other_read:     has_bit(modes::OTHER_READ),
-            other_write:    has_bit(modes::OTHER_WRITE),
-            other_execute:  has_bit(modes::OTHER_EXECUTE),
+            other_read: has_bit(modes::OTHER_READ),
+            other_write: has_bit(modes::OTHER_WRITE),
+            other_execute: has_bit(modes::OTHER_EXECUTE),
 
-            sticky:         has_bit(modes::STICKY),
-            setgid:         has_bit(modes::SETGID),
-            setuid:         has_bit(modes::SETUID),
+            sticky: has_bit(modes::STICKY),
+            setgid: has_bit(modes::SETGID),
+            setuid: has_bit(modes::SETUID),
         }
     }
 
@@ -707,12 +726,12 @@ impl<'dir> File<'dir> {
 
         // https://docs.microsoft.com/en-us/windows/win32/fileio/file-attribute-constants
         f::Attributes {
-            directory:      has_bit(0x10),
-            archive:        has_bit(0x20),
-            readonly:       has_bit(0x1),
-            hidden:         has_bit(0x2),
-            system:         has_bit(0x4),
-            reparse_point:  has_bit(0x400),
+            directory: has_bit(0x10),
+            archive: has_bit(0x20),
+            readonly: has_bit(0x1),
+            hidden: has_bit(0x2),
+            system: has_bit(0x4),
+            reparse_point: has_bit(0x400),
         }
     }
 
@@ -721,8 +740,8 @@ impl<'dir> File<'dir> {
     /// This will always return `false` if the file has no extension.
     pub fn extension_is_one_of(&self, choices: &[&str]) -> bool {
         match &self.ext {
-            Some(ext)  => choices.contains(&&ext[..]),
-            None       => false,
+            Some(ext) => choices.contains(&&ext[..]),
+            None => false,
         }
     }
 
@@ -733,17 +752,14 @@ impl<'dir> File<'dir> {
     }
 }
 
-
 impl<'a> AsRef<File<'a>> for File<'a> {
     fn as_ref(&self) -> &File<'a> {
         self
     }
 }
 
-
 /// The result of following a symlink.
 pub enum FileTarget<'dir> {
-
     /// The symlink pointed at a file that exists.
     Ok(Box<File<'dir>>),
 
@@ -755,21 +771,18 @@ pub enum FileTarget<'dir> {
     /// file isn’t a link to begin with, but also if, say, we don’t have
     /// permission to follow it.
     Err(io::Error),
-
     // Err is its own variant, instead of having the whole thing be inside an
     // `io::Result`, because being unable to follow a symlink is not a serious
     // error — we just display the error message and move on.
 }
 
 impl FileTarget<'_> {
-
     /// Whether this link doesn’t lead to a file, for whatever reason. This
     /// gets used to determine how to highlight the link in grid views.
     pub fn is_broken(&self) -> bool {
         matches!(self, Self::Broken(_) | Self::Err(_))
     }
 }
-
 
 /// More readable aliases for the permission bits exposed by libc.
 #[allow(trivial_numeric_casts)]
@@ -780,23 +793,22 @@ mod modes {
     // from `metadata.permissions().mode()` is always `u32`.
     pub type Mode = u32;
 
-    pub const USER_READ: Mode     = libc::S_IRUSR as Mode;
-    pub const USER_WRITE: Mode    = libc::S_IWUSR as Mode;
-    pub const USER_EXECUTE: Mode  = libc::S_IXUSR as Mode;
+    pub const USER_READ: Mode = libc::S_IRUSR as Mode;
+    pub const USER_WRITE: Mode = libc::S_IWUSR as Mode;
+    pub const USER_EXECUTE: Mode = libc::S_IXUSR as Mode;
 
-    pub const GROUP_READ: Mode    = libc::S_IRGRP as Mode;
-    pub const GROUP_WRITE: Mode   = libc::S_IWGRP as Mode;
+    pub const GROUP_READ: Mode = libc::S_IRGRP as Mode;
+    pub const GROUP_WRITE: Mode = libc::S_IWGRP as Mode;
     pub const GROUP_EXECUTE: Mode = libc::S_IXGRP as Mode;
 
-    pub const OTHER_READ: Mode    = libc::S_IROTH as Mode;
-    pub const OTHER_WRITE: Mode   = libc::S_IWOTH as Mode;
+    pub const OTHER_READ: Mode = libc::S_IROTH as Mode;
+    pub const OTHER_WRITE: Mode = libc::S_IWOTH as Mode;
     pub const OTHER_EXECUTE: Mode = libc::S_IXOTH as Mode;
 
-    pub const STICKY: Mode        = libc::S_ISVTX as Mode;
-    pub const SETGID: Mode        = libc::S_ISGID as Mode;
-    pub const SETUID: Mode        = libc::S_ISUID as Mode;
+    pub const STICKY: Mode = libc::S_ISVTX as Mode;
+    pub const SETGID: Mode = libc::S_ISGID as Mode;
+    pub const SETUID: Mode = libc::S_ISUID as Mode;
 }
-
 
 #[cfg(test)]
 mod ext_test {
@@ -818,7 +830,6 @@ mod ext_test {
         assert_eq!(None, File::ext(Path::new("jarlsberg")))
     }
 }
-
 
 #[cfg(test)]
 mod filename_test {

--- a/src/fs/filter.rs
+++ b/src/fs/filter.rs
@@ -6,7 +6,6 @@ use std::iter::FromIterator;
 use crate::fs::DotFilter;
 use crate::fs::File;
 
-
 /// The **file filter** processes a list of files before displaying them to
 /// the user, by removing files they don’t want to see, and putting the list
 /// in the desired order.
@@ -23,7 +22,6 @@ use crate::fs::File;
 /// performing the comparison.
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FileFilter {
-
     /// Whether to group directories before or after other files.
     pub group_dirs: GroupDirs,
 
@@ -72,7 +70,6 @@ pub struct FileFilter {
     pub symlink_mode: SymlinkMode,
 }
 
-
 /// How symlinks should be handled.
 #[derive(PartialEq, Eq, Debug, Copy, Clone, Default)]
 pub enum SymlinkMode {
@@ -95,11 +92,11 @@ impl FileFilter {
     /// Remove every file in the given vector that does *not* pass the
     /// filter predicate for files found inside a directory.
     pub fn filter_child_files(&self, files: &mut Vec<File<'_>>) {
-        files.retain(|f| ! self.ignore_patterns.is_matched(&f.name));
+        files.retain(|f| !self.ignore_patterns.is_matched(&f.name));
 
         match self.symlink_mode {
             SymlinkMode::Hide => {
-                files.retain(|f| ! f.is_link());
+                files.retain(|f| !f.is_link());
             }
             SymlinkMode::Follow => {
                 for f in files.iter_mut() {
@@ -114,7 +111,7 @@ impl FileFilter {
         }
 
         if self.only_files {
-            files.retain(|f| ! f.is_directory());
+            files.retain(|f| !f.is_directory());
         }
     }
 
@@ -128,9 +125,7 @@ impl FileFilter {
     /// `lx -I=’*.ogg’ music/*` should filter out the ogg files obtained
     /// from the glob, even though the globbing is done by the shell!
     pub fn filter_argument_files(&self, files: &mut Vec<File<'_>>) {
-        files.retain(|f| {
-            ! self.ignore_patterns.is_matched(&f.name)
-        });
+        files.retain(|f| !self.ignore_patterns.is_matched(&f.name));
 
         if self.symlink_mode == SymlinkMode::Follow {
             for f in files.iter_mut() {
@@ -148,7 +143,8 @@ impl FileFilter {
     /// fields then fall back to the registry entry's normal
     /// comparator (typically by-name for VCS sort).
     pub fn sort_files<'a, F>(&self, files: &mut [F], vcs: Option<&dyn crate::fs::feature::VcsCache>)
-    where F: AsRef<File<'a>>
+    where
+        F: AsRef<File<'a>>,
     {
         use crate::fs::sort_registry::SortFieldDef;
 
@@ -158,8 +154,14 @@ impl FileFilter {
             // When --total-size is active, sort by recursive dir size.
             use crate::fs::fields::Size;
             files.sort_by(|a, b| {
-                let sa = match a.as_ref().total_size() { Size::Some(s) => s, _ => 0 };
-                let sb = match b.as_ref().total_size() { Size::Some(s) => s, _ => 0 };
+                let sa = match a.as_ref().total_size() {
+                    Size::Some(s) => s,
+                    _ => 0,
+                };
+                let sb = match b.as_ref().total_size() {
+                    Size::Some(s) => s,
+                    _ => 0,
+                };
                 sa.cmp(&sb)
             });
         } else if def.needs_vcs && vcs.is_some() {
@@ -171,7 +173,8 @@ impl FileFilter {
                 // and unstaged are identical in jj; for git the
                 // unstaged state is usually the more interesting one
                 // for "what needs attention").
-                Self::vcs_sort_key(sa.unstaged).cmp(&Self::vcs_sort_key(sb.unstaged))
+                Self::vcs_sort_key(sa.unstaged)
+                    .cmp(&Self::vcs_sort_key(sb.unstaged))
                     .then_with(|| natord::compare(&a.as_ref().name, &b.as_ref().name))
             });
         } else {
@@ -187,13 +190,15 @@ impl FileFilter {
                 // This relies on the fact that `sort_by` is *stable*: it will
                 // keep adjacent elements next to each other.
                 files.sort_by(|a, b| {
-                    b.as_ref().points_to_directory()
+                    b.as_ref()
+                        .points_to_directory()
                         .cmp(&a.as_ref().points_to_directory())
                 });
             }
             GroupDirs::Last => {
                 files.sort_by(|a, b| {
-                    a.as_ref().points_to_directory()
+                    a.as_ref()
+                        .points_to_directory()
                         .cmp(&b.as_ref().points_to_directory())
                 });
             }
@@ -212,25 +217,23 @@ impl FileFilter {
     fn vcs_sort_key(status: crate::fs::fields::VcsStatus) -> u8 {
         use crate::fs::fields::VcsStatus::*;
         match status {
-            Conflicted  => 0,
-            Modified    => 1,
-            New         => 2,
-            Deleted     => 3,
-            Renamed     => 4,
-            Copied      => 5,
-            TypeChange  => 6,
-            Untracked   => 7,
-            Ignored     => 8,
+            Conflicted => 0,
+            Modified => 1,
+            New => 2,
+            Deleted => 3,
+            Renamed => 4,
+            Copied => 5,
+            TypeChange => 6,
+            Untracked => 7,
+            Ignored => 8,
             NotModified => 9,
         }
     }
 }
 
-
 /// User-supplied field to sort by.
 #[derive(PartialEq, Eq, Debug, Copy, Clone)]
 pub enum SortField {
-
     /// Don’t apply any sorting. This is usually used as an optimisation in
     /// scripts, where the order doesn’t matter.
     Unsorted,
@@ -352,7 +355,6 @@ pub enum SortField {
 /// effects they have.
 #[derive(PartialEq, Eq, Debug, Copy, Clone)]
 pub enum SortCase {
-
     /// Sort files case-sensitively with uppercase first, with ‘A’ coming
     /// before ‘a’.
     ABCabc,
@@ -362,7 +364,6 @@ pub enum SortCase {
 }
 
 impl SortField {
-
     /// Compares two files to determine the order they should be listed in,
     /// depending on the search field.
     ///
@@ -386,7 +387,6 @@ impl SortField {
     }
 }
 
-
 /// The **ignore patterns** are a list of globs that are tested against
 /// each filename, and if any of them match, that file isn’t displayed.
 /// This lets a user hide, say, text files by ignoring `*.txt`.
@@ -396,9 +396,9 @@ pub struct IgnorePatterns {
 }
 
 impl FromIterator<glob::Pattern> for IgnorePatterns {
-
     fn from_iter<I>(iter: I) -> Self
-    where I: IntoIterator<Item = glob::Pattern>
+    where
+        I: IntoIterator<Item = glob::Pattern>,
     {
         let patterns = iter.into_iter().collect();
         Self { patterns }
@@ -406,18 +406,19 @@ impl FromIterator<glob::Pattern> for IgnorePatterns {
 }
 
 impl IgnorePatterns {
-
     /// Create a new list from the input glob strings, turning the inputs that
     /// are valid glob patterns into an `IgnorePatterns`. The inputs that
     /// don’t parse correctly are returned separately.
-    pub fn parse_from_iter<'a, I: IntoIterator<Item = &'a str>>(iter: I) -> (Self, Vec<glob::PatternError>) {
+    pub fn parse_from_iter<'a, I: IntoIterator<Item = &'a str>>(
+        iter: I,
+    ) -> (Self, Vec<glob::PatternError>) {
         let iter = iter.into_iter();
 
         // Almost all glob patterns are valid, so it’s worth pre-allocating
         // the vector with enough space for all of them.
         let mut patterns = match iter.size_hint() {
-            (_, Some(count))  => Vec::with_capacity(count),
-             _                => Vec::new(),
+            (_, Some(count)) => Vec::with_capacity(count),
+            _ => Vec::new(),
         };
 
         // Similarly, assume there won’t be any errors.
@@ -426,7 +427,7 @@ impl IgnorePatterns {
         for input in iter {
             match glob::Pattern::new(input) {
                 Ok(pat) => patterns.push(pat),
-                Err(e)  => errors.push(e),
+                Err(e) => errors.push(e),
             }
         }
 
@@ -435,7 +436,9 @@ impl IgnorePatterns {
 
     /// Create a new empty set of patterns that matches nothing.
     pub fn empty() -> Self {
-        Self { patterns: Vec::new() }
+        Self {
+            patterns: Vec::new(),
+        }
     }
 
     /// Test whether the given filename matches any of the patterns.
@@ -443,7 +446,6 @@ impl IgnorePatterns {
         self.patterns.iter().any(|p| p.matches(file))
     }
 }
-
 
 /// How to group directories relative to other files in the listing.
 #[derive(PartialEq, Eq, Debug, Copy, Clone, Default)]
@@ -457,19 +459,15 @@ pub enum GroupDirs {
     None,
 }
 
-
 /// Whether to ignore or display files that the VCS would ignore.
 #[derive(PartialEq, Eq, Debug, Copy, Clone)]
 pub enum VcsIgnore {
-
     /// Ignore files that the VCS would ignore.
     CheckAndIgnore,
 
     /// Display files, even if the VCS would ignore them.
     Off,
 }
-
-
 
 #[cfg(test)]
 mod test_ignores {
@@ -484,7 +482,7 @@ mod test_ignores {
 
     #[test]
     fn ignores_a_glob() {
-        let (pats, fails) = IgnorePatterns::parse_from_iter(vec![ "*.mp3" ]);
+        let (pats, fails) = IgnorePatterns::parse_from_iter(vec!["*.mp3"]);
         assert!(fails.is_empty());
         assert!(!pats.is_matched("nothing"));
         assert!(pats.is_matched("test.mp3"));
@@ -492,7 +490,7 @@ mod test_ignores {
 
     #[test]
     fn ignores_an_exact_filename() {
-        let (pats, fails) = IgnorePatterns::parse_from_iter(vec![ "nothing" ]);
+        let (pats, fails) = IgnorePatterns::parse_from_iter(vec!["nothing"]);
         assert!(fails.is_empty());
         assert!(pats.is_matched("nothing"));
         assert!(!pats.is_matched("test.mp3"));
@@ -500,7 +498,7 @@ mod test_ignores {
 
     #[test]
     fn ignores_both() {
-        let (pats, fails) = IgnorePatterns::parse_from_iter(vec![ "nothing", "*.mp3" ]);
+        let (pats, fails) = IgnorePatterns::parse_from_iter(vec!["nothing", "*.mp3"]);
         assert!(fails.is_empty());
         assert!(pats.is_matched("nothing"));
         assert!(pats.is_matched("test.mp3"));

--- a/src/fs/sort_registry.rs
+++ b/src/fs/sort_registry.rs
@@ -15,7 +15,6 @@ use crate::fs::File;
 use crate::fs::fields::Blocks;
 use crate::fs::filter::SortField;
 
-
 // ── SortFieldDef ────────────────────────────────────────────────
 
 /// Metadata for a single `--sort` field.
@@ -57,7 +56,6 @@ pub struct SortFieldDef {
     pub hidden: bool,
 }
 
-
 // ── Comparator functions ────────────────────────────────────────
 //
 // Each `--sort` value has a dedicated top-level function here.
@@ -91,14 +89,14 @@ fn strip_dot(n: &str) -> &str {
 fn cmp_extension_ci(a: &File<'_>, b: &File<'_>) -> Ordering {
     match a.ext.cmp(&b.ext) {
         Ordering::Equal => natord::compare_ignore_case(&a.name, &b.name),
-        order           => order,
+        order => order,
     }
 }
 
 fn cmp_extension_cs(a: &File<'_>, b: &File<'_>) -> Ordering {
     match a.ext.cmp(&b.ext) {
         Ordering::Equal => natord::compare(&a.name, &b.name),
-        order           => order,
+        order => order,
     }
 }
 
@@ -130,7 +128,7 @@ fn cmp_created(a: &File<'_>, b: &File<'_>) -> Ordering {
 fn cmp_type(a: &File<'_>, b: &File<'_>) -> Ordering {
     match a.type_char().cmp(&b.type_char()) {
         Ordering::Equal => natord::compare(&a.name, &b.name),
-        order           => order,
+        order => order,
     }
 }
 
@@ -142,13 +140,15 @@ fn cmp_inode(a: &File<'_>, b: &File<'_>) -> Ordering {
 
 #[cfg(unix)]
 fn cmp_permissions(a: &File<'_>, b: &File<'_>) -> Ordering {
-    a.permissions_octal().cmp(&b.permissions_octal())
+    a.permissions_octal()
+        .cmp(&b.permissions_octal())
         .then_with(|| natord::compare(&a.name, &b.name))
 }
 
 #[cfg(unix)]
 fn cmp_blocks(a: &File<'_>, b: &File<'_>) -> Ordering {
-    blocks_value(a).cmp(&blocks_value(b))
+    blocks_value(a)
+        .cmp(&blocks_value(b))
         .then_with(|| natord::compare(&a.name, &b.name))
 }
 
@@ -156,18 +156,22 @@ fn cmp_blocks(a: &File<'_>, b: &File<'_>) -> Ordering {
 fn blocks_value(f: &File<'_>) -> u64 {
     match f.blocks() {
         Blocks::Some(n) => n,
-        Blocks::None    => 0,
+        Blocks::None => 0,
     }
 }
 
 #[cfg(unix)]
 fn cmp_hard_links(a: &File<'_>, b: &File<'_>) -> Ordering {
-    a.links().count.cmp(&b.links().count)
+    a.links()
+        .count
+        .cmp(&b.links().count)
         .then_with(|| natord::compare(&a.name, &b.name))
 }
 
 fn cmp_flags(a: &File<'_>, b: &File<'_>) -> Ordering {
-    a.flags().0.cmp(&b.flags().0)
+    a.flags()
+        .0
+        .cmp(&b.flags().0)
         .then_with(|| natord::compare(&a.name, &b.name))
 }
 
@@ -193,13 +197,17 @@ fn cmp_group_cs(a: &File<'_>, b: &File<'_>) -> Ordering {
 
 #[cfg(unix)]
 fn cmp_uid(a: &File<'_>, b: &File<'_>) -> Ordering {
-    a.user().0.cmp(&b.user().0)
+    a.user()
+        .0
+        .cmp(&b.user().0)
         .then_with(|| natord::compare(&a.name, &b.name))
 }
 
 #[cfg(unix)]
 fn cmp_gid(a: &File<'_>, b: &File<'_>) -> Ordering {
-    a.group().0.cmp(&b.group().0)
+    a.group()
+        .0
+        .cmp(&b.group().0)
         .then_with(|| natord::compare(&a.name, &b.name))
 }
 
@@ -210,12 +218,14 @@ fn cmp_vcs_fallback(a: &File<'_>, b: &File<'_>) -> Ordering {
     natord::compare(&a.name, &b.name)
 }
 
-
 // ── User / group name resolution ────────────────────────────────
 
 #[cfg(unix)]
 #[derive(Copy, Clone)]
-enum CaseMode { Sensitive, Insensitive }
+enum CaseMode {
+    Sensitive,
+    Insensitive,
+}
 
 #[cfg(unix)]
 fn compare_user_names(a: &File<'_>, b: &File<'_>, case: CaseMode) -> Ordering {
@@ -223,17 +233,19 @@ fn compare_user_names(a: &File<'_>, b: &File<'_>, case: CaseMode) -> Ordering {
 
     let env = crate::output::table::environment();
     let users = env.lock_users();
-    let name_a = users.get_user_by_uid(a.user().0)
+    let name_a = users
+        .get_user_by_uid(a.user().0)
         .map(|u| u.name().to_string_lossy().into_owned());
-    let name_b = users.get_user_by_uid(b.user().0)
+    let name_b = users
+        .get_user_by_uid(b.user().0)
         .map(|u| u.name().to_string_lossy().into_owned());
     drop(users);
 
     match (name_a, name_b) {
         (Some(na), Some(nb)) => case_compare(&na, &nb, case),
-        (Some(_), None)      => Ordering::Less,
-        (None, Some(_))      => Ordering::Greater,
-        (None, None)         => a.user().0.cmp(&b.user().0),
+        (Some(_), None) => Ordering::Less,
+        (None, Some(_)) => Ordering::Greater,
+        (None, None) => a.user().0.cmp(&b.user().0),
     }
     .then_with(|| natord::compare(&a.name, &b.name))
 }
@@ -244,17 +256,19 @@ fn compare_group_names(a: &File<'_>, b: &File<'_>, case: CaseMode) -> Ordering {
 
     let env = crate::output::table::environment();
     let users = env.lock_users();
-    let name_a = users.get_group_by_gid(a.group().0)
+    let name_a = users
+        .get_group_by_gid(a.group().0)
         .map(|g| g.name().to_string_lossy().into_owned());
-    let name_b = users.get_group_by_gid(b.group().0)
+    let name_b = users
+        .get_group_by_gid(b.group().0)
         .map(|g| g.name().to_string_lossy().into_owned());
     drop(users);
 
     match (name_a, name_b) {
         (Some(na), Some(nb)) => case_compare(&na, &nb, case),
-        (Some(_), None)      => Ordering::Less,
-        (None, Some(_))      => Ordering::Greater,
-        (None, None)         => a.group().0.cmp(&b.group().0),
+        (Some(_), None) => Ordering::Less,
+        (None, Some(_)) => Ordering::Greater,
+        (None, None) => a.group().0.cmp(&b.group().0),
     }
     .then_with(|| natord::compare(&a.name, &b.name))
 }
@@ -262,11 +276,10 @@ fn compare_group_names(a: &File<'_>, b: &File<'_>, case: CaseMode) -> Ordering {
 #[cfg(unix)]
 fn case_compare(a: &str, b: &str, case: CaseMode) -> Ordering {
     match case {
-        CaseMode::Sensitive   => natord::compare(a, b),
+        CaseMode::Sensitive => natord::compare(a, b),
         CaseMode::Insensitive => natord::compare_ignore_case(a, b),
     }
 }
-
 
 // ── The registry ────────────────────────────────────────────────
 
@@ -285,7 +298,6 @@ use crate::fs::filter::SortCase;
 /// and "Name" to different comparators.
 pub static SORT_REGISTRY: &[SortFieldDef] = &[
     // ── Name and extension ───────────────────────────────────
-
     SortFieldDef {
         field: SortField::Name(SortCase::AaBbCc),
         name: "name",
@@ -340,9 +352,7 @@ pub static SORT_REGISTRY: &[SortFieldDef] = &[
         needs_vcs: false,
         hidden: false,
     },
-
     // ── Size and allocation ──────────────────────────────────
-
     SortFieldDef {
         field: SortField::Size,
         name: "size",
@@ -372,9 +382,7 @@ pub static SORT_REGISTRY: &[SortFieldDef] = &[
         needs_vcs: false,
         hidden: false,
     },
-
     // ── Ownership and mode ───────────────────────────────────
-
     #[cfg(unix)]
     SortFieldDef {
         field: SortField::Permissions,
@@ -454,9 +462,7 @@ pub static SORT_REGISTRY: &[SortFieldDef] = &[
         needs_vcs: false,
         hidden: false,
     },
-
     // ── Time ─────────────────────────────────────────────────
-
     SortFieldDef {
         field: SortField::ModifiedDate,
         name: "modified",
@@ -502,9 +508,7 @@ pub static SORT_REGISTRY: &[SortFieldDef] = &[
         needs_vcs: false,
         hidden: false,
     },
-
     // ── VCS ──────────────────────────────────────────────────
-
     SortFieldDef {
         field: SortField::VcsStatusSort,
         name: "vcs",
@@ -514,9 +518,7 @@ pub static SORT_REGISTRY: &[SortFieldDef] = &[
         needs_vcs: true,
         hidden: false,
     },
-
     // ── Miscellaneous ────────────────────────────────────────
-
     #[cfg(unix)]
     SortFieldDef {
         field: SortField::FileInode,
@@ -545,7 +547,6 @@ pub static SORT_REGISTRY: &[SortFieldDef] = &[
         needs_vcs: false,
         hidden: false,
     },
-
     // Hidden alias entries for values accepted by `--sort` but that
     // map to the same SortField as a canonical entry above.  These
     // are lookup-only: they're present so `SortField::from_name`
@@ -554,7 +555,6 @@ pub static SORT_REGISTRY: &[SortFieldDef] = &[
     // the visible `--help` list by checking for an empty `name`;
     // here we use a distinct name-alias convention below instead.
 ];
-
 
 // ── Lookup functions ────────────────────────────────────────────
 
@@ -567,7 +567,8 @@ impl SortFieldDef {
     /// enum outer); this returns the first match, which is always
     /// the authoritative entry for `compare_files` dispatch.
     pub fn for_field(field: SortField) -> &'static SortFieldDef {
-        SORT_REGISTRY.iter()
+        SORT_REGISTRY
+            .iter()
             .find(|d| d.field == field)
             .expect("every SortField variant must have a registry entry")
     }
@@ -577,7 +578,8 @@ impl SortFieldDef {
     ///
     /// Matches both canonical names and aliases.
     pub fn field_from_name(s: &str) -> Option<SortField> {
-        SORT_REGISTRY.iter()
+        SORT_REGISTRY
+            .iter()
             .find(|d| d.name == s || d.aliases.contains(&s))
             .map(|d| d.field)
     }
@@ -595,11 +597,8 @@ impl SortFieldDef {
     ///    (e.g. `.name`, `.Name`), and
     /// 2. all alias names from every entry.
     pub fn all_hidden_names() -> impl Iterator<Item = &'static str> {
-        let hidden_canonicals = SORT_REGISTRY.iter()
-            .filter(|d| d.hidden)
-            .map(|d| d.name);
-        let all_aliases = SORT_REGISTRY.iter()
-            .flat_map(|d| d.aliases.iter().copied());
+        let hidden_canonicals = SORT_REGISTRY.iter().filter(|d| d.hidden).map(|d| d.name);
+        let all_aliases = SORT_REGISTRY.iter().flat_map(|d| d.aliases.iter().copied());
         hidden_canonicals.chain(all_aliases)
     }
 }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -2,8 +2,7 @@
 
 use std::ffi::OsStr;
 
-use nu_ansi_term::{Color, AnsiString};
-
+use nu_ansi_term::{AnsiString, Color};
 
 /// Sets the internal logger, changing the log level based on the value of an
 /// environment variable.
@@ -17,8 +16,7 @@ pub fn configure<T: AsRef<OsStr>>(ev: Option<T>) {
 
     if env_var == "trace" {
         log::set_max_level(log::LevelFilter::Trace);
-    }
-    else {
+    } else {
         log::set_max_level(log::LevelFilter::Debug);
     }
 
@@ -28,7 +26,6 @@ pub fn configure<T: AsRef<OsStr>>(ev: Option<T>) {
     }
 }
 
-
 #[derive(Debug)]
 struct Logger;
 
@@ -36,7 +33,7 @@ const GLOBAL_LOGGER: &Logger = &Logger;
 
 impl log::Log for Logger {
     fn enabled(&self, _: &log::Metadata<'_>) -> bool {
-        true  // no need to filter after using ‘set_max_level’.
+        true // no need to filter after using ‘set_max_level’.
     }
 
     fn log(&self, record: &log::Record<'_>) {
@@ -44,7 +41,14 @@ impl log::Log for Logger {
         let level = level(record.level());
         let close = Color::Fixed(243).paint("]");
 
-        eprintln!("{}{} {}{} {}", open, level, record.target(), close, record.args());
+        eprintln!(
+            "{}{} {}{} {}",
+            open,
+            level,
+            record.target(),
+            close,
+            record.args()
+        );
     }
 
     fn flush(&self) {
@@ -54,10 +58,10 @@ impl log::Log for Logger {
 
 fn level(level: log::Level) -> AnsiString<'static> {
     match level {
-        log::Level::Error  => Color::Red.paint("ERROR"),
-        log::Level::Warn   => Color::Yellow.paint("WARN"),
-        log::Level::Info   => Color::Cyan.paint("INFO"),
-        log::Level::Debug  => Color::Blue.paint("DEBUG"),
-        log::Level::Trace  => Color::Fixed(245).paint("TRACE"),
+        log::Level::Error => Color::Red.paint("ERROR"),
+        log::Level::Warn => Color::Yellow.paint("WARN"),
+        log::Level::Info => Color::Cyan.paint("INFO"),
+        log::Level::Debug => Color::Blue.paint("DEBUG"),
+        log::Level::Trace => Color::Fixed(245).paint("TRACE"),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,6 @@
 #![warn(rust_2018_idioms)]
 #![warn(trivial_casts, trivial_numeric_casts)]
 #![warn(unused)]
-
 #![warn(clippy::all, clippy::pedantic)]
 #![allow(clippy::cast_precision_loss)]
 #![allow(clippy::cast_possible_truncation)]
@@ -24,7 +23,7 @@
 
 use std::env;
 use std::ffi::OsString;
-use std::io::{self, Write, ErrorKind};
+use std::io::{self, ErrorKind, Write};
 use std::path::{Component, PathBuf};
 
 use nu_ansi_term::{AnsiStrings, Style};
@@ -32,13 +31,13 @@ use nu_ansi_term::{AnsiStrings, Style};
 use log::*;
 
 use crate::config::ConfigError;
-use crate::fs::{Dir, File};
+use crate::fs::feature::VcsCache;
 use crate::fs::feature::git::GitCache;
 use crate::fs::feature::jj::JjCache;
-use crate::fs::feature::VcsCache;
 use crate::fs::filter::VcsIgnore;
-use crate::options::{Options, OptionsError, VcsBackend, Vars, vars, OptionsResult};
-use crate::output::{escape, lines, grid, grid_details, details, View, Mode};
+use crate::fs::{Dir, File};
+use crate::options::{Options, OptionsError, OptionsResult, Vars, VcsBackend, vars};
+use crate::output::{Mode, View, details, escape, grid, grid_details, lines};
 use crate::theme::{Theme, ThemeError};
 
 mod config;
@@ -47,7 +46,6 @@ mod logger;
 pub(crate) mod options;
 mod output;
 mod theme;
-
 
 /// Top-level error type for the `lx` binary.
 ///
@@ -75,14 +73,15 @@ impl LxError {
         match self {
             Self::Options(_)
             | Self::Theme(_)
-            | Self::Config(ConfigError::InheritanceCycle { .. }
-                          | ConfigError::MissingParent { .. }
-                          | ConfigError::NotFound { .. }) => exits::OPTIONS_ERROR,
+            | Self::Config(
+                ConfigError::InheritanceCycle { .. }
+                | ConfigError::MissingParent { .. }
+                | ConfigError::NotFound { .. },
+            ) => exits::OPTIONS_ERROR,
             _ => exits::RUNTIME_ERROR,
         }
     }
 }
-
 
 fn main() {
     #[cfg(unix)]
@@ -106,7 +105,6 @@ fn main() {
     }
 }
 
-
 /// Format the "error:" label the way clap does: bold red when stderr is
 /// a terminal and `NO_COLOR` is unset, plain otherwise.  Keeps our
 /// non-clap fatal errors visually consistent with clap's own output.
@@ -119,7 +117,6 @@ fn error_label() -> &'static str {
         "error:"
     }
 }
-
 
 /// Discover personality names for shell-completion alias registration
 /// by scanning `$PATH` for symlinks that resolve to the same binary
@@ -142,15 +139,25 @@ fn personality_completion_names() -> Vec<String> {
 
     let mut names = Vec::new();
     for dir in std::env::split_paths(&path_var) {
-        let Ok(entries) = std::fs::read_dir(&dir) else { continue };
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
         for entry in entries.filter_map(Result::ok) {
             let path = entry.path();
             // Only check symlinks — skip regular files and dirs.
-            let Ok(meta) = path.symlink_metadata() else { continue };
-            if !meta.is_symlink() { continue }
+            let Ok(meta) = path.symlink_metadata() else {
+                continue;
+            };
+            if !meta.is_symlink() {
+                continue;
+            }
             // Does this symlink resolve to our binary?
-            let Ok(target) = path.canonicalize() else { continue };
-            if target != our_exe { continue }
+            let Ok(target) = path.canonicalize() else {
+                continue;
+            };
+            if target != our_exe {
+                continue;
+            }
             if let Some(name) = path.file_name().and_then(|n| n.to_str())
                 && name != "lx"
                 && !names.iter().any(|n| n == name)
@@ -163,7 +170,6 @@ fn personality_completion_names() -> Vec<String> {
     names.sort();
     names
 }
-
 
 /// Fallible body of `main()`.  Returns the desired process exit code on
 /// success or a top-level `LxError` to be reported by the wrapper.
@@ -245,7 +251,7 @@ fn try_main() -> Result<i32, LxError> {
                     candidates: config::all_personality_names().join(", "),
                 }));
             }
-            None => {}  // -p (clap will catch it) or argv[0] (silent default)
+            None => {} // -p (clap will catch it) or argv[0] (silent default)
         }
         // `explicit` is now only consulted via personality_source above.
         let _ = explicit;
@@ -254,14 +260,12 @@ fn try_main() -> Result<i32, LxError> {
     // Layer 3: actual CLI args (override everything above).
     args.extend(cli_args.iter().cloned());
 
-
     match Options::parse(&args, &LiveVars) {
         OptionsResult::Ok(options, mut input_paths) => {
-
             // List the current directory by default.
             // (This has to be done here, otherwise git_options won't see it.)
             if input_paths.is_empty() {
-                input_paths = vec![ OsString::from(".") ];
+                input_paths = vec![OsString::from(".")];
             }
 
             let vcs = vcs_cache(&options, &input_paths);
@@ -271,16 +275,34 @@ fn try_main() -> Result<i32, LxError> {
             let theme = options.theme.to_theme(console_width.is_some())?;
 
             // Build a locale::Numeric with personality overrides applied.
-            let mut numeric = locale::Numeric::load_user_locale()
-                .unwrap_or_else(|_| locale::Numeric::english());
-            if let Some(ref dp) = options.view.table_options().and_then(|t| t.decimal_point.clone()) {
+            let mut numeric =
+                locale::Numeric::load_user_locale().unwrap_or_else(|_| locale::Numeric::english());
+            if let Some(ref dp) = options
+                .view
+                .table_options()
+                .and_then(|t| t.decimal_point.clone())
+            {
                 numeric.decimal_sep.clone_from(dp);
             }
-            if let Some(ref ts) = options.view.table_options().and_then(|t| t.thousands_separator.clone()) {
+            if let Some(ref ts) = options
+                .view
+                .table_options()
+                .and_then(|t| t.thousands_separator.clone())
+            {
                 numeric.thousands_sep.clone_from(ts);
             }
 
-            let lx = Lx { options, writer, input_paths, theme, console_width, vcs, item_count: 0, size_total: 0, numeric };
+            let lx = Lx {
+                options,
+                writer,
+                input_paths,
+                theme,
+                console_width,
+                vcs,
+                item_count: 0,
+                size_total: 0,
+                numeric,
+            };
 
             match lx.run() {
                 Ok(exit_status) => return Ok(exit_status),
@@ -321,14 +343,17 @@ fn try_main() -> Result<i32, LxError> {
                 let joined = names.join(" ");
                 match shell {
                     clap_complete::Shell::Bash => {
-                        let _ = write!(out, "\n\
+                        let _ = write!(
+                            out,
+                            "\n\
                             if [[ \"${{BASH_VERSINFO[0]}}\" -eq 4 && \
                             \"${{BASH_VERSINFO[1]}}\" -ge 4 || \
                             \"${{BASH_VERSINFO[0]}}\" -gt 4 ]]; then\n    \
                             complete -F _lx -o nosort -o bashdefault -o default {joined}\n\
                             else\n    \
                             complete -F _lx -o bashdefault -o default {joined}\n\
-                            fi\n");
+                            fi\n"
+                        );
                     }
                     clap_complete::Shell::Zsh => {
                         let _ = writeln!(out, "\ncompdef _lx {joined}");
@@ -408,8 +433,7 @@ fn try_main() -> Result<i32, LxError> {
         }
 
         OptionsResult::UpgradeConfig => {
-            let path = config::find_config_path()
-                .ok_or(config::ConfigError::NothingToUpgrade)?;
+            let path = config::find_config_path().ok_or(config::ConfigError::NothingToUpgrade)?;
             config::upgrade_config(&path)?;
         }
 
@@ -419,11 +443,9 @@ fn try_main() -> Result<i32, LxError> {
     Ok(exits::SUCCESS)
 }
 
-
 /// The main program wrapper.  Holds parsed options, the theme, and any
 /// pre-populated caches (e.g. Git status).
 pub struct Lx {
-
     /// List of command-line options, having been successfully parsed.
     pub options: Options,
 
@@ -461,9 +483,13 @@ pub struct Lx {
 /// Format a byte count as a human-readable string for the `-CZ` summary.
 /// Respects the active size format (`-B` for binary, `-b` for bytes)
 /// and the personality's numeric formatting overrides.
-fn format_size(bytes: u64, fmt: crate::output::table::SizeFormat, numeric: &locale::Numeric) -> String {
-    use unit_prefix::NumberPrefix;
+fn format_size(
+    bytes: u64,
+    fmt: crate::output::table::SizeFormat,
+    numeric: &locale::Numeric,
+) -> String {
     use crate::output::table::SizeFormat;
+    use unit_prefix::NumberPrefix;
 
     match fmt {
         SizeFormat::JustBytes => {
@@ -475,7 +501,9 @@ fn format_size(bytes: u64, fmt: crate::output::table::SizeFormat, numeric: &loca
             } else {
                 let mut out = String::new();
                 for (i, c) in s.chars().rev().enumerate() {
-                    if i > 0 && i % 3 == 0 { out.insert_str(0, sep); }
+                    if i > 0 && i % 3 == 0 {
+                        out.insert_str(0, sep);
+                    }
                     out.insert(0, c);
                 }
                 out
@@ -530,9 +558,7 @@ fn vcs_cache(options: &Options, args: &[OsString]) -> Option<Box<dyn VcsCache>> 
             Some(Box::new(cache))
         }
 
-        VcsBackend::Jj => {
-            discover_jj(&paths)
-        }
+        VcsBackend::Jj => discover_jj(&paths),
 
         VcsBackend::Auto => {
             // Prefer jj if a workspace is detected, fall back to git.
@@ -565,13 +591,14 @@ impl Lx {
                 }
 
                 Ok(f) => {
-                    if f.points_to_directory() && ! self.options.dir_action.treat_dirs_as_files() {
+                    if f.points_to_directory() && !self.options.dir_action.treat_dirs_as_files() {
                         match f.to_dir() {
-                            Ok(d)   => dirs.push(d),
-                            Err(e)  => writeln!(io::stderr(), "{}: {e}", file_path.to_string_lossy())?,
+                            Ok(d) => dirs.push(d),
+                            Err(e) => {
+                                writeln!(io::stderr(), "{}: {e}", file_path.to_string_lossy())?
+                            }
                         }
-                    }
-                    else {
+                    } else {
                         files.push(f);
                     }
                 }
@@ -600,7 +627,10 @@ impl Lx {
             let count_p = number_style.paint(&count);
             let label_p = chrome_style.paint(" items shown");
             if self.options.view.has_total_size() {
-                let fmt = self.options.view.size_format()
+                let fmt = self
+                    .options
+                    .view
+                    .size_format()
                     .unwrap_or(crate::output::table::SizeFormat::DecimalBytes);
                 let size_str = format_size(self.size_total, fmt, &self.numeric);
                 let comma_p = chrome_style.paint(", ");
@@ -614,52 +644,75 @@ impl Lx {
         result
     }
 
-    fn print_dirs(&mut self, dir_files: Vec<Dir>, mut first: bool, is_only_dir: bool, exit_status: i32) -> io::Result<i32> {
+    fn print_dirs(
+        &mut self,
+        dir_files: Vec<Dir>,
+        mut first: bool,
+        is_only_dir: bool,
+        exit_status: i32,
+    ) -> io::Result<i32> {
         for dir in dir_files {
-
             // Put a gap between directories, or between the list of files and
             // the first directory.
             if first {
                 first = false;
-            }
-            else {
+            } else {
                 writeln!(&mut self.writer)?;
             }
 
-            if ! is_only_dir {
+            if !is_only_dir {
                 let mut bits = Vec::new();
-                escape(dir.path.display().to_string(), &mut bits, Style::default(), Style::default());
+                escape(
+                    dir.path.display().to_string(),
+                    &mut bits,
+                    Style::default(),
+                    Style::default(),
+                );
                 writeln!(&mut self.writer, "{}:", AnsiStrings(&bits))?;
             }
 
             let mut children = Vec::new();
             let vcs_ignore = self.options.filter.vcs_ignore == VcsIgnore::CheckAndIgnore;
-            for file in dir.files(self.options.filter.dot_filter, self.vcs.as_deref(), vcs_ignore) {
+            for file in dir.files(
+                self.options.filter.dot_filter,
+                self.vcs.as_deref(),
+                vcs_ignore,
+            ) {
                 match file {
-                    Ok(file)        => children.push(file),
-                    Err((path, e))  => writeln!(io::stderr(), "[{}: {}]", path.display(), e)?,
+                    Ok(file) => children.push(file),
+                    Err((path, e)) => writeln!(io::stderr(), "[{}: {}]", path.display(), e)?,
                 }
-            };
+            }
 
             self.options.filter.filter_child_files(&mut children);
-            self.options.filter.sort_files(&mut children, self.vcs.as_deref());
+            self.options
+                .filter
+                .sort_files(&mut children, self.vcs.as_deref());
 
             if let Some(recurse_opts) = self.options.dir_action.recurse_options() {
-                let depth = dir.path.components().filter(|&c| c != Component::CurDir).count() + 1;
-                if ! recurse_opts.tree && ! recurse_opts.is_too_deep(depth) {
-
+                let depth = dir
+                    .path
+                    .components()
+                    .filter(|&c| c != Component::CurDir)
+                    .count()
+                    + 1;
+                if !recurse_opts.tree && !recurse_opts.is_too_deep(depth) {
                     let mut child_dirs = Vec::new();
-                    for child_dir in children.iter().filter(|f| f.is_directory() && ! f.is_all_all && ! self.options.filter.is_pruned(f)) {
+                    for child_dir in children.iter().filter(|f| {
+                        f.is_directory() && !f.is_all_all && !self.options.filter.is_pruned(f)
+                    }) {
                         match child_dir.to_dir() {
-                            Ok(d)   => child_dirs.push(d),
-                            Err(e)  => writeln!(io::stderr(), "{}: {}", child_dir.path.display(), e)?,
+                            Ok(d) => child_dirs.push(d),
+                            Err(e) => {
+                                writeln!(io::stderr(), "{}: {}", child_dir.path.display(), e)?
+                            }
                         }
                     }
 
                     self.print_files(Some(&dir), children)?;
                     match self.print_dirs(child_dirs, false, false, exit_status) {
-                        Ok(_)   => (),
-                        Err(e)  => return Err(e),
+                        Ok(_) => (),
+                        Err(e) => return Err(e),
                     }
                     continue;
                 }
@@ -678,11 +731,14 @@ impl Lx {
         }
 
         let theme = &self.theme;
-        let View { mode, file_style, .. } = &self.options.view;
+        let View {
+            mode, file_style, ..
+        } = &self.options.view;
 
         // Sum file sizes for non-details modes (flat listing).
         let sum_file_sizes = |files: &[File<'_>]| -> u64 {
-            files.iter()
+            files
+                .iter()
                 .filter(|f| f.is_file())
                 .map(|f| f.metadata().len())
                 .sum()
@@ -693,16 +749,27 @@ impl Lx {
                 self.item_count += files.len();
                 self.size_total += sum_file_sizes(&files);
                 let filter = &self.options.filter;
-                let r = grid::Render { files, theme, file_style, opts, console_width, filter };
+                let r = grid::Render {
+                    files,
+                    theme,
+                    file_style,
+                    opts,
+                    console_width,
+                    filter,
+                };
                 r.render(&mut self.writer)
             }
 
-            (Mode::Grid(_), None) |
-            (Mode::Lines,   _)    => {
+            (Mode::Grid(_), None) | (Mode::Lines, _) => {
                 self.item_count += files.len();
                 self.size_total += sum_file_sizes(&files);
                 let filter = &self.options.filter;
-                let r = lines::Render { files, theme, file_style, filter };
+                let r = lines::Render {
+                    files,
+                    theme,
+                    file_style,
+                    filter,
+                };
                 r.render(&mut self.writer)
             }
 
@@ -712,7 +779,17 @@ impl Lx {
 
                 let vcs_ignoring = self.options.filter.vcs_ignore == VcsIgnore::CheckAndIgnore;
                 let vcs = self.vcs.as_deref();
-                let r = details::Render { dir, files, theme, file_style, opts, recurse, filter, vcs_ignoring, vcs };
+                let r = details::Render {
+                    dir,
+                    files,
+                    theme,
+                    file_style,
+                    opts,
+                    recurse,
+                    filter,
+                    vcs_ignoring,
+                    vcs,
+                };
                 let (count, bytes) = r.render(&mut self.writer)?;
                 self.item_count += count;
                 self.size_total += bytes;
@@ -730,7 +807,19 @@ impl Lx {
                 let vcs_ignoring = self.options.filter.vcs_ignore == VcsIgnore::CheckAndIgnore;
                 let vcs = self.vcs.as_deref();
 
-                let r = grid_details::Render { dir, files, theme, file_style, grid, details, filter, row_threshold, vcs_ignoring, vcs, console_width };
+                let r = grid_details::Render {
+                    dir,
+                    files,
+                    theme,
+                    file_style,
+                    grid,
+                    details,
+                    filter,
+                    row_threshold,
+                    vcs_ignoring,
+                    vcs,
+                    console_width,
+                };
                 r.render(&mut self.writer)
             }
 
@@ -741,7 +830,17 @@ impl Lx {
                 let vcs_ignoring = self.options.filter.vcs_ignore == VcsIgnore::CheckAndIgnore;
 
                 let vcs = self.vcs.as_deref();
-                let r = details::Render { dir, files, theme, file_style, opts, recurse, filter, vcs_ignoring, vcs };
+                let r = details::Render {
+                    dir,
+                    files,
+                    theme,
+                    file_style,
+                    opts,
+                    recurse,
+                    filter,
+                    vcs_ignoring,
+                    vcs,
+                };
                 let (count, bytes) = r.render(&mut self.writer)?;
                 self.item_count += count;
                 self.size_total += bytes;
@@ -750,7 +849,6 @@ impl Lx {
         }
     }
 }
-
 
 /// Scan raw args for --personality=NAME or -p NAME before Clap parsing.
 fn find_personality_arg(args: &[OsString]) -> Option<String> {
@@ -761,14 +859,17 @@ fn find_personality_arg(args: &[OsString]) -> Option<String> {
             return Some(name.to_string());
         }
         if (s == "--personality" || s == "-p")
-            && let Some(next) = iter.next() {
-                return Some(next.to_string_lossy().to_string());
-            }
+            && let Some(next) = iter.next()
+        {
+            return Some(next.to_string_lossy().to_string());
+        }
         // Handle -pNAME (short flag with attached value)
         if let Some(name) = s.strip_prefix("-p")
-            && !name.is_empty() && !name.starts_with('-') {
-                return Some(name.to_string());
-            }
+            && !name.is_empty()
+            && !name.starts_with('-')
+        {
+            return Some(name.to_string());
+        }
     }
     None
 }
@@ -783,13 +884,13 @@ fn find_theme_arg(args: &[OsString]) -> Option<String> {
             return Some(name.to_string());
         }
         if s == "--theme"
-            && let Some(next) = iter.next() {
-                return Some(next.to_string_lossy().to_string());
-            }
+            && let Some(next) = iter.next()
+        {
+            return Some(next.to_string_lossy().to_string());
+        }
     }
     None
 }
-
 
 mod exits {
 

--- a/src/options/dir_action.rs
+++ b/src/options/dir_action.rs
@@ -1,13 +1,11 @@
 //! Parsing the options for `DirAction`.
 
 use crate::options::parser::MatchedFlags;
-use crate::options::{flags, OptionsError};
+use crate::options::{OptionsError, flags};
 
 use crate::fs::dir_action::{DirAction, RecurseOptions};
 
-
 impl DirAction {
-
     /// Determine which action to perform when trying to list a directory.
     /// There are three possible actions, and they overlap somewhat: the
     /// `--tree` flag is another form of recursion, so those two are allowed
@@ -15,28 +13,23 @@ impl DirAction {
     pub fn deduce(matches: &MatchedFlags, can_tree: bool) -> Result<Self, OptionsError> {
         let recurse = matches.has(flags::RECURSE);
         let as_file = matches.has(flags::LIST_DIRS);
-        let tree    = matches.has(flags::TREE);
+        let tree = matches.has(flags::TREE);
 
         if tree && can_tree {
             // Tree is only appropriate in details mode, so this has to
             // examine the View, which should have already been deduced by now
             Ok(Self::Recurse(RecurseOptions::deduce(matches, true)?))
-        }
-        else if recurse {
+        } else if recurse {
             Ok(Self::Recurse(RecurseOptions::deduce(matches, false)?))
-        }
-        else if as_file {
+        } else if as_file {
             Ok(Self::AsFile)
-        }
-        else {
+        } else {
             Ok(Self::List)
         }
     }
 }
 
-
 impl RecurseOptions {
-
     /// Determine which files should be recursed into, based on the `--level`
     /// flag's value, and whether the `--tree` flag was passed, which was
     /// determined earlier. The maximum level should be a number, and this
@@ -47,7 +40,6 @@ impl RecurseOptions {
         Ok(Self { tree, max_depth })
     }
 }
-
 
 #[cfg(test)]
 mod test {
@@ -63,7 +55,6 @@ mod test {
             }
         };
     }
-
 
     // Default behaviour
     test!(empty:           DirAction <- [];               Ok(DirAction::List));

--- a/src/options/error.rs
+++ b/src/options/error.rs
@@ -3,18 +3,18 @@ use std::num::ParseIntError;
 
 use thiserror::Error;
 
-
 /// Something wrong with the combination of options the user has picked.
 #[derive(PartialEq, Eq, Debug, Error)]
 pub enum OptionsError {
-
     /// The user supplied a set of options that are unsupported.
     #[error("{0}")]
     Unsupported(String),
 
     /// A very specific edge case where --tree can't be used with --all twice.
-    #[error("the argument '--tree' cannot be used with '--all --all' \
-             (listing '.' and '..' in tree mode would recurse forever)")]
+    #[error(
+        "the argument '--tree' cannot be used with '--all --all' \
+             (listing '.' and '..' in tree mode would recurse forever)"
+    )]
     TreeAllAll,
 
     /// A numeric option was given that failed to be parsed as a number.
@@ -33,7 +33,6 @@ pub enum OptionsError {
 /// The source of a string that failed to be parsed as a number.
 #[derive(PartialEq, Eq, Debug)]
 pub enum NumberSource {
-
     /// It came from an environment variable.
     Env(&'static str),
 

--- a/src/options/file_name.rs
+++ b/src/options/file_name.rs
@@ -1,11 +1,10 @@
 use std::io::IsTerminal;
 
-use crate::options::{flags, OptionsError, NumberSource};
 use crate::options::parser::MatchedFlags;
 use crate::options::vars::{self, Vars};
+use crate::options::{NumberSource, OptionsError, flags};
 
-use crate::output::file_name::{Options, Classify, ShowIcons, Quotes};
-
+use crate::output::file_name::{Classify, Options, Quotes, ShowIcons};
 
 impl Options {
     pub fn deduce<V: Vars>(matches: &MatchedFlags, vars: &V) -> Result<Self, OptionsError> {
@@ -14,25 +13,37 @@ impl Options {
         let absolute = matches.has(flags::ABSOLUTE);
         let hyperlink = match matches.get(flags::HYPERLINK) {
             Some("always") => true,
-            Some("auto")   => std::io::stdout().is_terminal(),
-            _              => false,
+            Some("auto") => std::io::stdout().is_terminal(),
+            _ => false,
         };
         let quotes = match matches.get(flags::QUOTES) {
             Some("always" | "auto") => Quotes::Always,
             _ => Quotes::Never,
         };
 
-        Ok(Self { classify, show_icons, absolute, hyperlink, quotes })
+        Ok(Self {
+            classify,
+            show_icons,
+            absolute,
+            hyperlink,
+            quotes,
+        })
     }
 }
 
 impl Classify {
     fn deduce(matches: &MatchedFlags) -> Self {
         match matches.get(flags::CLASSIFY) {
-            Some("always")  => Self::AddFileIndicators,
-            Some("auto")    => if std::io::stdout().is_terminal() { Self::AddFileIndicators } else { Self::JustFilenames },
-            Some("never")   => Self::JustFilenames,
-            _               => Self::JustFilenames,
+            Some("always") => Self::AddFileIndicators,
+            Some("auto") => {
+                if std::io::stdout().is_terminal() {
+                    Self::AddFileIndicators
+                } else {
+                    Self::JustFilenames
+                }
+            }
+            Some("never") => Self::JustFilenames,
+            _ => Self::JustFilenames,
         }
     }
 }
@@ -46,10 +57,10 @@ impl ShowIcons {
 
         // Check --icons=WHEN value.
         let show = match matches.get(flags::ICONS) {
-            Some("always")  => true,
-            Some("auto")    => std::io::stdout().is_terminal(),
-            Some("never")   => false,
-            _               => false,  // absent = off
+            Some("always") => true,
+            Some("auto") => std::io::stdout().is_terminal(),
+            Some("never") => false,
+            _ => false, // absent = off
         };
 
         if !show {
@@ -60,22 +71,26 @@ impl ShowIcons {
         if let Some(spacing) = matches.get("icon-spacing") {
             return match spacing.parse::<u32>() {
                 Ok(n) => Ok(Self::On(n)),
-                Err(e) => Err(OptionsError::FailedParse(spacing.into(), NumberSource::Arg("icon-spacing"), e)),
+                Err(e) => Err(OptionsError::FailedParse(
+                    spacing.into(),
+                    NumberSource::Arg("icon-spacing"),
+                    e,
+                )),
             };
         }
 
-        if let Some(columns) = vars.get(vars::LX_ICON_SPACING).and_then(|s| s.into_string().ok()) {
+        if let Some(columns) = vars
+            .get(vars::LX_ICON_SPACING)
+            .and_then(|s| s.into_string().ok())
+        {
             match columns.parse() {
-                Ok(width) => {
-                    Ok(Self::On(width))
-                }
+                Ok(width) => Ok(Self::On(width)),
                 Err(e) => {
                     let source = NumberSource::Env(vars::LX_ICON_SPACING);
                     Err(OptionsError::FailedParse(columns, source, e))
                 }
             }
-        }
-        else {
+        } else {
             Ok(Self::On(1))
         }
     }

--- a/src/options/filter.rs
+++ b/src/options/filter.rs
@@ -1,28 +1,28 @@
 //! Parsing the options for `FileFilter`.
 
 use crate::fs::DotFilter;
-use crate::fs::filter::{FileFilter, SortField, SortCase, GroupDirs, IgnorePatterns, SymlinkMode, VcsIgnore};
+use crate::fs::filter::{
+    FileFilter, GroupDirs, IgnorePatterns, SortCase, SortField, SymlinkMode, VcsIgnore,
+};
 
-use crate::options::{flags, OptionsError};
 use crate::options::parser::MatchedFlags;
-
+use crate::options::{OptionsError, flags};
 
 impl FileFilter {
-
     /// Determines which of all the file filter options to use.
     pub fn deduce(matches: &MatchedFlags) -> Result<Self, OptionsError> {
         Ok(Self {
-            group_dirs:       GroupDirs::deduce(matches),
-            reverse:          matches.has(flags::REVERSE),
-            only_dirs:        matches.has(flags::ONLY_DIRS),
-            only_files:       matches.has(flags::ONLY_FILES),
-            sort_field:       SortField::deduce(matches)?,
+            group_dirs: GroupDirs::deduce(matches),
+            reverse: matches.has(flags::REVERSE),
+            only_dirs: matches.has(flags::ONLY_DIRS),
+            only_files: matches.has(flags::ONLY_FILES),
+            sort_field: SortField::deduce(matches)?,
             sort_by_total_size: matches.has(flags::TOTAL),
-            dot_filter:       DotFilter::deduce(matches)?,
-            ignore_patterns:  IgnorePatterns::deduce(matches)?,
-            prune_patterns:   IgnorePatterns::deduce_from(matches, flags::PRUNE)?,
-            vcs_ignore:       VcsIgnore::deduce(matches),
-            symlink_mode:     SymlinkMode::deduce(matches),
+            dot_filter: DotFilter::deduce(matches)?,
+            ignore_patterns: IgnorePatterns::deduce(matches)?,
+            prune_patterns: IgnorePatterns::deduce_from(matches, flags::PRUNE)?,
+            vcs_ignore: VcsIgnore::deduce(matches),
+            symlink_mode: SymlinkMode::deduce(matches),
         })
     }
 }
@@ -41,9 +41,9 @@ impl GroupDirs {
         if let Some(word) = matches.get(flags::GROUP_DIRS) {
             return match word {
                 "first" => Self::First,
-                "last"  => Self::Last,
-                "none"  => Self::None,
-                _       => unreachable!("Clap rejects invalid --group-dirs values"),
+                "last" => Self::Last,
+                "none" => Self::None,
+                _ => unreachable!("Clap rejects invalid --group-dirs values"),
             };
         }
 
@@ -60,7 +60,6 @@ impl GroupDirs {
 }
 
 impl SortField {
-
     /// Determines which sort field to use based on the `--sort`
     /// argument.  Delegates the name → variant mapping to the sort
     /// registry (`src/fs/sort_registry.rs`) so this function stays
@@ -82,12 +81,11 @@ impl SortField {
             return Ok(Self::Name(SortCase::AaBbCc));
         }
 
-        let field = SortFieldDef::field_from_name(word)
-            .expect("Clap rejects invalid --sort values");
+        let field =
+            SortFieldDef::field_from_name(word).expect("Clap rejects invalid --sort values");
         Ok(field)
     }
 }
-
 
 // I've gone back and forth between whether to sort case-sensitively or
 // insensitively by default. The default string sort in most programming
@@ -125,9 +123,7 @@ impl Default for SortField {
     }
 }
 
-
 impl DotFilter {
-
     /// Determines the dot filter based on how many `--all` options were
     /// given: one will show dotfiles, but two will show `.` and `..` too.
     ///
@@ -139,22 +135,17 @@ impl DotFilter {
 
         if count == 0 {
             Ok(Self::JustFiles)
-        }
-        else if count == 1 {
+        } else if count == 1 {
             Ok(Self::Dotfiles)
-        }
-        else if matches.has(flags::TREE) {
+        } else if matches.has(flags::TREE) {
             Err(OptionsError::TreeAllAll)
-        }
-        else {
+        } else {
             Ok(Self::DotfilesAndDots)
         }
     }
 }
 
-
 impl IgnorePatterns {
-
     /// Determines the set of glob patterns to use based on the
     /// `--ignore-glob` argument's value. This is a list of strings
     /// separated by pipe (`|`) characters, given in any order.
@@ -172,19 +163,17 @@ impl IgnorePatterns {
         let (patterns, mut errors) = Self::parse_from_iter(inputs.split('|'));
 
         match errors.pop() {
-            Some(e)  => Err(e.into()),
-            None     => Ok(patterns),
+            Some(e) => Err(e.into()),
+            None => Ok(patterns),
         }
     }
 }
-
 
 impl VcsIgnore {
     pub fn deduce(matches: &MatchedFlags) -> Self {
         if matches.has(flags::VCS_IGNORE) {
             Self::CheckAndIgnore
-        }
-        else {
+        } else {
             Self::Off
         }
     }
@@ -193,13 +182,12 @@ impl VcsIgnore {
 impl SymlinkMode {
     pub fn deduce(matches: &MatchedFlags) -> Self {
         match matches.get(flags::SYMLINKS) {
-            Some("hide")   => Self::Hide,
+            Some("hide") => Self::Hide,
             Some("follow") => Self::Follow,
-            _              => Self::Show,
+            _ => Self::Show,
         }
     }
 }
-
 
 #[cfg(test)]
 mod test {
@@ -285,7 +273,6 @@ mod test {
         }
     }
 
-
     mod dot_filters {
         use super::*;
 
@@ -305,7 +292,6 @@ mod test {
         test!(tree_aaa:   DotFilter <- ["-Taaa"];        Err(OptionsError::TreeAllAll));
     }
 
-
     mod ignore_patterns {
         use super::*;
         use std::iter::FromIterator;
@@ -324,7 +310,6 @@ mod test {
         test!(overridden:   IgnorePatterns <- ["-I=*.ogg",    "-I", "*.mp3"];     Ok(IgnorePatterns::from_iter(vec![ pat("*.mp3") ])));
         test!(overridden_2: IgnorePatterns <- ["-I", "*.OGG", "-I*.MP3"];         Ok(IgnorePatterns::from_iter(vec![ pat("*.MP3") ])));
     }
-
 
     mod vcs_ignores {
         use super::*;

--- a/src/options/mod.rs
+++ b/src/options/mod.rs
@@ -16,7 +16,7 @@ use std::ffi::OsString;
 
 use crate::fs::dir_action::DirAction;
 use crate::fs::filter::{FileFilter, VcsIgnore};
-use crate::output::{View, Mode, details, grid_details};
+use crate::output::{Mode, View, details, grid_details};
 use crate::theme::Options as ThemeOptions;
 
 mod dir_action;
@@ -27,14 +27,13 @@ mod theme;
 mod view;
 
 mod error;
-pub use self::error::{OptionsError, NumberSource};
+pub use self::error::{NumberSource, OptionsError};
 
 pub mod parser;
 use self::parser::MatchedFlags;
 
 pub mod vars;
 pub use self::vars::Vars;
-
 
 /// Which VCS backend to use.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -53,7 +52,6 @@ pub enum VcsBackend {
 /// user's command-line options.
 #[derive(Debug)]
 pub struct Options {
-
     /// The action to perform when encountering a directory rather than a
     /// regular file.
     pub dir_action: DirAction,
@@ -78,13 +76,13 @@ pub struct Options {
 }
 
 impl Options {
-
     /// Parse the given iterator of command-line strings into an Options
     /// struct and a list of free filenames, using the environment variables
     /// for extra options.
     #[allow(unused_results)]
     pub fn parse<V>(args: &[OsString], vars: &V) -> OptionsResult
-    where V: Vars,
+    where
+        V: Vars,
     {
         // Use Clap for validation, help, and version.
         // try_get_matches_from expects the binary name as the first argument.
@@ -98,9 +96,7 @@ impl Options {
                     ErrorKind::DisplayHelp | ErrorKind::DisplayVersion => {
                         OptionsResult::HelpOrVersion(e)
                     }
-                    _ => {
-                        OptionsResult::InvalidOptionsClap(e)
-                    }
+                    _ => OptionsResult::InvalidOptionsClap(e),
                 }
             }
             Ok(clap_matches) => {
@@ -113,45 +109,55 @@ impl Options {
                 }
 
                 if clap_matches.contains_id("dump-class")
-                    && clap_matches.value_source("dump-class") == Some(clap::parser::ValueSource::CommandLine)
+                    && clap_matches.value_source("dump-class")
+                        == Some(clap::parser::ValueSource::CommandLine)
                 {
-                    let name = clap_matches.get_one::<String>("dump-class")
+                    let name = clap_matches
+                        .get_one::<String>("dump-class")
                         .cloned()
                         .unwrap_or_default();
                     return OptionsResult::DumpClass(name);
                 }
 
                 if clap_matches.contains_id("dump-format")
-                    && clap_matches.value_source("dump-format") == Some(clap::parser::ValueSource::CommandLine)
+                    && clap_matches.value_source("dump-format")
+                        == Some(clap::parser::ValueSource::CommandLine)
                 {
-                    let name = clap_matches.get_one::<String>("dump-format")
+                    let name = clap_matches
+                        .get_one::<String>("dump-format")
                         .cloned()
                         .unwrap_or_default();
                     return OptionsResult::DumpFormat(name);
                 }
 
                 if clap_matches.contains_id("dump-personality")
-                    && clap_matches.value_source("dump-personality") == Some(clap::parser::ValueSource::CommandLine)
+                    && clap_matches.value_source("dump-personality")
+                        == Some(clap::parser::ValueSource::CommandLine)
                 {
-                    let name = clap_matches.get_one::<String>("dump-personality")
+                    let name = clap_matches
+                        .get_one::<String>("dump-personality")
                         .cloned()
                         .unwrap_or_default();
                     return OptionsResult::DumpPersonality(name);
                 }
 
                 if clap_matches.contains_id("dump-theme")
-                    && clap_matches.value_source("dump-theme") == Some(clap::parser::ValueSource::CommandLine)
+                    && clap_matches.value_source("dump-theme")
+                        == Some(clap::parser::ValueSource::CommandLine)
                 {
-                    let name = clap_matches.get_one::<String>("dump-theme")
+                    let name = clap_matches
+                        .get_one::<String>("dump-theme")
                         .cloned()
                         .unwrap_or_default();
                     return OptionsResult::DumpTheme(name);
                 }
 
                 if clap_matches.contains_id("dump-style")
-                    && clap_matches.value_source("dump-style") == Some(clap::parser::ValueSource::CommandLine)
+                    && clap_matches.value_source("dump-style")
+                        == Some(clap::parser::ValueSource::CommandLine)
                 {
-                    let name = clap_matches.get_one::<String>("dump-style")
+                    let name = clap_matches
+                        .get_one::<String>("dump-style")
                         .cloned()
                         .unwrap_or_default();
                     return OptionsResult::DumpStyle(name);
@@ -161,7 +167,7 @@ impl Options {
                     let settings = Self::extract_cli_settings(&clap_matches);
                     return OptionsResult::SaveAs(
                         name.clone(),
-                        None,  // inherits — set by main.rs from active personality
+                        None, // inherits — set by main.rs from active personality
                         settings,
                     );
                 }
@@ -174,14 +180,15 @@ impl Options {
                     return OptionsResult::UpgradeConfig;
                 }
 
-                let frees = clap_matches.get_many::<OsString>("FILE")
+                let frees = clap_matches
+                    .get_many::<OsString>("FILE")
                     .map(|vals| vals.cloned().collect())
                     .unwrap_or_default();
                 let flags = MatchedFlags::new(clap_matches);
 
                 match Self::deduce(&flags, vars) {
-                    Ok(options)  => OptionsResult::Ok(options, frees),
-                    Err(oe)      => OptionsResult::InvalidOptions(oe),
+                    Ok(options) => OptionsResult::Ok(options, frees),
+                    Err(oe) => OptionsResult::InvalidOptions(oe),
                 }
             }
         }
@@ -190,9 +197,11 @@ impl Options {
     /// Extract settings that were explicitly passed on the CLI, as a
     /// config-key → TOML-value map suitable for writing a personality file.
     /// Only captures flags the user actually typed, not personality defaults.
-    fn extract_cli_settings(matches: &clap::ArgMatches) -> std::collections::HashMap<String, toml::Value> {
-        use std::collections::HashMap;
+    fn extract_cli_settings(
+        matches: &clap::ArgMatches,
+    ) -> std::collections::HashMap<String, toml::Value> {
         use crate::config::{SETTING_FLAGS, SettingKind, find_setting};
+        use std::collections::HashMap;
 
         let mut settings: HashMap<String, toml::Value> = HashMap::new();
 
@@ -201,15 +210,15 @@ impl Options {
             // without "--", but some differ (column enablers use "show-*"
             // IDs, British/American aliases share a single Clap ID).
             let clap_id = match def.key {
-                "permissions"  => flags::SHOW_PERMISSIONS,
-                "size"         => flags::SHOW_SIZE,
-                "filesize"     => flags::SHOW_SIZE,
-                "user"         => flags::SHOW_USER,
-                "colour"       => flags::COLOR,
-                "color"        => flags::COLOR,
+                "permissions" => flags::SHOW_PERMISSIONS,
+                "size" => flags::SHOW_SIZE,
+                "filesize" => flags::SHOW_SIZE,
+                "user" => flags::SHOW_USER,
+                "colour" => flags::COLOR,
+                "color" => flags::COLOR,
                 "colour-scale" => flags::COLOR_SCALE,
-                "color-scale"  => flags::COLOR_SCALE,
-                "ignore"       => flags::IGNORE_GLOB,
+                "color-scale" => flags::COLOR_SCALE,
+                "ignore" => flags::IGNORE_GLOB,
                 _ => def.flag.strip_prefix("--").unwrap_or(def.flag),
             };
 
@@ -220,9 +229,7 @@ impl Options {
             }
 
             // Only include flags the user explicitly typed on this CLI.
-            if matches.value_source(clap_id)
-                != Some(clap::parser::ValueSource::CommandLine)
-            {
+            if matches.value_source(clap_id) != Some(clap::parser::ValueSource::CommandLine) {
                 continue;
             }
 
@@ -254,12 +261,14 @@ impl Options {
 
         // Handle compounding -t (TIME_TIER): expand to individual
         // timestamp booleans so they're saved as explicit config keys.
-        if matches.value_source(flags::TIME_TIER)
-            == Some(clap::parser::ValueSource::CommandLine)
-        {
+        if matches.value_source(flags::TIME_TIER) == Some(clap::parser::ValueSource::CommandLine) {
             let count = matches.get_count(flags::TIME_TIER);
-            if count >= 1 { settings.insert("modified".into(), toml::Value::Boolean(true)); }
-            if count >= 2 { settings.insert("changed".into(), toml::Value::Boolean(true)); }
+            if count >= 1 {
+                settings.insert("modified".into(), toml::Value::Boolean(true));
+            }
+            if count >= 2 {
+                settings.insert("changed".into(), toml::Value::Boolean(true));
+            }
             if count >= 3 {
                 settings.insert("created".into(), toml::Value::Boolean(true));
                 settings.insert("accessed".into(), toml::Value::Boolean(true));
@@ -277,7 +286,8 @@ impl Options {
         // saved personality is correct and reads more naturally.
         // Exceptions: `no-time` (no positive `time` key — it's a bulk
         // clear), `no-icons`/`no-gradient` (positive is Str, not Bool).
-        let neg_keys: Vec<String> = settings.keys()
+        let neg_keys: Vec<String> = settings
+            .keys()
             .filter(|k| k.starts_with("no-"))
             .cloned()
             .collect();
@@ -318,10 +328,18 @@ impl Options {
         }
 
         match self.view.mode {
-            Mode::Details(details::Options { table: Some(ref table), .. }) |
-            Mode::GridDetails(grid_details::Options { details: details::Options { table: Some(ref table), .. }, .. }) => {
-                table.columns.contains(&Column::VcsStatus)
-            }
+            Mode::Details(details::Options {
+                table: Some(ref table),
+                ..
+            })
+            | Mode::GridDetails(grid_details::Options {
+                details:
+                    details::Options {
+                        table: Some(ref table),
+                        ..
+                    },
+                ..
+            }) => table.columns.contains(&Column::VcsStatus),
             _ => false,
         }
     }
@@ -329,26 +347,27 @@ impl Options {
     /// Determines the complete set of options based on the given command-line
     /// arguments, after they've been parsed.
     fn deduce<V: Vars>(matches: &MatchedFlags, vars: &V) -> Result<Self, OptionsError> {
-        let wants_git = matches.has(flags::VCS_STATUS) || matches.has(flags::VCS_IGNORE)
+        let wants_git = matches.has(flags::VCS_STATUS)
+            || matches.has(flags::VCS_IGNORE)
             || matches.get(flags::VCS).is_some_and(|v| v != "none");
 
         if cfg!(not(feature = "git")) && wants_git {
             return Err(OptionsError::Unsupported(String::from(
-                "VCS options can't be used because the `git` feature was disabled in this build of lx"
+                "VCS options can't be used because the `git` feature was disabled in this build of lx",
             )));
         }
 
         if cfg!(not(feature = "jj")) && matches.get(flags::VCS) == Some("jj") {
             return Err(OptionsError::Unsupported(String::from(
-                "--vcs=jj can't be used because the `jj` feature was disabled in this build of lx"
+                "--vcs=jj can't be used because the `jj` feature was disabled in this build of lx",
             )));
         }
 
         let vcs_backend = match matches.get(flags::VCS) {
-            Some("git")  => VcsBackend::Git,
-            Some("jj")   => VcsBackend::Jj,
+            Some("git") => VcsBackend::Git,
+            Some("jj") => VcsBackend::Jj,
             Some("none") => VcsBackend::None,
-            _            => VcsBackend::Auto,
+            _ => VcsBackend::Auto,
         };
 
         let view = View::deduce(matches, vars)?;
@@ -357,15 +376,20 @@ impl Options {
         let theme = ThemeOptions::deduce(matches, vars)?;
         let count = matches.has(flags::COUNT) && !matches.has(flags::NO_COUNT);
 
-        Ok(Self { dir_action, filter, view, theme, vcs_backend, count })
+        Ok(Self {
+            dir_action,
+            filter,
+            view,
+            theme,
+            vcs_backend,
+            count,
+        })
     }
 }
-
 
 /// The result of the `Options::parse` function.
 #[derive(Debug)]
 pub enum OptionsResult {
-
     /// The options were parsed successfully.
     Ok(Options, Vec<OsString>),
 
@@ -408,9 +432,12 @@ pub enum OptionsResult {
 
     /// The user wants to save CLI flags as a personality.
     /// Contains: (name, inherits, settings as TOML key/value pairs).
-    SaveAs(String, Option<String>, std::collections::HashMap<String, toml::Value>),
+    SaveAs(
+        String,
+        Option<String>,
+        std::collections::HashMap<String, toml::Value>,
+    ),
 }
-
 
 #[cfg(test)]
 pub mod test {
@@ -421,13 +448,15 @@ pub mod test {
     /// function on the resulting `MatchedFlags`.  Returns a single-element
     /// `Vec` so existing test macros that iterate over results still work.
     pub fn parse_for_test<T, F>(inputs: &[&str], get: F) -> Vec<T>
-    where F: Fn(&MatchedFlags) -> T
+    where
+        F: Fn(&MatchedFlags) -> T,
     {
         let args: Vec<OsString> = std::iter::once(OsString::from("lx"))
             .chain(inputs.iter().map(|s| OsString::from(s)))
             .collect();
         let cmd = crate::options::parser::build_command();
-        let clap_matches = cmd.try_get_matches_from(&args)
+        let clap_matches = cmd
+            .try_get_matches_from(&args)
             .expect("Clap parse error in test");
         let mf = MatchedFlags::new(clap_matches);
         vec![get(&mf)]

--- a/src/options/parser.rs
+++ b/src/options/parser.rs
@@ -1,9 +1,8 @@
-use clap::{Arg, ArgAction, Command};
 use clap::builder::PossibleValue;
 use clap::builder::styling;
+use clap::{Arg, ArgAction, Command};
 
 use super::flags;
-
 
 // ── Help-text typographic conventions ──────────────────────────────
 //
@@ -95,7 +94,6 @@ use super::flags;
 // Further rules may be implicit. Please ensure new additions fit
 // the `--help` structure and add rules here, should you divine any!
 
-
 /// Clap styling: yellow headers, cyan literals, green placeholders, red errors.
 const STYLES: styling::Styles = styling::Styles::styled()
     .header(styling::AnsiColor::Yellow.on_default().bold())
@@ -116,7 +114,6 @@ fn help_styles() -> styling::Styles {
     STYLES
 }
 
-
 /// Return valid values for the `--sort` flag.
 ///
 /// Generated from the sort registry (`src/fs/sort_registry.rs`) so
@@ -136,13 +133,10 @@ fn sort_values() -> Vec<PossibleValue> {
     values.push(PossibleValue::new("version"));
 
     // Hidden aliases and hidden-canonical entries from the registry.
-    values.extend(
-        SortFieldDef::all_hidden_names().map(|n| PossibleValue::new(n).hide(true))
-    );
+    values.extend(SortFieldDef::all_hidden_names().map(|n| PossibleValue::new(n).hide(true)));
 
     values
 }
-
 
 /// Custom value parser for the retired `--colour-scale` flag.
 ///
@@ -162,7 +156,6 @@ fn parse_colour_scale_deprecated(_s: &str) -> Result<String, String> {
          \x20 --no-gradient        alias for --gradient=none",
     ))
 }
-
 
 /// `TypedValueParser` for `--time-style`.
 ///
@@ -186,9 +179,10 @@ impl clap::builder::TypedValueParser for TimeStyleParser {
         value: &std::ffi::OsStr,
     ) -> Result<Self::Value, clap::Error> {
         if let Some(s) = value.to_str()
-            && s.starts_with('+') {
-                return Ok(s.to_string());
-            }
+            && s.starts_with('+')
+        {
+            return Ok(s.to_string());
+        }
         // `+FORMAT` is in the list so the error hint and "did you
         // mean" suggestions know about it; the `+`-prefix shortcut
         // above means a real `+%Y-%m-%d` value never has to match
@@ -199,9 +193,7 @@ impl clap::builder::TypedValueParser for TimeStyleParser {
         .parse_ref(cmd, arg, value)
     }
 
-    fn possible_values(
-        &self,
-    ) -> Option<Box<dyn Iterator<Item = PossibleValue> + '_>> {
+    fn possible_values(&self) -> Option<Box<dyn Iterator<Item = PossibleValue> + '_>> {
         Some(Box::new(
             [
                 PossibleValue::new("default"),
@@ -215,7 +207,6 @@ impl clap::builder::TypedValueParser for TimeStyleParser {
         ))
     }
 }
-
 
 /// `TypedValueParser` for selectors like `--dump-theme=NAME`,
 /// `--dump-personality=NAME`, `--personality=NAME`, etc.
@@ -238,11 +229,17 @@ struct NameListParser {
 
 impl NameListParser {
     const fn new(names_fn: fn() -> Vec<String>) -> Self {
-        Self { names_fn, allow_empty: true }
+        Self {
+            names_fn,
+            allow_empty: true,
+        }
     }
 
     const fn no_empty(names_fn: fn() -> Vec<String>) -> Self {
-        Self { names_fn, allow_empty: false }
+        Self {
+            names_fn,
+            allow_empty: false,
+        }
     }
 }
 
@@ -255,9 +252,9 @@ impl clap::builder::TypedValueParser for NameListParser {
         arg: Option<&clap::Arg>,
         value: &std::ffi::OsStr,
     ) -> Result<Self::Value, clap::Error> {
-        let s = value.to_str().ok_or_else(|| {
-            clap::Error::new(clap::error::ErrorKind::InvalidUtf8).with_cmd(cmd)
-        })?;
+        let s = value
+            .to_str()
+            .ok_or_else(|| clap::Error::new(clap::error::ErrorKind::InvalidUtf8).with_cmd(cmd))?;
         if s.is_empty() && self.allow_empty {
             return Ok(String::new());
         }
@@ -273,9 +270,7 @@ impl clap::builder::TypedValueParser for NameListParser {
         clap::builder::PossibleValuesParser::new(leaked).parse_ref(cmd, arg, value)
     }
 
-    fn possible_values(
-        &self,
-    ) -> Option<Box<dyn Iterator<Item = PossibleValue> + '_>> {
+    fn possible_values(&self) -> Option<Box<dyn Iterator<Item = PossibleValue> + '_>> {
         let names = (self.names_fn)();
         let pvs: Vec<PossibleValue> = names
             .into_iter()
@@ -287,7 +282,6 @@ impl clap::builder::TypedValueParser for NameListParser {
         Some(Box::new(pvs.into_iter()))
     }
 }
-
 
 /// `TypedValueParser` for `--columns`.
 ///
@@ -321,9 +315,9 @@ impl clap::builder::TypedValueParser for ColumnsParser {
     ) -> Result<Self::Value, clap::Error> {
         use crate::output::table::Column;
 
-        let s = value.to_str().ok_or_else(|| {
-            clap::Error::new(clap::error::ErrorKind::InvalidUtf8).with_cmd(cmd)
-        })?;
+        let s = value
+            .to_str()
+            .ok_or_else(|| clap::Error::new(clap::error::ErrorKind::InvalidUtf8).with_cmd(cmd))?;
         for name in s.split(',') {
             let name = name.trim();
             if Column::from_name(name).is_none() {
@@ -337,9 +331,7 @@ impl clap::builder::TypedValueParser for ColumnsParser {
         Ok(s.to_string())
     }
 
-    fn possible_values(
-        &self,
-    ) -> Option<Box<dyn Iterator<Item = PossibleValue> + '_>> {
+    fn possible_values(&self) -> Option<Box<dyn Iterator<Item = PossibleValue> + '_>> {
         Some(Box::new(
             Self::possible_values_static()
                 .into_iter()
@@ -347,7 +339,6 @@ impl clap::builder::TypedValueParser for ColumnsParser {
         ))
     }
 }
-
 
 /// `TypedValueParser` for `--gradient`.
 ///
@@ -377,8 +368,7 @@ impl GradientParser {
     /// `token_values()` below; they participate in clap's "did you
     /// mean" computation without cluttering the help output.
     const TOKENS: &'static [&'static str] = &[
-        "none", "all", "size", "date",
-        "modified", "accessed", "changed", "created",
+        "none", "all", "size", "date", "modified", "accessed", "changed", "created",
     ];
 
     /// `PossibleValue` objects for the parser, with hidden aliases
@@ -407,18 +397,17 @@ impl clap::builder::TypedValueParser for GradientParser {
         arg: Option<&clap::Arg>,
         value: &std::ffi::OsStr,
     ) -> Result<Self::Value, clap::Error> {
-        let s = value.to_str().ok_or_else(|| {
-            clap::Error::new(clap::error::ErrorKind::InvalidUtf8).with_cmd(cmd)
-        })?;
+        let s = value
+            .to_str()
+            .ok_or_else(|| clap::Error::new(clap::error::ErrorKind::InvalidUtf8).with_cmd(cmd))?;
         let mut saw_none_or_all = false;
         let mut saw_column = false;
         for tok in s.split(',') {
             let tok = tok.trim();
             match tok {
                 "none" | "all" => saw_none_or_all = true,
-                "size" | "filesize"
-                | "date" | "timestamp"
-                | "modified" | "accessed" | "changed" | "created" => saw_column = true,
+                "size" | "filesize" | "date" | "timestamp" | "modified" | "accessed"
+                | "changed" | "created" => saw_column = true,
                 _ => {
                     // Unknown token — let PossibleValuesParser
                     // construct the error so we get the same
@@ -435,10 +424,7 @@ impl clap::builder::TypedValueParser for GradientParser {
         if saw_none_or_all && saw_column {
             // none/all are exclusive — `--gradient=none,size` is
             // nonsense.  Build a clap-style error.
-            let mut err = clap::Error::new(
-                clap::error::ErrorKind::InvalidValue,
-            )
-            .with_cmd(cmd);
+            let mut err = clap::Error::new(clap::error::ErrorKind::InvalidValue).with_cmd(cmd);
             if let Some(arg) = arg {
                 err.insert(
                     clap::error::ContextKind::InvalidArg,
@@ -460,13 +446,10 @@ impl clap::builder::TypedValueParser for GradientParser {
         Ok(s.to_string())
     }
 
-    fn possible_values(
-        &self,
-    ) -> Option<Box<dyn Iterator<Item = PossibleValue> + '_>> {
+    fn possible_values(&self) -> Option<Box<dyn Iterator<Item = PossibleValue> + '_>> {
         Some(Box::new(Self::token_values().into_iter()))
     }
 }
-
 
 /// A wrapper around clap's `ArgMatches` that provides convenience
 /// methods matching those expected by the deduce functions.
@@ -482,10 +465,23 @@ impl MatchedFlags {
     /// Whether the given flag was present at all.
     pub fn has(&self, flag: &str) -> bool {
         // Try bool first (SetTrue), then u8 (Count).
-        if self.matches.try_get_one::<bool>(flag).ok().flatten().copied().unwrap_or(false) {
+        if self
+            .matches
+            .try_get_one::<bool>(flag)
+            .ok()
+            .flatten()
+            .copied()
+            .unwrap_or(false)
+        {
             return true;
         }
-        self.matches.try_get_one::<u8>(flag).ok().flatten().copied().unwrap_or(0) > 0
+        self.matches
+            .try_get_one::<u8>(flag)
+            .ok()
+            .flatten()
+            .copied()
+            .unwrap_or(0)
+            > 0
     }
 
     /// How many times a counted flag was passed.
@@ -495,7 +491,9 @@ impl MatchedFlags {
 
     /// Get the string value of a flag, if present.
     pub fn get(&self, flag: &str) -> Option<&str> {
-        self.matches.get_one::<String>(flag).map(std::string::String::as_str)
+        self.matches
+            .get_one::<String>(flag)
+            .map(std::string::String::as_str)
     }
 
     /// Get a usize value of a flag, if present.
@@ -505,10 +503,10 @@ impl MatchedFlags {
 
     /// Whether the given flag was present at all (including default values).
     pub fn is_present(&self, flag: &str) -> bool {
-        self.matches.contains_id(flag) && self.matches.value_source(flag) == Some(clap::parser::ValueSource::CommandLine)
+        self.matches.contains_id(flag)
+            && self.matches.value_source(flag) == Some(clap::parser::ValueSource::CommandLine)
     }
 }
-
 
 /// Build the Clap `Command` that defines all lx flags.
 pub fn build_command() -> Command {
@@ -520,389 +518,532 @@ pub fn build_command() -> Command {
         .disable_help_flag(true)
         .disable_version_flag(true)
         .args_override_self(true)
-        .help_template("{name} {version}\n{about-section}\n\
-                        {usage-heading}\n{tab}{usage}\n\n\
-                        {all-args}{after-help}")
-        .after_help("\
-Column overrides:\n  \
-  Every Long view column flag has a matching --no-FLAG suppressor,\n  \
-  e.g. --inode pairs with --no-inode, -M pairs with --no-M\n\
-\n\
-Environment:\n  \
-  NO_COLOR        Disable all colour output (no-color.org)\n  \
-  LX_CONFIG       Explicit path to config file\n  \
-  LX_PERSONALITY  Session-level personality selection\n  \
-  LS_COLORS       File-type colour scheme\n  \
-  TIME_STYLE      Default timestamp style")
-
+        .help_template(
+            "{name} {version}\n{about-section}\n\
+             {usage-heading}\n{tab}{usage}\n\n\
+             {all-args}{after-help}",
+        )
+        .after_help(concat!(
+            "Column overrides:\n",
+            "  Every Long view column flag has a matching --no-FLAG suppressor,\n",
+            "  e.g. --inode pairs with --no-inode, -M pairs with --no-M\n",
+            "\n",
+            "Environment:\n",
+            "  NO_COLOR        Disable all colour output (no-color.org)\n",
+            "  LX_CONFIG       Explicit path to config file\n",
+            "  LX_PERSONALITY  Session-level personality selection\n",
+            "  LS_COLORS       File-type colour scheme\n",
+            "  TIME_STYLE      Default timestamp style",
+        ))
         // ── Display mode ──────────────────────────────────────────
-
-        .arg(Arg::new(flags::ONE_LINE)
-            .short('1').long("oneline")
-            .help("Display one entry per line")
-            .help_heading("Display")
-            .action(ArgAction::Count)
-            .overrides_with_all([flags::LONG, flags::GRID]))
-        .arg(Arg::new(flags::LONG)
-            .short('l').long("long")
-            .help("Long view — repeat for more detail: -ll, -lll")
-            .help_heading("Display")
-            .action(ArgAction::Count)
-            .overrides_with(flags::ONE_LINE))
-        .arg(Arg::new(flags::GRID)
-            .short('G').long("grid")
-            .help("Display entries as a grid (default)")
-            .help_heading("Display")
-            .action(ArgAction::Count)
-            .overrides_with(flags::ONE_LINE))
-        .arg(Arg::new(flags::ACROSS)
-            .short('x').long("across")
-            .help("Sort the grid across, rather than downwards")
-            .help_heading("Display")
-            .action(ArgAction::Count))
-        .arg(Arg::new(flags::RECURSE)
-            .short('R').long("recurse")
-            .help("Recurse into directories")
-            .help_heading("Display")
-            .action(ArgAction::Count))
-        .arg(Arg::new(flags::TREE)
-            .short('T').long("tree")
-            .help("Recurse into directories as a tree")
-            .help_heading("Display")
-            .action(ArgAction::Count))
-        .arg(Arg::new(flags::LEVEL)
-            .short('L').long("level")
-            .help("Limit the depth of recursion")
-            .help_heading("Display")
-            .action(ArgAction::Set)
-            .value_name("DEPTH")
-            .value_parser(clap::value_parser!(usize)))
-        .arg(Arg::new(flags::CLASSIFY)
-            .long("classify")
-            .help("Display file kind indicators [always, auto, never]")
-            .help_heading("Display")
-            .action(ArgAction::Set)
-            .value_name("WHEN")
-            .hide_possible_values(true)
-            .value_parser([
-                PossibleValue::new("always"),
-                PossibleValue::new("auto"),
-                PossibleValue::new("never"),
-            ])
-            .num_args(0..=1)
-            .require_equals(true)
-            .default_missing_value("auto"))
-        .arg(Arg::new(flags::COUNT)
-            .short('C').long("count")
-            .help("Print item count to stderr (-CZ includes total size)")
-            .help_heading("Display")
-            .action(ArgAction::Count)
-            .overrides_with(flags::NO_COUNT))
-
+        .arg(
+            Arg::new(flags::ONE_LINE)
+                .short('1')
+                .long("oneline")
+                .help("Display one entry per line")
+                .help_heading("Display")
+                .action(ArgAction::Count)
+                .overrides_with_all([flags::LONG, flags::GRID]),
+        )
+        .arg(
+            Arg::new(flags::LONG)
+                .short('l')
+                .long("long")
+                .help("Long view — repeat for more detail: -ll, -lll")
+                .help_heading("Display")
+                .action(ArgAction::Count)
+                .overrides_with(flags::ONE_LINE),
+        )
+        .arg(
+            Arg::new(flags::GRID)
+                .short('G')
+                .long("grid")
+                .help("Display entries as a grid (default)")
+                .help_heading("Display")
+                .action(ArgAction::Count)
+                .overrides_with(flags::ONE_LINE),
+        )
+        .arg(
+            Arg::new(flags::ACROSS)
+                .short('x')
+                .long("across")
+                .help("Sort the grid across, rather than downwards")
+                .help_heading("Display")
+                .action(ArgAction::Count),
+        )
+        .arg(
+            Arg::new(flags::RECURSE)
+                .short('R')
+                .long("recurse")
+                .help("Recurse into directories")
+                .help_heading("Display")
+                .action(ArgAction::Count),
+        )
+        .arg(
+            Arg::new(flags::TREE)
+                .short('T')
+                .long("tree")
+                .help("Recurse into directories as a tree")
+                .help_heading("Display")
+                .action(ArgAction::Count),
+        )
+        .arg(
+            Arg::new(flags::LEVEL)
+                .short('L')
+                .long("level")
+                .help("Limit the depth of recursion")
+                .help_heading("Display")
+                .action(ArgAction::Set)
+                .value_name("DEPTH")
+                .value_parser(clap::value_parser!(usize)),
+        )
+        .arg(
+            Arg::new(flags::CLASSIFY)
+                .long("classify")
+                .help("Display file kind indicators [always, auto, never]")
+                .help_heading("Display")
+                .action(ArgAction::Set)
+                .value_name("WHEN")
+                .hide_possible_values(true)
+                .value_parser([
+                    PossibleValue::new("always"),
+                    PossibleValue::new("auto"),
+                    PossibleValue::new("never"),
+                ])
+                .num_args(0..=1)
+                .require_equals(true)
+                .default_missing_value("auto"),
+        )
+        .arg(
+            Arg::new(flags::COUNT)
+                .short('C')
+                .long("count")
+                .help("Print item count to stderr (-CZ includes total size)")
+                .help_heading("Display")
+                .action(ArgAction::Count)
+                .overrides_with(flags::NO_COUNT),
+        )
         // ── Long view columns ─────────────────────────────────────
-
         // Display modifiers
-        .arg(Arg::new(flags::HEADER)
-            .short('h').long("header")
-            .help("Add a header row")
-            .help_heading("Long view")
-            .action(ArgAction::Count)
-            .overrides_with(flags::NO_HEADER))
-
+        .arg(
+            Arg::new(flags::HEADER)
+                .short('h')
+                .long("header")
+                .help("Add a header row")
+                .help_heading("Long view")
+                .action(ArgAction::Count)
+                .overrides_with(flags::NO_HEADER),
+        )
         // Column-add flags — canonical column order, modifiers after enabler flags
-        .arg(Arg::new(flags::INODE)
-            .short('i').long("inode")
-            .help("Show inode numbers")
-            .help_heading("Long view")
-            .action(ArgAction::Count))
-        .arg(Arg::new(flags::OCTAL)
-            .short('o').long("octal")
-            .alias("octal-permissions")
-            .help("Show permissions in octal format")
-            .help_heading("Long view")
-            .action(ArgAction::Count)
-            .overrides_with(flags::NO_OCTAL))
-        .arg(Arg::new(flags::SHOW_PERMISSIONS)
-            .short('M').long("permissions").visible_alias("mode")
-            .help("Show the permissions column")
-            .help_heading("Long view")
-            .action(ArgAction::Count)
-            .overrides_with(flags::NO_PERMISSIONS))
-        .arg(Arg::new(flags::FILE_FLAGS)
-            .short('O').long("flags")
-            .help("Show file flags (macOS/BSD chflags, Linux chattr)")
-            .help_heading("Long view")
-            .action(ArgAction::Count))
-        .arg(Arg::new(flags::LINKS)
-            .short('H').long("links")
-            .help("Show hard link counts")
-            .help_heading("Long view")
-            .action(ArgAction::Count))
-        .arg(Arg::new(flags::SHOW_SIZE)
-            .short('z').long("size").alias("filesize")
-            .help("Show the file size column")
-            .help_heading("Long view")
-            .action(ArgAction::Count)
-            .overrides_with(flags::NO_SIZE))
-        .arg(Arg::new(flags::SIZE_STYLE)
-            .long("size-style")
-            .help("How to display file sizes\n[decimal (default), binary, bytes]")
-            .help_heading("Long view")
-            .action(ArgAction::Set)
-            .value_name("STYLE")
-            .value_parser(["decimal", "binary", "bytes"])
-            .hide_possible_values(true)
-            .overrides_with_all([flags::BINARY, flags::BYTES, flags::DECIMAL]))
-        .arg(Arg::new(flags::DECIMAL)
-            .short('K').long("decimal")
-            .help("Decimal size prefixes (k, M, G, ...)\n[short for --size-style=decimal]")
-            .help_heading("Long view")
-            .action(ArgAction::Count)
-            .overrides_with_all([flags::BINARY, flags::BYTES, flags::SIZE_STYLE]))
-        .arg(Arg::new(flags::BINARY)
-            .short('B').long("binary")
-            .help("Binary size prefixes (KiB, MiB, ...)\n[short for --size-style=binary]")
-            .help_heading("Long view")
-            .action(ArgAction::Count)
-            .overrides_with_all([flags::BYTES, flags::DECIMAL, flags::SIZE_STYLE]))
-        .arg(Arg::new(flags::BYTES)
-            .short('b').long("bytes")
-            .help("Raw byte counts\n[short for --size-style=bytes]")
-            .help_heading("Long view")
-            .action(ArgAction::Count)
-            .overrides_with_all([flags::BINARY, flags::DECIMAL, flags::SIZE_STYLE]))
-        .arg(Arg::new(flags::TOTAL)
-            .short('Z').long("total")
-            .alias("total-size")
-            .help("Show directory content sizes (recursive)\n[aliases: --total-size]")
-            .help_heading("Long view")
-            .action(ArgAction::Count)
-            .overrides_with(flags::NO_TOTAL))
-        .arg(Arg::new(flags::BLOCKS)
-            .short('S').long("blocks")
-            .help("Show file system block counts")
-            .help_heading("Long view")
-            .action(ArgAction::Count))
-        .arg(Arg::new(flags::SHOW_USER)
-            .short('u').long("user")
-            .help("Show the user column")
-            .help_heading("Long view")
-            .action(ArgAction::Count)
-            .overrides_with(flags::NO_USER))
-        .arg(Arg::new(flags::UID)
-            .long("uid")
-            .help("Show the numeric user ID column")
-            .help_heading("Long view")
-            .action(ArgAction::Count))
-        .arg(Arg::new(flags::GROUP)
-            .short('g').long("group")
-            .help("Show the group column")
-            .help_heading("Long view")
-            .action(ArgAction::Count))
-        .arg(Arg::new(flags::GID)
-            .long("gid")
-            .help("Show the numeric group ID column")
-            .help_heading("Long view")
-            .action(ArgAction::Count))
-
+        .arg(
+            Arg::new(flags::INODE)
+                .short('i')
+                .long("inode")
+                .help("Show inode numbers")
+                .help_heading("Long view")
+                .action(ArgAction::Count),
+        )
+        .arg(
+            Arg::new(flags::OCTAL)
+                .short('o')
+                .long("octal")
+                .alias("octal-permissions")
+                .help("Show permissions in octal format")
+                .help_heading("Long view")
+                .action(ArgAction::Count)
+                .overrides_with(flags::NO_OCTAL),
+        )
+        .arg(
+            Arg::new(flags::SHOW_PERMISSIONS)
+                .short('M')
+                .long("permissions")
+                .visible_alias("mode")
+                .help("Show the permissions column")
+                .help_heading("Long view")
+                .action(ArgAction::Count)
+                .overrides_with(flags::NO_PERMISSIONS),
+        )
+        .arg(
+            Arg::new(flags::FILE_FLAGS)
+                .short('O')
+                .long("flags")
+                .help("Show file flags (macOS/BSD chflags, Linux chattr)")
+                .help_heading("Long view")
+                .action(ArgAction::Count),
+        )
+        .arg(
+            Arg::new(flags::LINKS)
+                .short('H')
+                .long("links")
+                .help("Show hard link counts")
+                .help_heading("Long view")
+                .action(ArgAction::Count),
+        )
+        .arg(
+            Arg::new(flags::SHOW_SIZE)
+                .short('z')
+                .long("size")
+                .alias("filesize")
+                .help("Show the file size column")
+                .help_heading("Long view")
+                .action(ArgAction::Count)
+                .overrides_with(flags::NO_SIZE),
+        )
+        .arg(
+            Arg::new(flags::SIZE_STYLE)
+                .long("size-style")
+                .help("How to display file sizes\n[decimal (default), binary, bytes]")
+                .help_heading("Long view")
+                .action(ArgAction::Set)
+                .value_name("STYLE")
+                .value_parser(["decimal", "binary", "bytes"])
+                .hide_possible_values(true)
+                .overrides_with_all([flags::BINARY, flags::BYTES, flags::DECIMAL]),
+        )
+        .arg(
+            Arg::new(flags::DECIMAL)
+                .short('K')
+                .long("decimal")
+                .help("Decimal size prefixes (k, M, G, ...)\n[short for --size-style=decimal]")
+                .help_heading("Long view")
+                .action(ArgAction::Count)
+                .overrides_with_all([flags::BINARY, flags::BYTES, flags::SIZE_STYLE]),
+        )
+        .arg(
+            Arg::new(flags::BINARY)
+                .short('B')
+                .long("binary")
+                .help("Binary size prefixes (KiB, MiB, ...)\n[short for --size-style=binary]")
+                .help_heading("Long view")
+                .action(ArgAction::Count)
+                .overrides_with_all([flags::BYTES, flags::DECIMAL, flags::SIZE_STYLE]),
+        )
+        .arg(
+            Arg::new(flags::BYTES)
+                .short('b')
+                .long("bytes")
+                .help("Raw byte counts\n[short for --size-style=bytes]")
+                .help_heading("Long view")
+                .action(ArgAction::Count)
+                .overrides_with_all([flags::BINARY, flags::DECIMAL, flags::SIZE_STYLE]),
+        )
+        .arg(
+            Arg::new(flags::TOTAL)
+                .short('Z')
+                .long("total")
+                .alias("total-size")
+                .help("Show directory content sizes (recursive)\n[aliases: --total-size]")
+                .help_heading("Long view")
+                .action(ArgAction::Count)
+                .overrides_with(flags::NO_TOTAL),
+        )
+        .arg(
+            Arg::new(flags::BLOCKS)
+                .short('S')
+                .long("blocks")
+                .help("Show file system block counts")
+                .help_heading("Long view")
+                .action(ArgAction::Count),
+        )
+        .arg(
+            Arg::new(flags::SHOW_USER)
+                .short('u')
+                .long("user")
+                .help("Show the user column")
+                .help_heading("Long view")
+                .action(ArgAction::Count)
+                .overrides_with(flags::NO_USER),
+        )
+        .arg(
+            Arg::new(flags::UID)
+                .long("uid")
+                .help("Show the numeric user ID column")
+                .help_heading("Long view")
+                .action(ArgAction::Count),
+        )
+        .arg(
+            Arg::new(flags::GROUP)
+                .short('g')
+                .long("group")
+                .help("Show the group column")
+                .help_heading("Long view")
+                .action(ArgAction::Count),
+        )
+        .arg(
+            Arg::new(flags::GID)
+                .long("gid")
+                .help("Show the numeric group ID column")
+                .help_heading("Long view")
+                .action(ArgAction::Count),
+        )
         // Extras
-        .arg(Arg::new(flags::EXTENDED)
-            .short('@').long("extended")
-            .help("Show extended attributes and sizes")
-            .help_heading("Long view")
-            .action(ArgAction::Count)
-            .overrides_with(flags::NO_EXTENDED))
-
+        .arg(
+            Arg::new(flags::EXTENDED)
+                .short('@')
+                .long("extended")
+                .help("Show extended attributes and sizes")
+                .help_heading("Long view")
+                .action(ArgAction::Count)
+                .overrides_with(flags::NO_EXTENDED),
+        )
         // ── Filtering and sorting ─────────────────────────────────
-
-        .arg(Arg::new(flags::ALL)
-            .short('a').long("all")
-            .help("Show hidden and dot files (-aa for . and ..)")
-            .help_heading("Filtering & Sorting")
-            .action(ArgAction::Count))
-        .arg(Arg::new(flags::LIST_DIRS)
-            .short('d').long("list-dirs")
-            .help("List directories as regular files")
-            .help_heading("Filtering & Sorting")
-            .action(ArgAction::Count))
-        .arg(Arg::new(flags::ONLY_DIRS)
-            .short('D').long("only-dirs")
-            .help("List only directories, not files")
-            .help_heading("Filtering & Sorting")
-            .action(ArgAction::Count))
-        .arg(Arg::new(flags::ONLY_FILES)
-            .short('f').long("only-files")
-            .help("List only regular files, not directories")
-            .help_heading("Filtering & Sorting")
-            .action(ArgAction::Count))
-        .arg(Arg::new(flags::SYMLINKS)
-            .long("symlinks")
-            .help("How to handle symlinks [show, hide, follow]")
-            .help_heading("Filtering & Sorting")
-            .action(ArgAction::Set)
-            .value_name("MODE")
-            .hide_possible_values(true)
-            .value_parser([
-                PossibleValue::new("show"),
-                PossibleValue::new("hide"),
-                PossibleValue::new("follow"),
-            ]))
-        .arg(Arg::new(flags::IGNORE_GLOB)
-            .short('I').long("ignore")
-            .alias("ignore-glob")
-            .help("Glob patterns (pipe-separated) of files to hide")
-            .help_heading("Filtering & Sorting")
-            .action(ArgAction::Set)
-            .value_name("GLOB"))
-        .arg(Arg::new(flags::PRUNE)
-            .short('P').long("prune")
-            .alias("prune-glob")
-            .help("Glob patterns of directories to show but not recurse")
-            .help_heading("Filtering & Sorting")
-            .action(ArgAction::Set)
-            .value_name("GLOB"))
-        .arg(Arg::new(flags::SORT)
-            .short('s').long("sort")
-            // NOTE: this list is hand-curated to keep the --help
-            // output grouped by category.  The authoritative list
-            // of accepted values is in src/fs/sort_registry.rs;
-            // if you add a new sort field there, add it here too.
-            // `clap` uses the registry (via sort_values()) for
-            // validation and error-message suggestions, so a new
-            // field will still *work* without updating this text —
-            // it just won't appear in --help until you do.
-            .help("Sort field\n\
+        .arg(
+            Arg::new(flags::ALL)
+                .short('a')
+                .long("all")
+                .help("Show hidden and dot files (-aa for . and ..)")
+                .help_heading("Filtering & Sorting")
+                .action(ArgAction::Count),
+        )
+        .arg(
+            Arg::new(flags::LIST_DIRS)
+                .short('d')
+                .long("list-dirs")
+                .help("List directories as regular files")
+                .help_heading("Filtering & Sorting")
+                .action(ArgAction::Count),
+        )
+        .arg(
+            Arg::new(flags::ONLY_DIRS)
+                .short('D')
+                .long("only-dirs")
+                .help("List only directories, not files")
+                .help_heading("Filtering & Sorting")
+                .action(ArgAction::Count),
+        )
+        .arg(
+            Arg::new(flags::ONLY_FILES)
+                .short('f')
+                .long("only-files")
+                .help("List only regular files, not directories")
+                .help_heading("Filtering & Sorting")
+                .action(ArgAction::Count),
+        )
+        .arg(
+            Arg::new(flags::SYMLINKS)
+                .long("symlinks")
+                .help("How to handle symlinks [show, hide, follow]")
+                .help_heading("Filtering & Sorting")
+                .action(ArgAction::Set)
+                .value_name("MODE")
+                .hide_possible_values(true)
+                .value_parser([
+                    PossibleValue::new("show"),
+                    PossibleValue::new("hide"),
+                    PossibleValue::new("follow"),
+                ]),
+        )
+        .arg(
+            Arg::new(flags::IGNORE_GLOB)
+                .short('I')
+                .long("ignore")
+                .alias("ignore-glob")
+                .help("Glob patterns (pipe-separated) of files to hide")
+                .help_heading("Filtering & Sorting")
+                .action(ArgAction::Set)
+                .value_name("GLOB"),
+        )
+        .arg(
+            Arg::new(flags::PRUNE)
+                .short('P')
+                .long("prune")
+                .alias("prune-glob")
+                .help("Glob patterns of directories to show but not recurse")
+                .help_heading("Filtering & Sorting")
+                .action(ArgAction::Set)
+                .value_name("GLOB"),
+        )
+        .arg(
+            Arg::new(flags::SORT)
+                .short('s')
+                .long("sort")
+                // NOTE: this list is hand-curated to keep the --help
+                // output grouped by category.  The authoritative list
+                // of accepted values is in src/fs/sort_registry.rs;
+                // if you add a new sort field there, add it here too.
+                // `clap` uses the registry (via sort_values()) for
+                // validation and error-message suggestions, so a new
+                // field will still *work* without updating this text —
+                // it just won't appear in --help until you do.
+                .help(
+                    "Sort field\n\
                    [name, Name, extension, Extension, version,\n \
                    size, blocks, links, permissions, flags,\n \
                    user, User, group, Group, uid, gid,\n \
                    modified, changed, accessed, created,\n \
-                   vcs, type, inode, none]")
-            .help_heading("Filtering & Sorting")
-            .action(ArgAction::Set)
-            .value_name("FIELD")
-            .hide_possible_values(true)
-            .value_parser(sort_values()))
-        .arg(Arg::new(flags::REVERSE)
-            .short('r').long("reverse")
-            .help("Reverse the sort order")
-            .help_heading("Filtering & Sorting")
-            .action(ArgAction::Count))
-        .arg(Arg::new(flags::GROUP_DIRS)
-            .long("group-dirs")
-            .help("Group directories before or after other files\n[first, last, none]")
-            .help_heading("Filtering & Sorting")
-            .action(ArgAction::Set)
-            .value_name("WHEN")
-            .hide_possible_values(true)
-            .overrides_with_all([flags::DIRS_FIRST, flags::DIRS_LAST])
-            .value_parser([
-                PossibleValue::new("first"),
-                PossibleValue::new("last"),
-                PossibleValue::new("none"),
-            ]))
-        .arg(Arg::new(flags::DIRS_FIRST)
-            .short('F')
-            .long("dirs-first")
-            .alias("group-directories-first")
-            .help("Directories first [short for --group-dirs=first]")
-            .help_heading("Filtering & Sorting")
-            .action(ArgAction::SetTrue)
-            .overrides_with_all([flags::GROUP_DIRS, flags::DIRS_LAST]))
-        .arg(Arg::new(flags::DIRS_LAST)
-            .short('J')
-            .long("dirs-last")
-            .alias("group-directories-last")
-            .help("Directories last [short for --group-dirs=last]")
-            .help_heading("Filtering & Sorting")
-            .action(ArgAction::SetTrue)
-            .overrides_with_all([flags::GROUP_DIRS, flags::DIRS_FIRST]))
-        .arg(Arg::new(flags::NO_DIRS_FIRST)
-            .long("no-dirs-first")
-            .hide(true)
-            .action(ArgAction::Count))
-        .arg(Arg::new(flags::NO_DIRS_LAST)
-            .long("no-dirs-last")
-            .hide(true)
-            .action(ArgAction::Count))
-
+                   vcs, type, inode, none]",
+                )
+                .help_heading("Filtering & Sorting")
+                .action(ArgAction::Set)
+                .value_name("FIELD")
+                .hide_possible_values(true)
+                .value_parser(sort_values()),
+        )
+        .arg(
+            Arg::new(flags::REVERSE)
+                .short('r')
+                .long("reverse")
+                .help("Reverse the sort order")
+                .help_heading("Filtering & Sorting")
+                .action(ArgAction::Count),
+        )
+        .arg(
+            Arg::new(flags::GROUP_DIRS)
+                .long("group-dirs")
+                .help("Group directories before or after other files\n[first, last, none]")
+                .help_heading("Filtering & Sorting")
+                .action(ArgAction::Set)
+                .value_name("WHEN")
+                .hide_possible_values(true)
+                .overrides_with_all([flags::DIRS_FIRST, flags::DIRS_LAST])
+                .value_parser([
+                    PossibleValue::new("first"),
+                    PossibleValue::new("last"),
+                    PossibleValue::new("none"),
+                ]),
+        )
+        .arg(
+            Arg::new(flags::DIRS_FIRST)
+                .short('F')
+                .long("dirs-first")
+                .alias("group-directories-first")
+                .help("Directories first [short for --group-dirs=first]")
+                .help_heading("Filtering & Sorting")
+                .action(ArgAction::SetTrue)
+                .overrides_with_all([flags::GROUP_DIRS, flags::DIRS_LAST]),
+        )
+        .arg(
+            Arg::new(flags::DIRS_LAST)
+                .short('J')
+                .long("dirs-last")
+                .alias("group-directories-last")
+                .help("Directories last [short for --group-dirs=last]")
+                .help_heading("Filtering & Sorting")
+                .action(ArgAction::SetTrue)
+                .overrides_with_all([flags::GROUP_DIRS, flags::DIRS_FIRST]),
+        )
+        .arg(
+            Arg::new(flags::NO_DIRS_FIRST)
+                .long("no-dirs-first")
+                .hide(true)
+                .action(ArgAction::Count),
+        )
+        .arg(
+            Arg::new(flags::NO_DIRS_LAST)
+                .long("no-dirs-last")
+                .hide(true)
+                .action(ArgAction::Count),
+        )
         // ── Column / format / personality ─────────────────────────
-
-        .arg(Arg::new(flags::PERSONALITY)
-            .short('p').long("personality")
-            .help("Apply a named personality (columns + flags) 🌟\n[ll, lll, la, tree, ...]")
-            .help_heading("Personalities & Formats")
-            .action(ArgAction::Set)
-            .value_name("NAME")
-            .hide_possible_values(true)
-            .value_parser(NameListParser::no_empty(crate::config::all_personality_names)))
-        .arg(Arg::new(flags::COLUMNS)
-            .long("columns")
-            .help("Explicit column list (comma-separated)")
-            .help_heading("Personalities & Formats")
-            .action(ArgAction::Set)
-            .value_name("COLS")
-            .hide_possible_values(true)
-            .value_parser(ColumnsParser))
-        .arg(Arg::new(flags::FORMAT)
-            .long("format")
-            .help("Named column format [long, long2, long3, ...]")
-            .help_heading("Personalities & Formats")
-            .action(ArgAction::Set)
-            .value_name("NAME")
-            .hide_possible_values(true)
-            .value_parser({
-                let names = crate::options::view::format_names();
-                names.into_iter()
-                    .map(|s| { let leaked: &'static str = Box::leak(s.into_boxed_str()); PossibleValue::new(leaked) })
-                    .collect::<Vec<_>>()
-            }))
-
+        .arg(
+            Arg::new(flags::PERSONALITY)
+                .short('p')
+                .long("personality")
+                .help("Apply a named personality (columns + flags) 🌟\n[ll, lll, la, tree, ...]")
+                .help_heading("Personalities & Formats")
+                .action(ArgAction::Set)
+                .value_name("NAME")
+                .hide_possible_values(true)
+                .value_parser(NameListParser::no_empty(
+                    crate::config::all_personality_names,
+                )),
+        )
+        .arg(
+            Arg::new(flags::COLUMNS)
+                .long("columns")
+                .help("Explicit column list (comma-separated)")
+                .help_heading("Personalities & Formats")
+                .action(ArgAction::Set)
+                .value_name("COLS")
+                .hide_possible_values(true)
+                .value_parser(ColumnsParser),
+        )
+        .arg(
+            Arg::new(flags::FORMAT)
+                .long("format")
+                .help("Named column format [long, long2, long3, ...]")
+                .help_heading("Personalities & Formats")
+                .action(ArgAction::Set)
+                .value_name("NAME")
+                .hide_possible_values(true)
+                .value_parser({
+                    let names = crate::options::view::format_names();
+                    names
+                        .into_iter()
+                        .map(|s| {
+                            let leaked: &'static str = Box::leak(s.into_boxed_str());
+                            PossibleValue::new(leaked)
+                        })
+                        .collect::<Vec<_>>()
+                }),
+        )
         // ── Timestamps ────────────────────────────────────────────
-
-        .arg(Arg::new(flags::TIME_TIER)
-            .short('t')
-            .help("Show timestamps — compounds like -l:\n\
+        .arg(
+            Arg::new(flags::TIME_TIER)
+                .short('t')
+                .help(
+                    "Show timestamps — compounds like -l:\n\
                    -t adds modified, -tt adds changed,\n\
-                   -ttt adds created and accessed")
-            .help_heading("Timestamps")
-            .action(ArgAction::Count))
-        .arg(Arg::new(flags::MODIFIED)
-            .short('m').long("modified")
-            .help("Show the modified timestamp column")
-            .help_heading("Timestamps")
-            .action(ArgAction::Count))
-        .arg(Arg::new(flags::CHANGED)
-            .short('c').long("changed")
-            .help("Show the changed timestamp column")
-            .help_heading("Timestamps")
-            .action(ArgAction::Count))
-        .arg(Arg::new(flags::ACCESSED)
-            .long("accessed")
-            .help("Show the accessed timestamp column")
-            .help_heading("Timestamps")
-            .action(ArgAction::Count))
-        .arg(Arg::new(flags::CREATED)
-            .long("created")
-            .help("Show the created timestamp column")
-            .help_heading("Timestamps")
-            .action(ArgAction::Count))
-        .arg(Arg::new(flags::TIME_STYLE)
-            .long("time-style")
-            .help("How to format timestamps\n\
+                   -ttt adds created and accessed",
+                )
+                .help_heading("Timestamps")
+                .action(ArgAction::Count),
+        )
+        .arg(
+            Arg::new(flags::MODIFIED)
+                .short('m')
+                .long("modified")
+                .help("Show the modified timestamp column")
+                .help_heading("Timestamps")
+                .action(ArgAction::Count),
+        )
+        .arg(
+            Arg::new(flags::CHANGED)
+                .short('c')
+                .long("changed")
+                .help("Show the changed timestamp column")
+                .help_heading("Timestamps")
+                .action(ArgAction::Count),
+        )
+        .arg(
+            Arg::new(flags::ACCESSED)
+                .long("accessed")
+                .help("Show the accessed timestamp column")
+                .help_heading("Timestamps")
+                .action(ArgAction::Count),
+        )
+        .arg(
+            Arg::new(flags::CREATED)
+                .long("created")
+                .help("Show the created timestamp column")
+                .help_heading("Timestamps")
+                .action(ArgAction::Count),
+        )
+        .arg(
+            Arg::new(flags::TIME_STYLE)
+                .long("time-style")
+                .help(
+                    "How to format timestamps\n\
             [default, iso, long-iso, full-iso,\n \
-            relative, +FORMAT]")
-            .help_heading("Timestamps")
-            .action(ArgAction::Set)
-            .value_name("STYLE")
-            .hide_possible_values(true)
-            .value_parser(TimeStyleParser))
-        .arg(Arg::new(flags::NO_TIME)
-            .long("no-time").alias("no-timestamps")
-            .help("Clear all timestamp columns from the base format\n\
-                   (`--no-time --accessed` shows only accessed)")
-            .help_heading("Timestamps")
-            .action(ArgAction::Count))
-
+            relative, +FORMAT]",
+                )
+                .help_heading("Timestamps")
+                .action(ArgAction::Set)
+                .value_name("STYLE")
+                .hide_possible_values(true)
+                .value_parser(TimeStyleParser),
+        )
+        .arg(
+            Arg::new(flags::NO_TIME)
+                .long("no-time")
+                .alias("no-timestamps")
+                .help(
+                    "Clear all timestamp columns from the base format\n\
+                   (`--no-time --accessed` shows only accessed)",
+                )
+                .help_heading("Timestamps")
+                .action(ArgAction::Count),
+        )
         // ── Column overrides (suppressions) ───────────────────────
         //
         // Every column-add flag has a matching --no-FLAG suppressor
@@ -910,375 +1051,497 @@ Environment:\n  \
         // they're mechanical negations of the positive flags; the
         // convention is documented once in the after_help block.
         // They remain fully functional and documented in lx(1).
-
-        .arg(Arg::new(flags::NO_PERMISSIONS)
-            .long("no-permissions").alias("no-mode").alias("no-M")
-            .hide(true)
-            .action(ArgAction::Count)
-            .overrides_with(flags::SHOW_PERMISSIONS))
-        .arg(Arg::new(flags::NO_SIZE)
-            .long("no-size").alias("no-filesize").alias("no-z")
-            .hide(true)
-            .action(ArgAction::Count)
-            .overrides_with(flags::SHOW_SIZE))
-        .arg(Arg::new(flags::NO_USER)
-            .long("no-user").alias("no-u")
-            .hide(true)
-            .action(ArgAction::Count)
-            .overrides_with(flags::SHOW_USER))
-        .arg(Arg::new(flags::NO_ICONS)
-            .long("no-icons")
-            .hide(true)
-            .action(ArgAction::Count))
-        .arg(Arg::new(flags::NO_INODE)
-            .long("no-inode").alias("no-i")
-            .hide(true)
-            .action(ArgAction::Count))
-        .arg(Arg::new(flags::NO_GROUP)
-            .long("no-group").alias("no-g")
-            .hide(true)
-            .action(ArgAction::Count))
-        .arg(Arg::new(flags::NO_UID)
-            .long("no-uid")
-            .hide(true)
-            .action(ArgAction::Count)
-            .overrides_with(flags::UID))
-        .arg(Arg::new(flags::NO_GID)
-            .long("no-gid")
-            .hide(true)
-            .action(ArgAction::Count)
-            .overrides_with(flags::GID))
-        .arg(Arg::new(flags::NO_LINKS)
-            .long("no-links").alias("no-H")
-            .hide(true)
-            .action(ArgAction::Count))
-        .arg(Arg::new(flags::NO_BLOCKS)
-            .long("no-blocks").alias("no-S")
-            .hide(true)
-            .action(ArgAction::Count))
-        .arg(Arg::new(flags::NO_EXTENDED)
-            .long("no-extended").alias("no-@")
-            .hide(true)
-            .action(ArgAction::Count)
-            .overrides_with(flags::EXTENDED))
-        .arg(Arg::new(flags::NO_FLAGS)
-            .long("no-flags").alias("no-O")
-            .hide(true)
-            .action(ArgAction::Count)
-            .overrides_with(flags::FILE_FLAGS))
-        .arg(Arg::new(flags::NO_OCTAL)
-            .long("no-octal").alias("no-o")
-            .hide(true)
-            .action(ArgAction::Count)
-            .overrides_with(flags::OCTAL))
-        .arg(Arg::new(flags::NO_HEADER)
-            .long("no-header").alias("no-h")
-            .hide(true)
-            .action(ArgAction::Count)
-            .overrides_with(flags::HEADER))
-        .arg(Arg::new(flags::NO_COUNT)
-            .long("no-count").alias("no-C")
-            .hide(true)
-            .action(ArgAction::Count)
-            .overrides_with(flags::COUNT))
-        .arg(Arg::new(flags::NO_TOTAL)
-            .long("no-total").alias("no-total-size").alias("no-Z")
-            .hide(true)
-            .action(ArgAction::Count)
-            .overrides_with(flags::TOTAL))
-        .arg(Arg::new(flags::NO_MODIFIED)
-            .long("no-modified").alias("no-m")
-            .hide(true)
-            .action(ArgAction::Count)
-            .overrides_with(flags::MODIFIED))
-        .arg(Arg::new(flags::NO_CHANGED)
-            .long("no-changed").alias("no-c")
-            .hide(true)
-            .action(ArgAction::Count)
-            .overrides_with(flags::CHANGED))
-        .arg(Arg::new(flags::NO_ACCESSED)
-            .long("no-accessed")
-            .hide(true)
-            .action(ArgAction::Count)
-            .overrides_with(flags::ACCESSED))
-        .arg(Arg::new(flags::NO_CREATED)
-            .long("no-created")
-            .hide(true)
-            .action(ArgAction::Count)
-            .overrides_with(flags::CREATED))
-
+        .arg(
+            Arg::new(flags::NO_PERMISSIONS)
+                .long("no-permissions")
+                .alias("no-mode")
+                .alias("no-M")
+                .hide(true)
+                .action(ArgAction::Count)
+                .overrides_with(flags::SHOW_PERMISSIONS),
+        )
+        .arg(
+            Arg::new(flags::NO_SIZE)
+                .long("no-size")
+                .alias("no-filesize")
+                .alias("no-z")
+                .hide(true)
+                .action(ArgAction::Count)
+                .overrides_with(flags::SHOW_SIZE),
+        )
+        .arg(
+            Arg::new(flags::NO_USER)
+                .long("no-user")
+                .alias("no-u")
+                .hide(true)
+                .action(ArgAction::Count)
+                .overrides_with(flags::SHOW_USER),
+        )
+        .arg(
+            Arg::new(flags::NO_ICONS)
+                .long("no-icons")
+                .hide(true)
+                .action(ArgAction::Count),
+        )
+        .arg(
+            Arg::new(flags::NO_INODE)
+                .long("no-inode")
+                .alias("no-i")
+                .hide(true)
+                .action(ArgAction::Count),
+        )
+        .arg(
+            Arg::new(flags::NO_GROUP)
+                .long("no-group")
+                .alias("no-g")
+                .hide(true)
+                .action(ArgAction::Count),
+        )
+        .arg(
+            Arg::new(flags::NO_UID)
+                .long("no-uid")
+                .hide(true)
+                .action(ArgAction::Count)
+                .overrides_with(flags::UID),
+        )
+        .arg(
+            Arg::new(flags::NO_GID)
+                .long("no-gid")
+                .hide(true)
+                .action(ArgAction::Count)
+                .overrides_with(flags::GID),
+        )
+        .arg(
+            Arg::new(flags::NO_LINKS)
+                .long("no-links")
+                .alias("no-H")
+                .hide(true)
+                .action(ArgAction::Count),
+        )
+        .arg(
+            Arg::new(flags::NO_BLOCKS)
+                .long("no-blocks")
+                .alias("no-S")
+                .hide(true)
+                .action(ArgAction::Count),
+        )
+        .arg(
+            Arg::new(flags::NO_EXTENDED)
+                .long("no-extended")
+                .alias("no-@")
+                .hide(true)
+                .action(ArgAction::Count)
+                .overrides_with(flags::EXTENDED),
+        )
+        .arg(
+            Arg::new(flags::NO_FLAGS)
+                .long("no-flags")
+                .alias("no-O")
+                .hide(true)
+                .action(ArgAction::Count)
+                .overrides_with(flags::FILE_FLAGS),
+        )
+        .arg(
+            Arg::new(flags::NO_OCTAL)
+                .long("no-octal")
+                .alias("no-o")
+                .hide(true)
+                .action(ArgAction::Count)
+                .overrides_with(flags::OCTAL),
+        )
+        .arg(
+            Arg::new(flags::NO_HEADER)
+                .long("no-header")
+                .alias("no-h")
+                .hide(true)
+                .action(ArgAction::Count)
+                .overrides_with(flags::HEADER),
+        )
+        .arg(
+            Arg::new(flags::NO_COUNT)
+                .long("no-count")
+                .alias("no-C")
+                .hide(true)
+                .action(ArgAction::Count)
+                .overrides_with(flags::COUNT),
+        )
+        .arg(
+            Arg::new(flags::NO_TOTAL)
+                .long("no-total")
+                .alias("no-total-size")
+                .alias("no-Z")
+                .hide(true)
+                .action(ArgAction::Count)
+                .overrides_with(flags::TOTAL),
+        )
+        .arg(
+            Arg::new(flags::NO_MODIFIED)
+                .long("no-modified")
+                .alias("no-m")
+                .hide(true)
+                .action(ArgAction::Count)
+                .overrides_with(flags::MODIFIED),
+        )
+        .arg(
+            Arg::new(flags::NO_CHANGED)
+                .long("no-changed")
+                .alias("no-c")
+                .hide(true)
+                .action(ArgAction::Count)
+                .overrides_with(flags::CHANGED),
+        )
+        .arg(
+            Arg::new(flags::NO_ACCESSED)
+                .long("no-accessed")
+                .hide(true)
+                .action(ArgAction::Count)
+                .overrides_with(flags::ACCESSED),
+        )
+        .arg(
+            Arg::new(flags::NO_CREATED)
+                .long("no-created")
+                .hide(true)
+                .action(ArgAction::Count)
+                .overrides_with(flags::CREATED),
+        )
         // ── VCS ───────────────────────────────────────────────────
-
-        .arg(Arg::new(flags::VCS)
-            .long("vcs")
-            .help("VCS backend [auto, git, jj, none]")
-            .help_heading("VCS")
-            .action(ArgAction::Set)
-            .value_name("BACKEND")
-            .hide_possible_values(true)
-            .value_parser([
-                PossibleValue::new("auto"),
-                PossibleValue::new("git"),
-                PossibleValue::new("jj"),
-                PossibleValue::new("none"),
-            ]))
-        .arg(Arg::new(flags::VCS_STATUS)
-            .long("vcs-status")
-            .help("Show per-file VCS status column")
-            .help_heading("VCS")
-            .action(ArgAction::Count))
-        .arg(Arg::new(flags::VCS_IGNORE)
-            .long("vcs-ignore")
-            .help("Hide VCS-ignored files and metadata directories")
-            .help_heading("VCS")
-            .action(ArgAction::Count))
-        .arg(Arg::new(flags::VCS_REPOS)
-            .long("vcs-repos")
-            .help("Show per-directory VCS repo indicator")
-            .help_heading("VCS")
-            .action(ArgAction::Count))
-        .arg(Arg::new(flags::NO_VCS_STATUS)
-            .long("no-vcs-status")
-            .hide(true)
-            .action(ArgAction::Count)
-            .overrides_with(flags::VCS_STATUS))
-        .arg(Arg::new(flags::NO_VCS_REPOS)
-            .long("no-vcs-repos")
-            .hide(true)
-            .action(ArgAction::Count)
-            .overrides_with(flags::VCS_REPOS))
-
+        .arg(
+            Arg::new(flags::VCS)
+                .long("vcs")
+                .help("VCS backend [auto, git, jj, none]")
+                .help_heading("VCS")
+                .action(ArgAction::Set)
+                .value_name("BACKEND")
+                .hide_possible_values(true)
+                .value_parser([
+                    PossibleValue::new("auto"),
+                    PossibleValue::new("git"),
+                    PossibleValue::new("jj"),
+                    PossibleValue::new("none"),
+                ]),
+        )
+        .arg(
+            Arg::new(flags::VCS_STATUS)
+                .long("vcs-status")
+                .help("Show per-file VCS status column")
+                .help_heading("VCS")
+                .action(ArgAction::Count),
+        )
+        .arg(
+            Arg::new(flags::VCS_IGNORE)
+                .long("vcs-ignore")
+                .help("Hide VCS-ignored files and metadata directories")
+                .help_heading("VCS")
+                .action(ArgAction::Count),
+        )
+        .arg(
+            Arg::new(flags::VCS_REPOS)
+                .long("vcs-repos")
+                .help("Show per-directory VCS repo indicator")
+                .help_heading("VCS")
+                .action(ArgAction::Count),
+        )
+        .arg(
+            Arg::new(flags::NO_VCS_STATUS)
+                .long("no-vcs-status")
+                .hide(true)
+                .action(ArgAction::Count)
+                .overrides_with(flags::VCS_STATUS),
+        )
+        .arg(
+            Arg::new(flags::NO_VCS_REPOS)
+                .long("no-vcs-repos")
+                .hide(true)
+                .action(ArgAction::Count)
+                .overrides_with(flags::VCS_REPOS),
+        )
         // ── Appearance ────────────────────────────────────────────
-
-        .arg(Arg::new(flags::COLOR)
-            .long("colour").visible_alias("color")
-            .help("When to use terminal colours\n[always, auto, never]")
-            .help_heading("Appearance")
-            .action(ArgAction::Set)
-            .value_name("WHEN")
-            .hide_possible_values(true)
-            .value_parser([
-                PossibleValue::new("always"),
-                PossibleValue::new("auto"),
-                PossibleValue::new("never"),
-                PossibleValue::new("automatic").hide(true),
-            ]))
+        .arg(
+            Arg::new(flags::COLOR)
+                .long("colour")
+                .visible_alias("color")
+                .help("When to use terminal colours\n[always, auto, never]")
+                .help_heading("Appearance")
+                .action(ArgAction::Set)
+                .value_name("WHEN")
+                .hide_possible_values(true)
+                .value_parser([
+                    PossibleValue::new("always"),
+                    PossibleValue::new("auto"),
+                    PossibleValue::new("never"),
+                    PossibleValue::new("automatic").hide(true),
+                ]),
+        )
         // --colour-scale is retired in 0.9 in favour of --gradient.
         // The flag is still recognised so we can return a useful
         // deprecation error pointing the user at the replacement,
         // rather than letting clap reject it as an unknown argument.
-        .arg(Arg::new(flags::COLOR_SCALE)
-            .long("colour-scale").visible_alias("color-scale")
-            .hide(true)
-            .action(ArgAction::Set)
-            .value_name("MODE")
-            .value_parser(parse_colour_scale_deprecated)
-            .num_args(0..=1)
-            .require_equals(true)
-            .default_missing_value(""))
-        .arg(Arg::new(flags::GRADIENT)
-            .long("gradient")
-            .help("Per-column gradient on/off\n[all, none, size, date,\n \
-                  modified, accessed, changed, created]")
-            .help_heading("Appearance")
-            .action(ArgAction::Set)
-            .value_name("COLUMNS")
-            .hide_possible_values(true)
-            .value_parser(GradientParser)
-            .num_args(0..=1)
-            .require_equals(true)
-            .default_missing_value("all"))
-        .arg(Arg::new(flags::NO_GRADIENT)
-            .long("no-gradient")
-            .hide(true)
-            .action(ArgAction::Count))
-        .arg(Arg::new(flags::SMOOTH)
-            .long("smooth")
-            .help("Smoothly interpolate gradients\n(24-bit themes only)")
-            .help_heading("Appearance")
-            .action(ArgAction::Count))
-        .arg(Arg::new(flags::NO_SMOOTH)
-            .long("no-smooth")
-            .hide(true)
-            .action(ArgAction::Count))
-        .arg(Arg::new(flags::ICONS)
-            .long("icons")
-            .help("Display icons next to file names\n[always, auto, never]")
-            .help_heading("Appearance")
-            .action(ArgAction::Set)
-            .value_name("WHEN")
-            .hide_possible_values(true)
-            .value_parser([
-                PossibleValue::new("always"),
-                PossibleValue::new("auto"),
-                PossibleValue::new("never"),
-            ])
-            .num_args(0..=1)
-            .require_equals(true)
-            .default_missing_value("auto"))
-        .arg(Arg::new("theme")
-            .long("theme")
-            .help("Use a named colour theme")
-            .help_heading("Appearance")
-            .action(ArgAction::Set)
-            .value_name("NAME")
-            .hide_possible_values(true)
-            .value_parser(NameListParser::no_empty(crate::config::all_theme_names)))
-        .arg(Arg::new("hyperlink")
-            .long("hyperlink")
-            .help("File names as clickable hyperlinks\n[always, auto, never]")
-            .help_heading("Appearance")
-            .action(ArgAction::Set)
-            .value_name("WHEN")
-            .hide_possible_values(true)
-            .default_missing_value("always")
-            .require_equals(true)
-            .num_args(0..=1)
-            .value_parser(["always", "auto", "never"]))
-        .arg(Arg::new("quotes")
-            .long("quotes")
-            .help("Quote file names containing spaces\n[always, auto, never]")
-            .help_heading("Appearance")
-            .action(ArgAction::Set)
-            .value_name("WHEN")
-            .hide_possible_values(true)
-            .default_missing_value("always")
-            .require_equals(true)
-            .num_args(0..=1)
-            .value_parser(["always", "auto", "never"]))
-        .arg(Arg::new("width")
-            .long("width")
-            .short('w')
-            .help("Override terminal width")
-            .help_heading("Appearance")
-            .action(ArgAction::Set)
-            .value_name("COLS")
-            .value_parser(clap::value_parser!(usize)))
-        .arg(Arg::new("absolute")
-            .short('A')
-            .long("absolute")
-            .help("Show absolute file paths")
-            .help_heading("Appearance")
-            .action(ArgAction::SetTrue))
-
+        .arg(
+            Arg::new(flags::COLOR_SCALE)
+                .long("colour-scale")
+                .visible_alias("color-scale")
+                .hide(true)
+                .action(ArgAction::Set)
+                .value_name("MODE")
+                .value_parser(parse_colour_scale_deprecated)
+                .num_args(0..=1)
+                .require_equals(true)
+                .default_missing_value(""),
+        )
+        .arg(
+            Arg::new(flags::GRADIENT)
+                .long("gradient")
+                .help(
+                    "Per-column gradient on/off\n[all, none, size, date,\n \
+                  modified, accessed, changed, created]",
+                )
+                .help_heading("Appearance")
+                .action(ArgAction::Set)
+                .value_name("COLUMNS")
+                .hide_possible_values(true)
+                .value_parser(GradientParser)
+                .num_args(0..=1)
+                .require_equals(true)
+                .default_missing_value("all"),
+        )
+        .arg(
+            Arg::new(flags::NO_GRADIENT)
+                .long("no-gradient")
+                .hide(true)
+                .action(ArgAction::Count),
+        )
+        .arg(
+            Arg::new(flags::SMOOTH)
+                .long("smooth")
+                .help("Smoothly interpolate gradients\n(24-bit themes only)")
+                .help_heading("Appearance")
+                .action(ArgAction::Count),
+        )
+        .arg(
+            Arg::new(flags::NO_SMOOTH)
+                .long("no-smooth")
+                .hide(true)
+                .action(ArgAction::Count),
+        )
+        .arg(
+            Arg::new(flags::ICONS)
+                .long("icons")
+                .help("Display icons next to file names\n[always, auto, never]")
+                .help_heading("Appearance")
+                .action(ArgAction::Set)
+                .value_name("WHEN")
+                .hide_possible_values(true)
+                .value_parser([
+                    PossibleValue::new("always"),
+                    PossibleValue::new("auto"),
+                    PossibleValue::new("never"),
+                ])
+                .num_args(0..=1)
+                .require_equals(true)
+                .default_missing_value("auto"),
+        )
+        .arg(
+            Arg::new("theme")
+                .long("theme")
+                .help("Use a named colour theme")
+                .help_heading("Appearance")
+                .action(ArgAction::Set)
+                .value_name("NAME")
+                .hide_possible_values(true)
+                .value_parser(NameListParser::no_empty(crate::config::all_theme_names)),
+        )
+        .arg(
+            Arg::new("hyperlink")
+                .long("hyperlink")
+                .help("File names as clickable hyperlinks\n[always, auto, never]")
+                .help_heading("Appearance")
+                .action(ArgAction::Set)
+                .value_name("WHEN")
+                .hide_possible_values(true)
+                .default_missing_value("always")
+                .require_equals(true)
+                .num_args(0..=1)
+                .value_parser(["always", "auto", "never"]),
+        )
+        .arg(
+            Arg::new("quotes")
+                .long("quotes")
+                .help("Quote file names containing spaces\n[always, auto, never]")
+                .help_heading("Appearance")
+                .action(ArgAction::Set)
+                .value_name("WHEN")
+                .hide_possible_values(true)
+                .default_missing_value("always")
+                .require_equals(true)
+                .num_args(0..=1)
+                .value_parser(["always", "auto", "never"]),
+        )
+        .arg(
+            Arg::new("width")
+                .long("width")
+                .short('w')
+                .help("Override terminal width")
+                .help_heading("Appearance")
+                .action(ArgAction::Set)
+                .value_name("COLS")
+                .value_parser(clap::value_parser!(usize)),
+        )
+        .arg(
+            Arg::new("absolute")
+                .short('A')
+                .long("absolute")
+                .help("Show absolute file paths")
+                .help_heading("Appearance")
+                .action(ArgAction::SetTrue),
+        )
         // ── Configuration ─────────────────────────────────────────
-
-        .arg(Arg::new("show-config")
-            .long("show-config")
-            .help("Show the active configuration and exit")
-            .help_heading("Configuration")
-            .action(ArgAction::SetTrue))
-        .arg(Arg::new("dump-class")
-            .long("dump-class")
-            .help("Dump class definitions as TOML")
-            .help_heading("Configuration")
-            .value_name("NAME")
-            .default_missing_value("")
-            .num_args(0..=1)
-            .require_equals(true)
-            .hide_possible_values(true)
-            .value_parser(NameListParser::new(crate::config::all_class_names)))
-        .arg(Arg::new("dump-format")
-            .long("dump-format")
-            .help("Dump format definitions as TOML")
-            .help_heading("Configuration")
-            .value_name("NAME")
-            .default_missing_value("")
-            .num_args(0..=1)
-            .require_equals(true)
-            .hide_possible_values(true)
-            .value_parser(NameListParser::new(crate::options::view::format_names)))
-        .arg(Arg::new("dump-personality")
-            .long("dump-personality")
-            .help("Dump personality definitions as TOML")
-            .help_heading("Configuration")
-            .value_name("NAME")
-            .default_missing_value("")
-            .num_args(0..=1)
-            .require_equals(true)
-            .hide_possible_values(true)
-            .value_parser(NameListParser::new(crate::config::all_personality_names)))
-        .arg(Arg::new("dump-theme")
-            .long("dump-theme")
-            .help("Dump theme definitions as TOML")
-            .help_heading("Configuration")
-            .value_name("NAME")
-            .default_missing_value("")
-            .num_args(0..=1)
-            .require_equals(true)
-            .hide_possible_values(true)
-            .value_parser(NameListParser::new(crate::config::all_theme_names)))
-        .arg(Arg::new("dump-style")
-            .long("dump-style")
-            .help("Dump style definitions as TOML")
-            .help_heading("Configuration")
-            .value_name("NAME")
-            .default_missing_value("")
-            .num_args(0..=1)
-            .require_equals(true)
-            .hide_possible_values(true)
-            .value_parser(NameListParser::new(crate::config::all_style_names)))
-        .arg(Arg::new("save-as")
-            .long("save-as")
-            .help("Save CLI flags as a personality in conf.d/")
-            .help_heading("Configuration")
-            .value_name("NAME")
-            .require_equals(true))
-        .arg(Arg::new("init-config")
-            .long("init-config")
-            .help("Generate a default config file")
-            .help_heading("Configuration")
-            .action(ArgAction::SetTrue))
-        .arg(Arg::new("upgrade-config")
-            .long("upgrade-config")
-            .help("Upgrade a legacy config file")
-            .help_heading("Configuration")
-            .action(ArgAction::SetTrue))
-        .arg(Arg::new("completions")
-            .long("completions")
-            .help("Generate shell completions\n[bash, zsh, fish, elvish, powershell]")
-            .help_heading("Shell completions")
-            .action(ArgAction::Set)
-            .value_name("SHELL")
-            .hide_possible_values(true)
-            .value_parser(clap::value_parser!(clap_complete::Shell)))
-
+        .arg(
+            Arg::new("show-config")
+                .long("show-config")
+                .help("Show the active configuration and exit")
+                .help_heading("Configuration")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("dump-class")
+                .long("dump-class")
+                .help("Dump class definitions as TOML")
+                .help_heading("Configuration")
+                .value_name("NAME")
+                .default_missing_value("")
+                .num_args(0..=1)
+                .require_equals(true)
+                .hide_possible_values(true)
+                .value_parser(NameListParser::new(crate::config::all_class_names)),
+        )
+        .arg(
+            Arg::new("dump-format")
+                .long("dump-format")
+                .help("Dump format definitions as TOML")
+                .help_heading("Configuration")
+                .value_name("NAME")
+                .default_missing_value("")
+                .num_args(0..=1)
+                .require_equals(true)
+                .hide_possible_values(true)
+                .value_parser(NameListParser::new(crate::options::view::format_names)),
+        )
+        .arg(
+            Arg::new("dump-personality")
+                .long("dump-personality")
+                .help("Dump personality definitions as TOML")
+                .help_heading("Configuration")
+                .value_name("NAME")
+                .default_missing_value("")
+                .num_args(0..=1)
+                .require_equals(true)
+                .hide_possible_values(true)
+                .value_parser(NameListParser::new(crate::config::all_personality_names)),
+        )
+        .arg(
+            Arg::new("dump-theme")
+                .long("dump-theme")
+                .help("Dump theme definitions as TOML")
+                .help_heading("Configuration")
+                .value_name("NAME")
+                .default_missing_value("")
+                .num_args(0..=1)
+                .require_equals(true)
+                .hide_possible_values(true)
+                .value_parser(NameListParser::new(crate::config::all_theme_names)),
+        )
+        .arg(
+            Arg::new("dump-style")
+                .long("dump-style")
+                .help("Dump style definitions as TOML")
+                .help_heading("Configuration")
+                .value_name("NAME")
+                .default_missing_value("")
+                .num_args(0..=1)
+                .require_equals(true)
+                .hide_possible_values(true)
+                .value_parser(NameListParser::new(crate::config::all_style_names)),
+        )
+        .arg(
+            Arg::new("save-as")
+                .long("save-as")
+                .help("Save CLI flags as a personality in conf.d/")
+                .help_heading("Configuration")
+                .value_name("NAME")
+                .require_equals(true),
+        )
+        .arg(
+            Arg::new("init-config")
+                .long("init-config")
+                .help("Generate a default config file")
+                .help_heading("Configuration")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("upgrade-config")
+                .long("upgrade-config")
+                .help("Upgrade a legacy config file")
+                .help_heading("Configuration")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("completions")
+                .long("completions")
+                .help("Generate shell completions\n[bash, zsh, fish, elvish, powershell]")
+                .help_heading("Shell completions")
+                .action(ArgAction::Set)
+                .value_name("SHELL")
+                .hide_possible_values(true)
+                .value_parser(clap::value_parser!(clap_complete::Shell)),
+        )
         // ── Hidden config-only flags ──────────────────────────────
         // These exist so personality definitions can set them via the
         // SETTING_FLAGS pipeline.  Not shown in --help.
-
-        .arg(Arg::new("grid-rows")
-            .long("grid-rows")
-            .action(ArgAction::Set)
-            .value_parser(clap::value_parser!(usize))
-            .hide(true))
-        .arg(Arg::new("icon-spacing")
-            .long("icon-spacing")
-            .action(ArgAction::Set)
-            .value_parser(clap::value_parser!(usize))
-            .hide(true))
-        .arg(Arg::new("decimal-point")
-            .long("decimal-point")
-            .action(ArgAction::Set)
-            .hide(true))
-        .arg(Arg::new("thousands-separator")
-            .long("thousands-separator")
-            .action(ArgAction::Set)
-            .hide(true))
-
+        .arg(
+            Arg::new("grid-rows")
+                .long("grid-rows")
+                .action(ArgAction::Set)
+                .value_parser(clap::value_parser!(usize))
+                .hide(true),
+        )
+        .arg(
+            Arg::new("icon-spacing")
+                .long("icon-spacing")
+                .action(ArgAction::Set)
+                .value_parser(clap::value_parser!(usize))
+                .hide(true),
+        )
+        .arg(
+            Arg::new("decimal-point")
+                .long("decimal-point")
+                .action(ArgAction::Set)
+                .hide(true),
+        )
+        .arg(
+            Arg::new("thousands-separator")
+                .long("thousands-separator")
+                .action(ArgAction::Set)
+                .hide(true),
+        )
         // ── Help & version ────────────────────────────────────────
-
-        .arg(Arg::new("help")
-            .short('?').long("help")
-            .help("Print help information")
-            .action(ArgAction::HelpShort))
-        .arg(Arg::new("version")
-            .short('v').long("version")
-            .help("Print version information")
-            .action(ArgAction::Version))
-
+        .arg(
+            Arg::new("help")
+                .short('?')
+                .long("help")
+                .help("Print help information")
+                .action(ArgAction::HelpShort),
+        )
+        .arg(
+            Arg::new("version")
+                .short('v')
+                .long("version")
+                .help("Print version information")
+                .action(ArgAction::Version),
+        )
         // Positional arguments (files/directories)
-        .arg(Arg::new("FILE")
-            .action(ArgAction::Append)
-            .value_parser(clap::value_parser!(std::ffi::OsString)))
+        .arg(
+            Arg::new("FILE")
+                .action(ArgAction::Append)
+                .value_parser(clap::value_parser!(std::ffi::OsString)),
+        )
 }

--- a/src/options/theme.rs
+++ b/src/options/theme.rs
@@ -1,7 +1,6 @@
-use crate::options::{flags, vars, Vars, OptionsError};
 use crate::options::parser::MatchedFlags;
-use crate::theme::{Options, UseColours, GradientFlags, Definitions};
-
+use crate::options::{OptionsError, Vars, flags, vars};
+use crate::theme::{Definitions, GradientFlags, Options, UseColours};
 
 impl Options {
     pub fn deduce<V: Vars>(matches: &MatchedFlags, vars: &V) -> Result<Self, OptionsError> {
@@ -9,18 +8,21 @@ impl Options {
         let gradient = GradientFlags::deduce(matches);
 
         let definitions = if use_colours == UseColours::Never {
-                Definitions::default()
-            }
-            else {
-                Definitions::deduce(vars)
-            };
+            Definitions::default()
+        } else {
+            Definitions::deduce(vars)
+        };
 
         let theme_override = matches.get(flags::THEME).map(String::from);
 
-        Ok(Self { use_colours, gradient, definitions, theme_override })
+        Ok(Self {
+            use_colours,
+            gradient,
+            definitions,
+            theme_override,
+        })
     }
 }
-
 
 impl UseColours {
     fn deduce<V: Vars>(matches: &MatchedFlags, vars: &V) -> Result<Self, OptionsError> {
@@ -35,14 +37,13 @@ impl UseColours {
 
         // Clap validates the value, so this match is exhaustive over accepted inputs.
         Ok(match word {
-            "always"                => Self::Always,
-            "auto" | "automatic"    => Self::Automatic,
-            "never"                 => Self::Never,
-            _                       => unreachable!("Clap rejects invalid --colour values"),
+            "always" => Self::Always,
+            "auto" | "automatic" => Self::Automatic,
+            "never" => Self::Never,
+            _ => unreachable!("Clap rejects invalid --colour values"),
         })
     }
 }
-
 
 impl GradientFlags {
     /// Deduce per-column gradient on/off from the CLI flags.
@@ -93,13 +94,13 @@ fn parse_gradient_value(s: &str) -> GradientFlags {
             "date" | "timestamp" => {
                 flags.modified = true;
                 flags.accessed = true;
-                flags.changed  = true;
-                flags.created  = true;
+                flags.changed = true;
+                flags.created = true;
             }
             "modified" => flags.modified = true,
             "accessed" => flags.accessed = true,
-            "changed"  => flags.changed  = true,
-            "created"  => flags.created  = true,
+            "changed" => flags.changed = true,
+            "created" => flags.created = true,
             // GradientParser already rejected anything else; this is
             // unreachable in practice.
             _ => {}
@@ -108,14 +109,14 @@ fn parse_gradient_value(s: &str) -> GradientFlags {
     flags
 }
 
-
 impl Definitions {
     fn deduce<V: Vars>(vars: &V) -> Self {
-        let ls = vars.get(vars::LS_COLORS).map(|e| e.to_string_lossy().to_string());
+        let ls = vars
+            .get(vars::LS_COLORS)
+            .map(|e| e.to_string_lossy().to_string());
         Self { ls }
     }
 }
-
 
 #[cfg(test)]
 mod terminal_test {
@@ -168,19 +169,15 @@ mod terminal_test {
     // Test impl that just returns the value it has.
     impl Vars for MockVars {
         fn get(&self, name: &'static str) -> Option<OsString> {
-            if name == vars::LS_COLORS && ! self.ls.is_empty() {
+            if name == vars::LS_COLORS && !self.ls.is_empty() {
                 Some(OsString::from(self.ls))
-            }
-            else if name == vars::NO_COLOR && ! self.no_color.is_empty() {
+            } else if name == vars::NO_COLOR && !self.no_color.is_empty() {
                 Some(OsString::from(self.no_color))
-            }
-            else {
+            } else {
                 None
             }
         }
     }
-
-
 
     // Default
     test!(empty:         UseColours <- [], MockVars::empty();                     Ok(UseColours::Automatic));
@@ -200,7 +197,10 @@ mod terminal_test {
     #[test]
     fn no_u_error() {
         let cmd = crate::options::parser::build_command();
-        assert!(cmd.try_get_matches_from(["lx", "--color=upstream"]).is_err());
+        assert!(
+            cmd.try_get_matches_from(["lx", "--color=upstream"])
+                .is_err()
+        );
     }
     #[test]
     fn u_error() {
@@ -218,7 +218,6 @@ mod terminal_test {
     // parse time with a deprecation pointer to --gradient.  See
     // tests/cli_basics.rs::colour_scale_deprecated for the
     // user-facing assertion.
-
 
     // --gradient and --smooth
     test!(gf_default:     GradientFlags <- [];                          GradientFlags::ALL);

--- a/src/options/vars.rs
+++ b/src/options/vars.rs
@@ -1,6 +1,5 @@
 use std::ffi::OsString;
 
-
 // General variables
 
 /// Environment variable used to colour files, both by their filesystem type
@@ -36,12 +35,10 @@ pub static LX_GRID_ROWS: &str = "LX_GRID_ROWS";
 /// far apart, so this may be necessary depending on how they are shown.
 pub static LX_ICON_SPACING: &str = "LX_ICON_SPACING";
 
-
 /// Mockable wrapper for `std::env::var_os`.
 pub trait Vars {
     fn get(&self, name: &'static str) -> Option<OsString>;
 }
-
 
 // Test impl that just returns the value it has.
 #[cfg(test)]

--- a/src/options/view.rs
+++ b/src/options/view.rs
@@ -1,25 +1,26 @@
 use crate::fs::feature::xattr;
-use crate::options::{flags, OptionsError, NumberSource, Vars};
 use crate::options::parser::MatchedFlags;
-use crate::output::{View, Mode, TerminalWidth, grid, details};
-use crate::output::grid_details::{self, RowThreshold};
+use crate::options::{NumberSource, OptionsError, Vars, flags};
 use crate::output::file_name::Options as FileStyle;
-use crate::output::table::{Column, TimeType, SizeFormat, Options as TableOptions};
+use crate::output::grid_details::{self, RowThreshold};
+use crate::output::table::{Column, Options as TableOptions, SizeFormat, TimeType};
 use crate::output::time::TimeFormat;
-
+use crate::output::{Mode, TerminalWidth, View, details, grid};
 
 impl View {
     pub fn deduce<V: Vars>(matches: &MatchedFlags, vars: &V) -> Result<Self, OptionsError> {
         let mode = Mode::deduce(matches, vars)?;
         let width = TerminalWidth::deduce(matches, vars)?;
         let file_style = FileStyle::deduce(matches, vars)?;
-        Ok(Self { mode, width, file_style })
+        Ok(Self {
+            mode,
+            width,
+            file_style,
+        })
     }
 }
 
-
 impl Mode {
-
     /// Determine which viewing mode to use based on the user's options.
     ///
     /// Clap's `overrides_with` ensures that conflicting flags (long/grid/
@@ -28,11 +29,11 @@ impl Mode {
     /// priority over grid when both are present.
     pub fn deduce<V: Vars>(matches: &MatchedFlags, vars: &V) -> Result<Self, OptionsError> {
         let long_count = matches.count(flags::LONG);
-        let has_columns = matches.get(flags::COLUMNS).is_some()
-            || matches.get(flags::FORMAT).is_some();
-        let long    = long_count > 0 || has_columns;
-        let tree    = matches.has(flags::TREE);
-        let grid    = matches.has(flags::GRID);
+        let has_columns =
+            matches.get(flags::COLUMNS).is_some() || matches.get(flags::FORMAT).is_some();
+        let long = long_count > 0 || has_columns;
+        let tree = matches.has(flags::TREE);
+        let grid = matches.has(flags::GRID);
         let oneline = matches.has(flags::ONE_LINE);
 
         // Tree takes priority over grid when combined with long.
@@ -45,7 +46,11 @@ impl Mode {
             let details = details::Options::deduce_long(matches, vars, long_count)?;
             let grid = grid::Options::deduce(matches);
             let row_threshold = RowThreshold::deduce(matches, vars)?;
-            let grid_details = grid_details::Options { grid, details, row_threshold };
+            let grid_details = grid_details::Options {
+                grid,
+                details,
+                row_threshold,
+            };
             return Ok(Self::GridDetails(grid_details));
         }
 
@@ -69,7 +74,6 @@ impl Mode {
     }
 }
 
-
 impl grid::Options {
     fn deduce(matches: &MatchedFlags) -> Self {
         Self {
@@ -78,25 +82,32 @@ impl grid::Options {
     }
 }
 
-
 impl details::Options {
     fn deduce_tree(matches: &MatchedFlags) -> Self {
         Self {
             table: None,
             header: false,
-            xattr: xattr::ENABLED && matches.has(flags::EXTENDED) && !matches.has(flags::NO_EXTENDED),
+            xattr: xattr::ENABLED
+                && matches.has(flags::EXTENDED)
+                && !matches.has(flags::NO_EXTENDED),
         }
     }
 
-    fn deduce_long<V: Vars>(matches: &MatchedFlags, vars: &V, long_count: u8) -> Result<Self, OptionsError> {
+    fn deduce_long<V: Vars>(
+        matches: &MatchedFlags,
+        vars: &V,
+        long_count: u8,
+    ) -> Result<Self, OptionsError> {
         Ok(Self {
             table: Some(TableOptions::deduce(matches, vars, long_count)?),
-            header: (matches.has(flags::HEADER) || long_count >= 3) && !matches.has(flags::NO_HEADER),
-            xattr: xattr::ENABLED && matches.has(flags::EXTENDED) && !matches.has(flags::NO_EXTENDED),
+            header: (matches.has(flags::HEADER) || long_count >= 3)
+                && !matches.has(flags::NO_HEADER),
+            xattr: xattr::ENABLED
+                && matches.has(flags::EXTENDED)
+                && !matches.has(flags::NO_EXTENDED),
         })
     }
 }
-
 
 impl TerminalWidth {
     fn deduce<V: Vars>(matches: &MatchedFlags, vars: &V) -> Result<Self, OptionsError> {
@@ -110,21 +121,17 @@ impl TerminalWidth {
         // COLUMNS environment variable.
         if let Some(columns) = vars.get(vars::COLUMNS).and_then(|s| s.into_string().ok()) {
             match columns.parse() {
-                Ok(width) => {
-                    Ok(Self::Set(width))
-                }
+                Ok(width) => Ok(Self::Set(width)),
                 Err(e) => {
                     let source = NumberSource::Env(vars::COLUMNS);
                     Err(OptionsError::FailedParse(columns, source, e))
                 }
             }
-        }
-        else {
+        } else {
             Ok(Self::Automatic)
         }
     }
 }
-
 
 impl RowThreshold {
     fn deduce<V: Vars>(matches: &MatchedFlags, vars: &V) -> Result<Self, OptionsError> {
@@ -134,53 +141,68 @@ impl RowThreshold {
         if let Some(rows) = matches.get("grid-rows") {
             return match rows.parse::<usize>() {
                 Ok(n) => Ok(Self::MinimumRows(n)),
-                Err(e) => Err(OptionsError::FailedParse(rows.into(), NumberSource::Arg("grid-rows"), e)),
+                Err(e) => Err(OptionsError::FailedParse(
+                    rows.into(),
+                    NumberSource::Arg("grid-rows"),
+                    e,
+                )),
             };
         }
 
-        if let Some(columns) = vars.get(vars::LX_GRID_ROWS).and_then(|s| s.into_string().ok()) {
+        if let Some(columns) = vars
+            .get(vars::LX_GRID_ROWS)
+            .and_then(|s| s.into_string().ok())
+        {
             match columns.parse() {
-                Ok(rows) => {
-                    Ok(Self::MinimumRows(rows))
-                }
+                Ok(rows) => Ok(Self::MinimumRows(rows)),
                 Err(e) => {
                     let source = NumberSource::Env(vars::LX_GRID_ROWS);
                     Err(OptionsError::FailedParse(columns, source, e))
                 }
             }
-        }
-        else {
+        } else {
             Ok(Self::AlwaysGrid)
         }
     }
 }
 
-
 impl TableOptions {
-    fn deduce<V: Vars>(matches: &MatchedFlags, vars: &V, long_count: u8) -> Result<Self, OptionsError> {
+    fn deduce<V: Vars>(
+        matches: &MatchedFlags,
+        vars: &V,
+        long_count: u8,
+    ) -> Result<Self, OptionsError> {
         let time_format = TimeFormat::deduce(matches, vars)?;
         let size_format = SizeFormat::deduce(matches);
         let columns = deduce_columns(matches, long_count)?;
         let total_size = matches.has(flags::TOTAL) && !matches.has(flags::NO_TOTAL);
         let decimal_point = matches.get("decimal-point").map(String::from);
         let thousands_separator = matches.get("thousands-separator").map(String::from);
-        Ok(Self { size_format, time_format, columns, total_size, decimal_point, thousands_separator })
+        Ok(Self {
+            size_format,
+            time_format,
+            columns,
+            total_size,
+            decimal_point,
+            thousands_separator,
+        })
     }
 }
-
 
 /// Look up a format by name: config-defined first, then compiled-in.
 fn format_columns(name: &str) -> Option<Vec<Column>> {
     // Check config-defined formats first.
     if let Some(cfg) = crate::config::config()
-        && let Some(columns) = cfg.format.get(name) {
-            let cols: Vec<Column> = columns.iter()
-                .filter_map(|s| Column::from_name(s))
-                .collect();
-            if !cols.is_empty() {
-                return Some(cols);
-            }
+        && let Some(columns) = cfg.format.get(name)
+    {
+        let cols: Vec<Column> = columns
+            .iter()
+            .filter_map(|s| Column::from_name(s))
+            .collect();
+        if !cols.is_empty() {
+            return Some(cols);
         }
+    }
 
     // Compiled-in formats.
     let cols = match name {
@@ -225,9 +247,7 @@ fn format_columns(name: &str) -> Option<Vec<Column>> {
 
 /// All available format names: config-defined + compiled-in.
 pub fn format_names() -> Vec<String> {
-    let mut names: Vec<String> = vec![
-        "long".into(), "long2".into(), "long3".into(),
-    ];
+    let mut names: Vec<String> = vec!["long".into(), "long2".into(), "long3".into()];
 
     if let Some(cfg) = crate::config::config() {
         for name in cfg.format.keys() {
@@ -239,7 +259,6 @@ pub fn format_names() -> Vec<String> {
 
     names
 }
-
 
 /// Build the column list from --columns, --format, the -l tier,
 /// individual flags, and positive/negative overrides.
@@ -254,9 +273,10 @@ fn deduce_columns(matches: &MatchedFlags, long_count: u8) -> Result<Vec<Column>,
         for name in cols_str.split(',') {
             let name = name.trim();
             if let Some(col) = Column::from_name(name)
-                && !columns.contains(&col) {
-                    columns.push(col);
-                }
+                && !columns.contains(&col)
+            {
+                columns.push(col);
+            }
         }
         // Individual adds, `-t` tier, and suppression flags still apply.
         apply_bulk_time_clear(matches, &mut columns);
@@ -268,23 +288,23 @@ fn deduce_columns(matches: &MatchedFlags, long_count: u8) -> Result<Vec<Column>,
 
     // --format: named column set.
     if let Some(fmt_name) = matches.get(flags::FORMAT)
-        && let Some(cols) = format_columns(fmt_name) {
-            let mut columns = cols;
-            apply_bulk_time_clear(matches, &mut columns);
-            apply_individual_adds(matches, &mut columns);
-            apply_time_tier(matches, &mut columns);
-            apply_suppressions(matches, &mut columns);
-            return Ok(columns);
-        }
+        && let Some(cols) = format_columns(fmt_name)
+    {
+        let mut columns = cols;
+        apply_bulk_time_clear(matches, &mut columns);
+        apply_individual_adds(matches, &mut columns);
+        apply_time_tier(matches, &mut columns);
+        apply_suppressions(matches, &mut columns);
+        return Ok(columns);
+    }
 
     // -l tier: compiled-in format.
     let tier_name = match long_count {
         0 | 1 => "long",
-        2     => "long2",
-        _     => "long3",
+        2 => "long2",
+        _ => "long3",
     };
-    let mut columns = format_columns(tier_name)
-        .expect("compiled-in format always exists");
+    let mut columns = format_columns(tier_name).expect("compiled-in format always exists");
 
     apply_bulk_time_clear(matches, &mut columns);
     apply_individual_adds(matches, &mut columns);
@@ -293,7 +313,6 @@ fn deduce_columns(matches: &MatchedFlags, long_count: u8) -> Result<Vec<Column>,
 
     Ok(columns)
 }
-
 
 /// Add columns requested by individual flags (-i, -g, -H, -S, etc.)
 /// if not already present.
@@ -324,13 +343,14 @@ fn apply_individual_adds(matches: &MatchedFlags, columns: &mut Vec<Column>) {
 
     for def in COLUMN_REGISTRY {
         if let Some(flag) = def.add_flag
-            && matches.has(flag) && !columns.contains(&def.column) {
-                let pos = canonical_insert_pos(columns, def.column);
-                columns.insert(pos, def.column);
-            }
+            && matches.has(flag)
+            && !columns.contains(&def.column)
+        {
+            let pos = canonical_insert_pos(columns, def.column);
+            columns.insert(pos, def.column);
+        }
     }
 }
-
 
 /// `--no-time` clears all timestamp columns the base format brought
 /// in.  It runs *before* individual adds and `-t` tiers so that
@@ -373,7 +393,6 @@ fn apply_time_tier(matches: &MatchedFlags, columns: &mut Vec<Column>) {
     }
 }
 
-
 /// Apply --no-* suppression flags and --show-* re-enable flags.
 /// Driven by the column registry — columns with suppress/show flags
 /// are checked automatically.
@@ -398,15 +417,16 @@ fn apply_suppressions(matches: &MatchedFlags, columns: &mut Vec<Column>) {
     // Registry-driven re-enables.
     for def in COLUMN_REGISTRY {
         if let Some(flag) = def.show_flag
-            && matches.has(flag) && !columns.contains(&def.column) {
-                let pos = canonical_insert_pos(columns, def.column);
-                columns.insert(pos, def.column);
-            }
+            && matches.has(flag)
+            && !columns.contains(&def.column)
+        {
+            let pos = canonical_insert_pos(columns, def.column);
+            columns.insert(pos, def.column);
+        }
     }
 }
 
 impl SizeFormat {
-
     /// Determine which file size to use in the file size column based on
     /// the user's options.
     ///
@@ -430,28 +450,24 @@ impl SizeFormat {
 
         if matches.has(flags::BINARY) {
             Self::BinaryBytes
-        }
-        else if matches.has(flags::BYTES) {
+        } else if matches.has(flags::BYTES) {
             Self::JustBytes
-        }
-        else {
+        } else {
             Self::DecimalBytes
         }
     }
 
     fn from_str(word: &str) -> Self {
         match word {
-            "binary"  => Self::BinaryBytes,
-            "bytes"   => Self::JustBytes,
+            "binary" => Self::BinaryBytes,
+            "bytes" => Self::JustBytes,
             "decimal" => Self::DecimalBytes,
-            _         => Self::DecimalBytes,
+            _ => Self::DecimalBytes,
         }
     }
 }
 
-
 impl TimeFormat {
-
     /// Determine how time should be formatted in timestamp columns.
     fn deduce<V: Vars>(matches: &MatchedFlags, vars: &V) -> Result<Self, OptionsError> {
         use crate::options::vars;
@@ -464,7 +480,7 @@ impl TimeFormat {
         }
 
         match vars.get(vars::TIME_STYLE) {
-            Some(ref t) if ! t.is_empty()  => {
+            Some(ref t) if !t.is_empty() => {
                 // Environment variable — not validated; silently fall
                 // back to default for unknown values so a stale
                 // TIME_STYLE can't fail to start lx.
@@ -476,21 +492,19 @@ impl TimeFormat {
 
     fn from_str(word: &str) -> Self {
         match word {
-            "default"  => Self::DefaultFormat,
-            "iso"      => Self::ISOFormat,
+            "default" => Self::DefaultFormat,
+            "iso" => Self::ISOFormat,
             "long-iso" => Self::LongISO,
             "full-iso" => Self::FullISO,
             "relative" => Self::Relative,
             s if s.starts_with('+') => Self::Custom(s[1..].to_string()),
-            _          => Self::DefaultFormat,
+            _ => Self::DefaultFormat,
         }
     }
 }
 
-
 // TimeTypes::deduce() has been replaced by deduce_columns() above,
 // which builds timestamps directly into the Vec<Column>.
-
 
 #[cfg(test)]
 mod test {
@@ -499,7 +513,6 @@ mod test {
     use crate::options::test::parse_for_test;
 
     macro_rules! test {
-
         ($name:ident: $type:ident <- $inputs:expr; $result:expr) => {
             #[test]
             fn $name() {
@@ -516,13 +529,12 @@ mod test {
                     println!("Testing {:?}", result);
                     match result {
                         $pat => assert!(true),
-                        _    => assert!(false),
+                        _ => assert!(false),
                     }
                 }
             }
         };
     }
-
 
     mod size_formats {
         use super::*;
@@ -564,7 +576,6 @@ mod test {
         test!(bytes_beats_style:  SizeFormat <- ["--size-style=binary", "--bytes"];   SizeFormat::JustBytes);
     }
 
-
     mod time_formats {
         use super::*;
 
@@ -601,16 +612,17 @@ mod test {
         test!(override_env:     TimeFormat <- ["--time-style=full-iso"], Some("long-iso".into());  like Ok(TimeFormat::FullISO));
     }
 
-
     mod columns {
+        use super::deduce_columns;
         use crate::options::test::parse_for_test;
         use crate::output::table::{Column, TimeType};
-        use super::deduce_columns;
 
         /// Helper: parse flags and return the timestamp columns present.
         fn timestamps(inputs: &[&str], long_count: u8) -> Vec<Column> {
             parse_for_test(inputs, |mf| deduce_columns(mf, long_count))
-                .into_iter().next().unwrap()
+                .into_iter()
+                .next()
+                .unwrap()
                 .expect("test inputs must not error")
                 .into_iter()
                 .filter(|c| matches!(c, Column::Timestamp(_)))
@@ -634,19 +646,25 @@ mod test {
             // `-l --accessed` now adds accessed on top of the base
             // `long` format's modified, rather than replacing.
             let ts = timestamps(&["--accessed"], 1);
-            assert_eq!(ts, vec![
-                Column::Timestamp(TimeType::Modified),
-                Column::Timestamp(TimeType::Accessed),
-            ]);
+            assert_eq!(
+                ts,
+                vec![
+                    Column::Timestamp(TimeType::Modified),
+                    Column::Timestamp(TimeType::Accessed),
+                ]
+            );
         }
 
         #[test]
         fn explicit_created_composes() {
             let ts = timestamps(&["--created"], 1);
-            assert_eq!(ts, vec![
-                Column::Timestamp(TimeType::Modified),
-                Column::Timestamp(TimeType::Created),
-            ]);
+            assert_eq!(
+                ts,
+                vec![
+                    Column::Timestamp(TimeType::Modified),
+                    Column::Timestamp(TimeType::Created),
+                ]
+            );
         }
 
         #[test]
@@ -719,7 +737,10 @@ mod test {
         #[test]
         fn tier2_has_vcs_and_group() {
             let cols: Vec<Column> = parse_for_test(&[], |mf| deduce_columns(mf, 2))
-                .into_iter().next().unwrap().expect("test inputs must not error");
+                .into_iter()
+                .next()
+                .unwrap()
+                .expect("test inputs must not error");
             assert!(cols.contains(&Column::VcsStatus));
             assert!(cols.contains(&Column::Group));
         }
@@ -727,7 +748,10 @@ mod test {
         #[test]
         fn tier3_has_links_and_blocks() {
             let cols: Vec<Column> = parse_for_test(&[], |mf| deduce_columns(mf, 3))
-                .into_iter().next().unwrap().expect("test inputs must not error");
+                .into_iter()
+                .next()
+                .unwrap()
+                .expect("test inputs must not error");
             assert!(cols.contains(&Column::HardLinks));
             assert!(cols.contains(&Column::Blocks));
         }
@@ -735,7 +759,10 @@ mod test {
         #[test]
         fn no_group_suppresses() {
             let cols: Vec<Column> = parse_for_test(&["--no-group"], |mf| deduce_columns(mf, 2))
-                .into_iter().next().unwrap().expect("test inputs must not error");
+                .into_iter()
+                .next()
+                .unwrap()
+                .expect("test inputs must not error");
             assert!(!cols.contains(&Column::Group));
         }
 
@@ -751,7 +778,8 @@ mod test {
         #[test]
         fn short_u_is_user() {
             let cmd = crate::options::parser::build_command();
-            let m = cmd.try_get_matches_from(["lx", "-l", "-u"])
+            let m = cmd
+                .try_get_matches_from(["lx", "-l", "-u"])
                 .expect("-u should parse as --user");
             assert!(m.get_count(crate::options::flags::SHOW_USER) > 0);
         }
@@ -806,14 +834,20 @@ mod test {
         #[test]
         fn no_z_suppresses_filesize() {
             let cols: Vec<Column> = parse_for_test(&["--no-z"], |mf| deduce_columns(mf, 1))
-                .into_iter().next().unwrap().expect("test inputs must not error");
+                .into_iter()
+                .next()
+                .unwrap()
+                .expect("test inputs must not error");
             assert!(!cols.contains(&Column::FileSize));
         }
 
         #[test]
         fn no_upper_m_suppresses_permissions() {
             let cols: Vec<Column> = parse_for_test(&["--no-M"], |mf| deduce_columns(mf, 1))
-                .into_iter().next().unwrap().expect("test inputs must not error");
+                .into_iter()
+                .next()
+                .unwrap()
+                .expect("test inputs must not error");
             assert!(!cols.contains(&Column::Permissions));
         }
 
@@ -821,7 +855,10 @@ mod test {
         #[test]
         fn no_u_suppresses_user() {
             let cols: Vec<Column> = parse_for_test(&["--no-u"], |mf| deduce_columns(mf, 1))
-                .into_iter().next().unwrap().expect("test inputs must not error");
+                .into_iter()
+                .next()
+                .unwrap()
+                .expect("test inputs must not error");
             assert!(!cols.contains(&Column::User));
         }
 
@@ -831,7 +868,10 @@ mod test {
         #[test]
         fn uid_adds_column_after_user() {
             let cols: Vec<Column> = parse_for_test(&["--uid"], |mf| deduce_columns(mf, 1))
-                .into_iter().next().unwrap().expect("test inputs must not error");
+                .into_iter()
+                .next()
+                .unwrap()
+                .expect("test inputs must not error");
             assert!(cols.contains(&Column::Uid));
             // Canonical position: uid sits immediately after user.
             let user_idx = cols.iter().position(|c| *c == Column::User);
@@ -844,7 +884,10 @@ mod test {
         #[test]
         fn gid_adds_column_after_group() {
             let cols: Vec<Column> = parse_for_test(&["-ll", "--gid"], |mf| deduce_columns(mf, 2))
-                .into_iter().next().unwrap().expect("test inputs must not error");
+                .into_iter()
+                .next()
+                .unwrap()
+                .expect("test inputs must not error");
             assert!(cols.contains(&Column::Gid));
             let group_idx = cols.iter().position(|c| *c == Column::Group);
             let gid_idx = cols.iter().position(|c| *c == Column::Gid);
@@ -857,24 +900,31 @@ mod test {
         fn uid_and_gid_compose() {
             // Adding both alongside user/group gives all four columns,
             // in canonical order: user, uid, group, gid.
-            let cols: Vec<Column> = parse_for_test(
-                &["-ll", "--uid", "--gid"],
-                |mf| deduce_columns(mf, 2),
-            ).into_iter().next().unwrap().expect("test inputs must not error");
+            let cols: Vec<Column> =
+                parse_for_test(&["-ll", "--uid", "--gid"], |mf| deduce_columns(mf, 2))
+                    .into_iter()
+                    .next()
+                    .unwrap()
+                    .expect("test inputs must not error");
             let positions: Vec<usize> = [Column::User, Column::Uid, Column::Group, Column::Gid]
                 .iter()
                 .map(|c| cols.iter().position(|x| x == c).expect("column present"))
                 .collect();
-            assert_eq!(positions, (0..4).map(|i| positions[0] + i).collect::<Vec<_>>());
+            assert_eq!(
+                positions,
+                (0..4).map(|i| positions[0] + i).collect::<Vec<_>>()
+            );
         }
 
         #[cfg(unix)]
         #[test]
         fn no_uid_suppresses() {
-            let cols: Vec<Column> = parse_for_test(
-                &["--uid", "--no-uid"],
-                |mf| deduce_columns(mf, 1),
-            ).into_iter().next().unwrap().expect("test inputs must not error");
+            let cols: Vec<Column> =
+                parse_for_test(&["--uid", "--no-uid"], |mf| deduce_columns(mf, 1))
+                    .into_iter()
+                    .next()
+                    .unwrap()
+                    .expect("test inputs must not error");
             assert!(!cols.contains(&Column::Uid));
         }
 
@@ -895,12 +945,10 @@ mod test {
         }
     }
 
-
     mod views {
         use super::*;
 
         use crate::output::grid::Options as GridOptions;
-
 
         // Default
         test!(empty:         Mode <- [], None;            like Ok(Mode::Grid(_)));

--- a/src/output/cell.rs
+++ b/src/output/cell.rs
@@ -3,9 +3,8 @@
 use std::iter::Sum;
 use std::ops::{Add, Deref, DerefMut};
 
-use nu_ansi_term::{Style, AnsiString, AnsiStrings};
+use nu_ansi_term::{AnsiString, AnsiStrings, Style};
 use unicode_width::UnicodeWidthStr;
-
 
 /// An individual cell that holds text in a table, used in the details and
 /// lines views to store ANSI-terminal-formatted data before it is printed.
@@ -19,7 +18,6 @@ use unicode_width::UnicodeWidthStr;
 /// type by that name too.)
 #[derive(PartialEq, Debug, Clone, Default)]
 pub struct TextCell {
-
     /// The contents of this cell, as a vector of ANSI-styled strings.
     pub contents: TextCellContents,
 
@@ -36,14 +34,13 @@ impl Deref for TextCell {
 }
 
 impl TextCell {
-
     /// Creates a new text cell that holds the given text in the given style,
     /// computing the Unicode width of the text.
     pub fn paint(style: Style, text: String) -> Self {
         let width = DisplayWidth::from(&*text);
 
         Self {
-            contents: vec![ style.paint(text) ].into(),
+            contents: vec![style.paint(text)].into(),
             width,
         }
     }
@@ -55,7 +52,7 @@ impl TextCell {
         let width = DisplayWidth::from(text);
 
         Self {
-            contents: vec![ style.paint(text) ].into(),
+            contents: vec![style.paint(text)].into(),
             width,
         }
     }
@@ -68,8 +65,8 @@ impl TextCell {
     /// tabular data when there is *something* in each cell.
     pub fn blank(style: Style) -> Self {
         Self {
-            contents: vec![ style.paint("-") ].into(),
-            width:    DisplayWidth::from(1),
+            contents: vec![style.paint("-")].into(),
+            width: DisplayWidth::from(1),
         }
     }
 
@@ -96,7 +93,6 @@ impl TextCell {
     }
 }
 
-
 // I’d like to eventually abstract cells so that instead of *every* cell
 // storing a vector, only variable-length cells would, and individual cells
 // would just store an array of a fixed length (which would usually be just 1
@@ -120,7 +116,6 @@ impl TextCell {
 // TODO: it would be nice to abstract the `TextCell` type so instead of a
 // `Vec`, it can use anything of type `T: IntoIterator<Item=AnsiString<’static>>`.
 // This would allow us to still hold all the data, but allocate less.
-
 
 /// The contents of a text cell, as a vector of ANSI-styled strings.
 ///
@@ -150,7 +145,6 @@ impl Deref for TextCellContents {
 // above can just access the value directly.
 
 impl TextCellContents {
-
     /// Produces an `AnsiStrings` value that can be used to print the styled
     /// values of this cell as an ANSI-terminal-formatted string.
     pub fn strings(&self) -> AnsiStrings<'_> {
@@ -160,7 +154,8 @@ impl TextCellContents {
     /// Calculates the width that a cell with these contents would take up, by
     /// counting the number of characters in each unformatted ANSI string.
     pub fn width(&self) -> DisplayWidth {
-        self.0.iter()
+        self.0
+            .iter()
             .map(|anstr| DisplayWidth::from(anstr.as_str()))
             .sum()
     }
@@ -174,7 +169,6 @@ impl TextCellContents {
         }
     }
 }
-
 
 /// The Unicode “display width” of a string.
 ///
@@ -236,12 +230,12 @@ impl Add<usize> for DisplayWidth {
 
 impl Sum for DisplayWidth {
     fn sum<I>(iter: I) -> Self
-    where I: Iterator<Item = Self>
+    where
+        I: Iterator<Item = Self>,
     {
         iter.fold(Self(0), Add::add)
     }
 }
-
 
 #[cfg(test)]
 mod width_unit_test {

--- a/src/output/column_registry.rs
+++ b/src/output/column_registry.rs
@@ -8,12 +8,11 @@
 use crate::fs::File;
 use crate::fs::feature::VcsCache;
 use crate::options::flags;
-use locale;
 use crate::output::cell::TextCell;
 use crate::output::table::{Alignment, Column, Environment, SizeFormat, TimeType};
 use crate::output::time::TimeFormat;
 use crate::theme::Theme;
-
+use locale;
 
 // ── RenderContext ────────────────────────────────────────────────
 
@@ -30,12 +29,10 @@ pub struct RenderContext<'a> {
     pub total_size: bool,
 }
 
-
 // ── Render function type ────────────────────────────────────────
 
 /// Signature for column render functions.
 pub type RenderFn = fn(&RenderContext<'_>, &File<'_>, bool) -> TextCell;
-
 
 // ── ColumnDef ───────────────────────────────────────────────────
 
@@ -73,7 +70,6 @@ pub struct ColumnDef {
     pub render: RenderFn,
 }
 
-
 // ── Render wrapper functions ────────────────────────────────────
 //
 // Thin wrappers that bridge the uniform RenderFn signature to the
@@ -95,7 +91,8 @@ fn render_permissions(ctx: &RenderContext<'_>, file: &File<'_>, xattrs: bool) ->
 
 fn render_size(ctx: &RenderContext<'_>, file: &File<'_>, _xattrs: bool) -> TextCell {
     if ctx.total_size {
-        file.total_size().render(ctx.theme, ctx.size_format, ctx.numeric)
+        file.total_size()
+            .render(ctx.theme, ctx.size_format, ctx.numeric)
     } else {
         file.size().render(ctx.theme, ctx.size_format, ctx.numeric)
     }
@@ -137,12 +134,11 @@ fn render_gid(ctx: &RenderContext<'_>, file: &File<'_>, _xattrs: bool) -> TextCe
 }
 
 fn render_vcs_status(ctx: &RenderContext<'_>, file: &File<'_>, _xattrs: bool) -> TextCell {
-    let status = ctx.vcs
+    let status = ctx
+        .vcs
         .map(|g| g.get(&file.path, file.is_directory()))
         .unwrap_or_default();
-    let backend = ctx.vcs
-        .map(VcsCache::header_name)
-        .unwrap_or("VCS");
+    let backend = ctx.vcs.map(VcsCache::header_name).unwrap_or("VCS");
     status.render(ctx.theme, backend)
 }
 
@@ -198,7 +194,6 @@ fn render_created(ctx: &RenderContext<'_>, file: &File<'_>, _xattrs: bool) -> Te
         ctx.time_format,
     )
 }
-
 
 // ── The registry ────────────────────────────────────────────────
 
@@ -427,13 +422,13 @@ pub static COLUMN_REGISTRY: &[ColumnDef] = &[
     },
 ];
 
-
 // ── Lookup functions ────────────────────────────────────────────
 
 impl ColumnDef {
     /// Look up a column definition by its `Column` enum variant.
     pub fn for_column(col: Column) -> &'static ColumnDef {
-        COLUMN_REGISTRY.iter()
+        COLUMN_REGISTRY
+            .iter()
             .find(|d| d.column == col)
             .expect("every Column variant must have a ColumnDef entry")
     }
@@ -441,7 +436,8 @@ impl ColumnDef {
     /// Parse a column name (from `--columns` or config).  Returns the
     /// `Column` variant, or `None` for unrecognised names.
     pub fn column_from_name(s: &str) -> Option<Column> {
-        COLUMN_REGISTRY.iter()
+        COLUMN_REGISTRY
+            .iter()
             .find(|d| d.name == s || d.aliases.contains(&s))
             .map(|d| d.column)
     }
@@ -450,7 +446,8 @@ impl ColumnDef {
     /// registry order.  Used for "[possible values: ...]" hints in
     /// error messages from `--columns=` parsing.
     pub fn all_names_csv() -> String {
-        COLUMN_REGISTRY.iter()
+        COLUMN_REGISTRY
+            .iter()
             .map(|d| d.name)
             .collect::<Vec<_>>()
             .join(", ")

--- a/src/output/details.rs
+++ b/src/output/details.rs
@@ -59,7 +59,6 @@
 //! means that we must wait until every row has been added to the table before it
 //! can be displayed, in order to make sure that every column is wide enough.
 
-
 use std::io::{self, Write};
 use std::path::PathBuf;
 use std::vec::IntoIter as VecIntoIter;
@@ -67,17 +66,16 @@ use std::vec::IntoIter as VecIntoIter;
 use log::error;
 use nu_ansi_term::Style;
 
-use crate::fs::{Dir, File};
 use crate::fs::dir_action::RecurseOptions;
 use crate::fs::feature::VcsCache;
 use crate::fs::feature::xattr::{Attribute, FileAttributes};
 use crate::fs::filter::FileFilter;
+use crate::fs::{Dir, File};
 use crate::output::cell::TextCell;
 use crate::output::file_name::Options as FileStyle;
-use crate::output::table::{Table, Options as TableOptions, Row as TableRow};
-use crate::output::tree::{TreeTrunk, TreeParams, TreeDepth};
+use crate::output::table::{Options as TableOptions, Row as TableRow, Table};
+use crate::output::tree::{TreeDepth, TreeParams, TreeTrunk};
 use crate::theme::Theme;
-
 
 /// With the **Details** view, the output gets formatted into columns, with
 /// each `Column` object showing some piece of information about the file,
@@ -92,7 +90,6 @@ use crate::theme::Theme;
 /// columns for each row.
 #[derive(PartialEq, Eq, Debug)]
 pub struct Options {
-
     /// Options specific to drawing a table.
     ///
     /// Directories themselves can pick which columns are *added* to this
@@ -105,7 +102,6 @@ pub struct Options {
     /// Whether to show each file’s extended attributes.
     pub xattr: bool,
 }
-
 
 pub struct Render<'a> {
     pub dir: Option<&'a Dir>,
@@ -128,13 +124,12 @@ pub struct Render<'a> {
     pub vcs: Option<&'a dyn VcsCache>,
 }
 
-
 struct Egg<'a> {
     table_row: Option<TableRow>,
-    xattrs:    Vec<Attribute>,
-    errors:    Vec<(io::Error, Option<PathBuf>)>,
-    dir:       Option<Dir>,
-    file:      &'a File<'a>,
+    xattrs: Vec<Attribute>,
+    errors: Vec<(io::Error, Option<PathBuf>)>,
+    dir: Option<Dir>,
+    file: &'a File<'a>,
 }
 
 impl<'a> AsRef<File<'a>> for Egg<'a> {
@@ -142,7 +137,6 @@ impl<'a> AsRef<File<'a>> for Egg<'a> {
         self.file
     }
 }
-
 
 impl<'a> Render<'a> {
     /// Render the file listing.  Returns `(item_count, size_total)`:
@@ -155,9 +149,17 @@ impl<'a> Render<'a> {
 
         if let Some(ref table) = self.opts.table {
             match (self.vcs, self.dir) {
-                (Some(g), Some(d))  => if ! g.has_anything_for(&d.path) { self.vcs = None },
-                (Some(g), None)     => if ! self.files.iter().any(|f| g.has_anything_for(&f.path)) { self.vcs = None },
-                (None,    _)        => {/* Keep Git how it is */},
+                (Some(g), Some(d)) => {
+                    if !g.has_anything_for(&d.path) {
+                        self.vcs = None
+                    }
+                }
+                (Some(g), None) => {
+                    if !self.files.iter().any(|f| g.has_anything_for(&f.path)) {
+                        self.vcs = None
+                    }
+                }
+                (None, _) => { /* Keep Git how it is */ }
             }
 
             let mut table = Table::new(table, self.vcs, self.theme);
@@ -173,17 +175,28 @@ impl<'a> Render<'a> {
             let mut table = Some(table);
             let rows_before = rows.len();
             let mut size_total = 0u64;
-            self.add_files_to_table(&mut table, &mut rows, &self.files, TreeDepth::root(), &mut size_total);
+            self.add_files_to_table(
+                &mut table,
+                &mut rows,
+                &self.files,
+                TreeDepth::root(),
+                &mut size_total,
+            );
             let file_count = rows.len() - rows_before;
 
             for row in self.iterate_with_table(table.unwrap(), rows) {
                 writeln!(w, "{}", row.strings())?;
             }
             Ok((file_count, size_total))
-        }
-        else {
+        } else {
             let mut size_total = 0u64;
-            self.add_files_to_table(&mut None, &mut rows, &self.files, TreeDepth::root(), &mut size_total);
+            self.add_files_to_table(
+                &mut None,
+                &mut rows,
+                &self.files,
+                TreeDepth::root(),
+                &mut size_total,
+            );
 
             let file_count = rows.len();
             for row in self.iterate(rows) {
@@ -195,13 +208,21 @@ impl<'a> Render<'a> {
 
     /// Adds files to the table, possibly recursively. This is easily
     /// parallelisable, and uses a pool of threads.
-    fn add_files_to_table<'dir>(&self, table: &mut Option<Table<'a>>, rows: &mut Vec<Row>, src: &[File<'dir>], depth: TreeDepth, size_total: &mut u64) {
+    fn add_files_to_table<'dir>(
+        &self,
+        table: &mut Option<Table<'a>>,
+        rows: &mut Vec<Row>,
+        src: &[File<'dir>],
+        depth: TreeDepth,
+        size_total: &mut u64,
+    ) {
         use crate::fs::feature::xattr;
 
         // When --total-size is active in tree mode, eagerly pre-compute
         // directory sizes in parallel.  This populates each File's
         // OnceLock so that render_size() reads cached values.
-        let total_size_active = table.as_ref()
+        let total_size_active = table
+            .as_ref()
             .is_some_and(super::table::Table::total_size_active);
         if total_size_active && self.recurse.is_some() {
             use rayon::prelude::*;
@@ -219,40 +240,49 @@ impl<'a> Render<'a> {
         use super::table::Column;
         let needs_xattr_full = self.opts.xattr;
         let needs_xattr_probe = !needs_xattr_full
-            && self.opts.table.as_ref()
+            && self
+                .opts
+                .table
+                .as_ref()
                 .is_some_and(|t| t.columns.contains(&Column::Permissions));
 
-        let mut file_eggs = src.iter().map(|file| {
-            let mut errors = Vec::new();
-            let mut xattrs = Vec::new();
-            let mut has_xattrs = false;
+        let mut file_eggs = src
+            .iter()
+            .map(|file| {
+                let mut errors = Vec::new();
+                let mut xattrs = Vec::new();
+                let mut has_xattrs = false;
 
-            if xattr::ENABLED && needs_xattr_full {
-                match file.path.attributes() {
-                    Ok(xs) => {
-                        has_xattrs = ! xs.is_empty();
-                        xattrs = xs;
+                if xattr::ENABLED && needs_xattr_full {
+                    match file.path.attributes() {
+                        Ok(xs) => {
+                            has_xattrs = !xs.is_empty();
+                            xattrs = xs;
+                        }
+                        Err(e) => {
+                            errors.push((e, None));
+                        }
                     }
-                    Err(e) => {
-                        errors.push((e, None));
+                } else if xattr::ENABLED && needs_xattr_probe {
+                    match file.path.has_attributes() {
+                        Ok(h) => {
+                            has_xattrs = h;
+                        }
+                        Err(e) => {
+                            error!("Error probing xattr for {}: {e}", file.path.display());
+                        }
                     }
                 }
-            } else if xattr::ENABLED && needs_xattr_probe {
-                match file.path.has_attributes() {
-                    Ok(h) => { has_xattrs = h; }
-                    Err(e) => {
-                        error!("Error probing xattr for {}: {e}", file.path.display());
-                    }
-                }
-            }
 
-            let table_row = table.as_ref()
-                                 .map(|t| t.row_for_file(file, has_xattrs));
+                let table_row = table.as_ref().map(|t| t.row_for_file(file, has_xattrs));
 
-            let mut dir = None;
-            if let Some(r) = self.recurse
-                && file.is_directory() && r.tree && ! r.is_too_deep(depth.0)
-                && ! self.filter.is_pruned(file) {
+                let mut dir = None;
+                if let Some(r) = self.recurse
+                    && file.is_directory()
+                    && r.tree
+                    && !r.is_too_deep(depth.0)
+                    && !self.filter.is_pruned(file)
+                {
                     match file.to_dir() {
                         Ok(d) => {
                             dir = Some(d);
@@ -263,8 +293,15 @@ impl<'a> Render<'a> {
                     }
                 }
 
-            Egg { table_row, xattrs, errors, dir, file }
-        }).collect::<Vec<_>>();
+                Egg {
+                    table_row,
+                    xattrs,
+                    errors,
+                    dir,
+                    file,
+                }
+            })
+            .collect::<Vec<_>>();
 
         self.filter.sort_files(&mut file_eggs, self.vcs);
 
@@ -276,15 +313,17 @@ impl<'a> Render<'a> {
                 t.add_widths(row);
             }
 
-            let file_name = self.file_style.for_file(egg.file, self.theme)
-                                .with_link_paths()
-                                .paint()
-                                .promote();
+            let file_name = self
+                .file_style
+                .for_file(egg.file, self.theme)
+                .with_link_paths()
+                .paint()
+                .promote();
 
             let row = Row {
-                tree:   tree_params,
-                cells:  egg.table_row,
-                name:   file_name,
+                tree: tree_params,
+                cells: egg.table_row,
+                name: file_name,
             };
 
             rows.push(row);
@@ -294,7 +333,8 @@ impl<'a> Render<'a> {
                 if egg.dir.is_none() {
                     // Not expanded (pruned or depth-limited): use total
                     // size if available, otherwise skip.
-                    let total_size_active = table.as_ref()
+                    let total_size_active = table
+                        .as_ref()
                         .is_some_and(super::table::Table::total_size_active);
                     if total_size_active
                         && let crate::fs::fields::Size::Some(s) = egg.file.total_size()
@@ -321,13 +361,19 @@ impl<'a> Render<'a> {
 
                 self.filter.filter_child_files(&mut files);
 
-                if ! files.is_empty() {
+                if !files.is_empty() {
                     for xattr in egg.xattrs {
-                        rows.push(self.render_xattr(&xattr, TreeParams::new(depth.deeper(), false)));
+                        rows.push(
+                            self.render_xattr(&xattr, TreeParams::new(depth.deeper(), false)),
+                        );
                     }
 
                     for (error, path) in errors {
-                        rows.push(self.render_error(&error, TreeParams::new(depth.deeper(), false), path));
+                        rows.push(self.render_error(
+                            &error,
+                            TreeParams::new(depth.deeper(), false),
+                            path,
+                        ));
                     }
 
                     self.add_files_to_table(table, rows, &files, depth.deeper(), size_total);
@@ -337,7 +383,8 @@ impl<'a> Render<'a> {
 
             let count = egg.xattrs.len();
             for (index, xattr) in egg.xattrs.into_iter().enumerate() {
-                let params = TreeParams::new(depth.deeper(), errors.is_empty() && index == count - 1);
+                let params =
+                    TreeParams::new(depth.deeper(), errors.is_empty() && index == count - 1);
                 let r = self.render_xattr(&xattr, params);
                 rows.push(r);
             }
@@ -353,9 +400,9 @@ impl<'a> Render<'a> {
 
     pub fn render_header(&self, header: TableRow) -> Row {
         Row {
-            tree:     TreeParams::new(TreeDepth::root(), false),
-            cells:    Some(header),
-            name:     TextCell::paint_str(self.theme.ui.header, "Name"),
+            tree: TreeParams::new(TreeDepth::root(), false),
+            cells: Some(header),
+            name: TextCell::paint_str(self.theme.ui.header, "Name"),
         }
     }
 
@@ -371,16 +418,31 @@ impl<'a> Render<'a> {
         // TODO: broken_symlink() doesn’t quite seem like the right name for
         // the style that’s being used here. Maybe split it in two?
         let name = TextCell::paint(self.theme.broken_symlink(), error_message);
-        Row { cells: None, name, tree }
+        Row {
+            cells: None,
+            name,
+            tree,
+        }
     }
 
     fn render_xattr(&self, xattr: &Attribute, tree: TreeParams) -> Row {
-        let name = TextCell::paint(self.theme.ui.perms.attribute, format!("{} (len {})", xattr.name, xattr.size));
-        Row { cells: None, name, tree }
+        let name = TextCell::paint(
+            self.theme.ui.perms.attribute,
+            format!("{} (len {})", xattr.name, xattr.size),
+        );
+        Row {
+            cells: None,
+            name,
+            tree,
+        }
     }
 
     pub fn render_file(&self, cells: TableRow, name: TextCell, tree: TreeParams) -> Row {
-        Row { cells: Some(cells), name, tree }
+        Row {
+            cells: Some(cells),
+            name,
+            tree,
+        }
     }
 
     pub fn iterate_with_table(&'a self, table: Table<'a>, rows: Vec<Row>) -> TableIter<'a> {
@@ -402,9 +464,7 @@ impl<'a> Render<'a> {
     }
 }
 
-
 pub struct Row {
-
     /// Vector of cells to display.
     ///
     /// Most of the rows will be used to display files’ metadata, so this will
@@ -421,14 +481,13 @@ pub struct Row {
     pub tree: TreeParams,
 }
 
-
 pub struct TableIter<'a> {
     inner: VecIntoIter<Row>,
     table: Table<'a>,
 
     total_width: usize,
-    tree_style:  Style,
-    tree_trunk:  TreeTrunk,
+    tree_style: Style,
+    tree_trunk: TreeTrunk,
 }
 
 impl Iterator for TableIter<'_> {
@@ -436,15 +495,13 @@ impl Iterator for TableIter<'_> {
 
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.next().map(|row| {
-            let mut cell =
-                if let Some(cells) = row.cells {
-                    self.table.render(cells)
-                }
-                else {
-                    let mut cell = TextCell::default();
-                    cell.add_spaces(self.total_width);
-                    cell
-                };
+            let mut cell = if let Some(cells) = row.cells {
+                self.table.render(cells)
+            } else {
+                let mut cell = TextCell::default();
+                cell.add_spaces(self.total_width);
+                cell
+            };
 
             for tree_part in self.tree_trunk.new_row(row.tree) {
                 cell.push(self.tree_style.paint(tree_part.ascii_art()), 4);
@@ -452,7 +509,7 @@ impl Iterator for TableIter<'_> {
 
             // If any tree characters have been printed, then add an extra
             // space, which makes the output look much better.
-            if ! row.tree.is_at_root() {
+            if !row.tree.is_at_root() {
                 cell.add_spaces(1);
             }
 
@@ -461,7 +518,6 @@ impl Iterator for TableIter<'_> {
         })
     }
 }
-
 
 pub struct Iter {
     tree_trunk: TreeTrunk,
@@ -482,7 +538,7 @@ impl Iterator for Iter {
 
             // If any tree characters have been printed, then add an extra
             // space, which makes the output look much better.
-            if ! row.tree.is_at_root() {
+            if !row.tree.is_at_root() {
                 cell.add_spaces(1);
             }
 

--- a/src/output/escape.rs
+++ b/src/output/escape.rs
@@ -1,8 +1,10 @@
 use nu_ansi_term::{AnsiString, Style};
 
-
 pub fn escape(string: String, bits: &mut Vec<AnsiString<'_>>, good: Style, bad: Style) {
-    if string.chars().all(|c| c >= 0x20 as char && c != 0x7f as char) {
+    if string
+        .chars()
+        .all(|c| c >= 0x20 as char && c != 0x7f as char)
+    {
         bits.push(good.paint(string));
         return;
     }
@@ -17,8 +19,7 @@ pub fn escape(string: String, bits: &mut Vec<AnsiString<'_>>, good: Style, bad: 
             let mut s = String::new();
             s.push(c);
             bits.push(good.paint(s));
-        }
-        else {
+        } else {
             let s = c.escape_default().collect::<String>();
             bits.push(bad.paint(s));
         }

--- a/src/output/file_name.rs
+++ b/src/output/file_name.rs
@@ -9,11 +9,9 @@ use crate::output::escape;
 use crate::output::icons::{icon_for_file, iconify_style};
 use crate::output::render::FiletypeColours;
 
-
 /// Basically a file name factory.
 #[derive(Debug, Copy, Clone)]
 pub struct Options {
-
     /// Whether to append file class characters to file names.
     pub classify: Classify,
 
@@ -41,17 +39,23 @@ pub enum Quotes {
 }
 
 impl Options {
-
     /// Create a new `FileName` that prints the given file’s name, painting it
     /// with the remaining arguments.
-    pub fn for_file<'a, 'dir, C>(self, file: &'a File<'dir>, colours: &'a C) -> FileName<'a, 'dir, C> {
+    pub fn for_file<'a, 'dir, C>(
+        self,
+        file: &'a File<'dir>,
+        colours: &'a C,
+    ) -> FileName<'a, 'dir, C> {
         FileName {
             file,
             colours,
             link_style: LinkStyle::JustFilenames,
-            options:    self,
-            target:     if file.is_link() { Some(file.link_target()) }
-                                     else { None }
+            options: self,
+            target: if file.is_link() {
+                Some(file.link_target())
+            } else {
+                None
+            },
         }
     }
 }
@@ -60,7 +64,6 @@ impl Options {
 /// links, depending on how long the resulting Cell can be.
 #[derive(PartialEq, Debug, Copy, Clone)]
 enum LinkStyle {
-
     /// Just display the file names, but colour them differently if they’re
     /// a broken link or can’t be followed.
     JustFilenames,
@@ -71,12 +74,9 @@ enum LinkStyle {
     FullLinkPaths,
 }
 
-
 /// Whether to append file class characters to the file names.
-#[derive(PartialEq, Eq, Debug, Copy, Clone)]
-#[derive(Default)]
+#[derive(PartialEq, Eq, Debug, Copy, Clone, Default)]
 pub enum Classify {
-
     /// Just display the file names, without any characters.
     #[default]
     JustFilenames,
@@ -86,12 +86,9 @@ pub enum Classify {
     AddFileIndicators,
 }
 
-
-
 /// Whether and how to show icons.
 #[derive(PartialEq, Eq, Debug, Copy, Clone)]
 pub enum ShowIcons {
-
     /// Don’t show icons at all.
     Off,
 
@@ -100,11 +97,9 @@ pub enum ShowIcons {
     On(u32),
 }
 
-
 /// A **file name** holds all the information necessary to display the name
 /// of the given file. This is used in all of the views.
 pub struct FileName<'a, 'dir, C> {
-
     /// A reference to the file that we’re getting the name of.
     file: &'a File<'dir>,
 
@@ -112,7 +107,7 @@ pub struct FileName<'a, 'dir, C> {
     colours: &'a C,
 
     /// The file that this file points to if it’s a link.
-    target: Option<FileTarget<'dir>>,  // todo: remove?
+    target: Option<FileTarget<'dir>>, // todo: remove?
 
     /// How to handle displaying links.
     link_style: LinkStyle,
@@ -121,7 +116,6 @@ pub struct FileName<'a, 'dir, C> {
 }
 
 impl<C> FileName<'_, '_, C> {
-
     /// Sets the flag on this file name to display link targets with an
     /// arrow followed by their path.
     pub fn with_link_paths(mut self) -> Self {
@@ -131,7 +125,6 @@ impl<C> FileName<'_, '_, C> {
 }
 
 impl<C: Colours> FileName<'_, '_, C> {
-
     /// Paints the name of the file using the colours, resulting in a vector
     /// of coloured cells that can be printed to the terminal.
     ///
@@ -156,14 +149,14 @@ impl<C: Colours> FileName<'_, '_, C> {
 
         // OSC 8 hyperlink opening.
         if self.options.hyperlink
-            && let Ok(abs) = std::fs::canonicalize(&self.file.path) {
-                let uri = format!("file://{}", abs.display());
-                bits.push(Style::default().paint(format!("\x1b]8;;{uri}\x07")));
-            }
+            && let Ok(abs) = std::fs::canonicalize(&self.file.path)
+        {
+            let uri = format!("file://{}", abs.display());
+            bits.push(Style::default().paint(format!("\x1b]8;;{uri}\x07")));
+        }
 
         // Opening quote.
-        let needs_quotes = self.options.quotes == Quotes::Always
-            && self.file.name.contains(' ');
+        let needs_quotes = self.options.quotes == Quotes::Always && self.file.name.contains(' ');
         if needs_quotes {
             bits.push(Style::default().paint("\""));
         }
@@ -172,21 +165,23 @@ impl<C: Colours> FileName<'_, '_, C> {
         // just the parent directory.
         if self.options.absolute {
             if let Ok(abs) = std::fs::canonicalize(&self.file.path)
-                && let Some(parent) = abs.parent() {
-                    self.add_parent_bits(&mut bits, parent);
-                }
-        } else if self.file.parent_dir.is_none()
-            && let Some(parent) = self.file.path.parent() {
+                && let Some(parent) = abs.parent()
+            {
                 self.add_parent_bits(&mut bits, parent);
             }
+        } else if self.file.parent_dir.is_none()
+            && let Some(parent) = self.file.path.parent()
+        {
+            self.add_parent_bits(&mut bits, parent);
+        }
 
-        if ! self.file.name.is_empty() {
-        	// The “missing file” colour seems like it should be used here,
-        	// but it’s not! In a grid view, where there’s no space to display
-        	// link targets, the filename has to have a different style to
-        	// indicate this fact. But when showing targets, we can just
-        	// colour the path instead (see below), and leave the broken
-        	// link’s filename as the link colour.
+        if !self.file.name.is_empty() {
+            // The “missing file” colour seems like it should be used here,
+            // but it’s not! In a grid view, where there’s no space to display
+            // link targets, the filename has to have a different style to
+            // indicate this fact. But when showing targets, we can just
+            // colour the path instead (see below), and leave the broken
+            // link’s filename as the link colour.
             for bit in self.coloured_file_name() {
                 bits.push(bit);
             }
@@ -203,7 +198,7 @@ impl<C: Colours> FileName<'_, '_, C> {
                         self.add_parent_bits(&mut bits, parent);
                     }
 
-                    if ! target.name.is_empty() {
+                    if !target.name.is_empty() {
                         let target_options = Options {
                             classify: Classify::JustFilenames,
                             show_icons: ShowIcons::Off,
@@ -225,9 +220,10 @@ impl<C: Colours> FileName<'_, '_, C> {
                         }
 
                         if let Classify::AddFileIndicators = self.options.classify
-                            && let Some(class) = self.classify_char(target) {
-                                bits.push(Style::default().paint(class));
-                            }
+                            && let Some(class) = self.classify_char(target)
+                        {
+                            bits.push(Style::default().paint(class));
+                        }
                     }
                 }
 
@@ -248,11 +244,11 @@ impl<C: Colours> FileName<'_, '_, C> {
                     // Do nothing — the error gets displayed on the next line
                 }
             }
+        } else if let Classify::AddFileIndicators = self.options.classify
+            && let Some(class) = self.classify_char(self.file)
+        {
+            bits.push(Style::default().paint(class));
         }
-        else if let Classify::AddFileIndicators = self.options.classify
-            && let Some(class) = self.classify_char(self.file) {
-                bits.push(Style::default().paint(class));
-            }
 
         // Closing quote.
         if needs_quotes {
@@ -273,16 +269,23 @@ impl<C: Colours> FileName<'_, '_, C> {
         let coconut = parent.components().count();
 
         if coconut == 1 && parent.has_root() {
-            bits.push(self.colours.symlink_path().paint(std::path::MAIN_SEPARATOR.to_string()));
-        }
-        else if coconut >= 1 {
+            bits.push(
+                self.colours
+                    .symlink_path()
+                    .paint(std::path::MAIN_SEPARATOR.to_string()),
+            );
+        } else if coconut >= 1 {
             escape(
                 parent.to_string_lossy().to_string(),
                 bits,
                 self.colours.symlink_path(),
                 self.colours.control_char(),
             );
-            bits.push(self.colours.symlink_path().paint(std::path::MAIN_SEPARATOR.to_string()));
+            bits.push(
+                self.colours
+                    .symlink_path()
+                    .paint(std::path::MAIN_SEPARATOR.to_string()),
+            );
         }
     }
 
@@ -292,20 +295,15 @@ impl<C: Colours> FileName<'_, '_, C> {
     fn classify_char(&self, file: &File<'_>) -> Option<&'static str> {
         if file.is_executable_file() {
             Some("*")
-        }
-        else if file.is_directory() {
+        } else if file.is_directory() {
             Some("/")
-        }
-        else if file.is_pipe() {
+        } else if file.is_pipe() {
             Some("|")
-        }
-        else if file.is_link() {
+        } else if file.is_link() {
             Some("@")
-        }
-        else if file.is_socket() {
+        } else if file.is_socket() {
             Some("=")
-        }
-        else {
+        } else {
             None
         }
     }
@@ -314,11 +312,9 @@ impl<C: Colours> FileName<'_, '_, C> {
     fn classify_char(&self, file: &File<'_>) -> Option<&'static str> {
         if file.is_directory() {
             Some("/")
-        }
-        else if file.is_link() {
+        } else if file.is_link() {
             Some("@")
-        }
-        else {
+        } else {
             None
         }
     }
@@ -354,33 +350,32 @@ impl<C: Colours> FileName<'_, '_, C> {
     pub fn style(&self) -> Style {
         if let LinkStyle::JustFilenames = self.link_style
             && let Some(ref target) = self.target
-                && target.is_broken() {
-                    return self.colours.broken_symlink();
-                }
+            && target.is_broken()
+        {
+            return self.colours.broken_symlink();
+        }
 
         match self.file {
-            f if f.is_directory()        => self.colours.directory(),
+            f if f.is_directory() => self.colours.directory(),
             #[cfg(unix)]
-            f if f.is_executable_file()  => self.colours.executable_file(),
-            f if f.is_link()             => self.colours.symlink(),
+            f if f.is_executable_file() => self.colours.executable_file(),
+            f if f.is_link() => self.colours.symlink(),
             #[cfg(unix)]
-            f if f.is_pipe()             => self.colours.pipe(),
+            f if f.is_pipe() => self.colours.pipe(),
             #[cfg(unix)]
-            f if f.is_block_device()     => self.colours.block_device(),
+            f if f.is_block_device() => self.colours.block_device(),
             #[cfg(unix)]
-            f if f.is_char_device()      => self.colours.char_device(),
+            f if f.is_char_device() => self.colours.char_device(),
             #[cfg(unix)]
-            f if f.is_socket()           => self.colours.socket(),
-            f if ! f.is_file()           => self.colours.special(),
-            _                            => self.colours.colour_file(self.file),
+            f if f.is_socket() => self.colours.socket(),
+            f if !f.is_file() => self.colours.special(),
+            _ => self.colours.colour_file(self.file),
         }
     }
 }
 
-
 /// The set of colours that are needed to paint a file name.
 pub trait Colours: FiletypeColours {
-
     /// The style to paint the path of a symlink’s target, up to but not
     /// including the file’s name.
     fn symlink_path(&self) -> Style;
@@ -388,9 +383,9 @@ pub trait Colours: FiletypeColours {
     /// The style to paint the arrow between a link and its target.
     fn normal_arrow(&self) -> Style;
 
-	/// The style to paint the filenames of broken links in views that don’t
-	/// show link targets, and the style to paint the *arrow* between the link
-	/// and its target in views that *do* show link targets.
+    /// The style to paint the filenames of broken links in views that don’t
+    /// show link targets, and the style to paint the *arrow* between the link
+    /// and its target in views that *do* show link targets.
     fn broken_symlink(&self) -> Style;
 
     /// The style to paint the entire filename of a broken link.
@@ -409,8 +404,7 @@ pub trait Colours: FiletypeColours {
     fn colour_file(&self, file: &File<'_>) -> Style;
 }
 
-
 /// Generate a string made of `n` spaces.
 fn spaces(width: u32) -> String {
-    (0 .. width).map(|_| ' ').collect()
+    (0..width).map(|_| ' ').collect()
 }

--- a/src/output/grid.rs
+++ b/src/output/grid.rs
@@ -7,7 +7,6 @@ use crate::fs::filter::FileFilter;
 use crate::output::file_name::Options as FileStyle;
 use crate::theme::Theme;
 
-
 #[derive(PartialEq, Eq, Debug, Copy, Clone)]
 pub struct Options {
     pub across: bool,
@@ -15,11 +14,13 @@ pub struct Options {
 
 impl Options {
     pub fn direction(self) -> tg::Direction {
-        if self.across { tg::Direction::LeftToRight }
-                  else { tg::Direction::TopToBottom }
+        if self.across {
+            tg::Direction::LeftToRight
+        } else {
+            tg::Direction::TopToBottom
+        }
     }
 }
-
 
 pub struct Render<'a, 'dir> {
     pub files: Vec<File<'dir>>,
@@ -34,7 +35,9 @@ impl Render<'_, '_> {
     pub fn render<W: Write>(mut self, w: &mut W) -> io::Result<()> {
         self.filter.sort_files(&mut self.files, None);
 
-        let cells: Vec<String> = self.files.iter()
+        let cells: Vec<String> = self
+            .files
+            .iter()
             .map(|file| {
                 let filename = self.file_style.for_file(file, self.theme).paint();
                 filename.strings().to_string()
@@ -45,11 +48,14 @@ impl Render<'_, '_> {
             return Ok(());
         }
 
-        let grid = tg::Grid::new(cells, tg::GridOptions {
-            direction:  self.opts.direction(),
-            filling:    tg::Filling::Spaces(2),
-            width:      self.console_width,
-        });
+        let grid = tg::Grid::new(
+            cells,
+            tg::GridOptions {
+                direction: self.opts.direction(),
+                filling: tg::Filling::Spaces(2),
+                width: self.console_width,
+            },
+        );
 
         // If the grid has as many rows as cells, it couldn't fit into
         // multiple columns, so fall back to listing one per line.
@@ -59,8 +65,7 @@ impl Render<'_, '_> {
                 writeln!(w, "{}", name_cell.strings())?;
             }
             Ok(())
-        }
-        else {
+        } else {
             write!(w, "{grid}")
         }
     }

--- a/src/output/grid_details.rs
+++ b/src/output/grid_details.rs
@@ -5,18 +5,19 @@ use std::io::{self, Write};
 use nu_ansi_term::AnsiStrings;
 use term_grid as tg;
 
-use crate::fs::{Dir, File};
 use crate::fs::feature::VcsCache;
 use crate::fs::feature::xattr::FileAttributes;
 use crate::fs::filter::FileFilter;
+use crate::fs::{Dir, File};
 use crate::output::cell::TextCell;
-use crate::output::details::{Options as DetailsOptions, Row as DetailsRow, Render as DetailsRender};
+use crate::output::details::{
+    Options as DetailsOptions, Render as DetailsRender, Row as DetailsRow,
+};
 use crate::output::file_name::Options as FileStyle;
 use crate::output::grid::Options as GridOptions;
-use crate::output::table::{Table, Row as TableRow, Options as TableOptions};
-use crate::output::tree::{TreeParams, TreeDepth};
+use crate::output::table::{Options as TableOptions, Row as TableRow, Table};
+use crate::output::tree::{TreeDepth, TreeParams};
 use crate::theme::Theme;
-
 
 #[derive(PartialEq, Eq, Debug)]
 pub struct Options {
@@ -31,7 +32,6 @@ impl Options {
     }
 }
 
-
 /// The grid-details view can be configured to revert to just a details view
 /// (with one column) if it wouldn't produce enough rows of output.
 ///
@@ -41,7 +41,6 @@ impl Options {
 /// larger directory listings.
 #[derive(PartialEq, Eq, Debug, Copy, Clone)]
 pub enum RowThreshold {
-
     /// Only use grid-details view if it would result in at least this many
     /// rows of output.
     MinimumRows(usize),
@@ -50,9 +49,7 @@ pub enum RowThreshold {
     AlwaysGrid,
 }
 
-
 pub struct Render<'a> {
-
     /// The directory that's being rendered here.
     /// We need this to know which columns to put in the output.
     pub dir: Option<&'a Dir>,
@@ -99,7 +96,6 @@ struct RenderedGrid {
 }
 
 impl<'a> Render<'a> {
-
     /// Create a temporary Details render that gets used for the columns of
     /// the grid-details render that's being generated.
     ///
@@ -108,15 +104,15 @@ impl<'a> Render<'a> {
     /// *n* files into each column's table, not all of them.
     fn details_for_column(&self) -> DetailsRender<'a> {
         DetailsRender {
-            dir:           self.dir,
-            files:         Vec::new(),
-            theme:         self.theme,
-            file_style:    self.file_style,
-            opts:          self.details,
-            recurse:       None,
-            filter:        self.filter,
-            vcs_ignoring:  self.vcs_ignoring,
-            vcs:           self.vcs,
+            dir: self.dir,
+            files: Vec::new(),
+            theme: self.theme,
+            file_style: self.file_style,
+            opts: self.details,
+            recurse: None,
+            filter: self.filter,
+            vcs_ignoring: self.vcs_ignoring,
+            vcs: self.vcs,
         }
     }
 
@@ -126,15 +122,15 @@ impl<'a> Render<'a> {
     /// not available, so we downgrade.
     pub fn give_up(self) -> DetailsRender<'a> {
         DetailsRender {
-            dir:           self.dir,
-            files:         self.files,
-            theme:         self.theme,
-            file_style:    self.file_style,
-            opts:          self.details,
-            recurse:       None,
-            filter:        self.filter,
-            vcs_ignoring:  self.vcs_ignoring,
-            vcs:           self.vcs,
+            dir: self.dir,
+            files: self.files,
+            theme: self.theme,
+            file_style: self.file_style,
+            opts: self.details,
+            recurse: None,
+            filter: self.filter,
+            vcs_ignoring: self.vcs_ignoring,
+            vcs: self.vcs,
         }
     }
 
@@ -143,38 +139,52 @@ impl<'a> Render<'a> {
 
     pub fn render<W: Write>(mut self, w: &mut W) -> io::Result<()> {
         if let Some(rendered) = self.find_fitting_grid() {
-            let direction = if self.grid.across { tg::Direction::LeftToRight }
-                                           else { tg::Direction::TopToBottom };
+            let direction = if self.grid.across {
+                tg::Direction::LeftToRight
+            } else {
+                tg::Direction::TopToBottom
+            };
 
-            let grid = tg::Grid::new(rendered.cells, tg::GridOptions {
-                direction,
-                filling: tg::Filling::Spaces(4),
-                width:   self.console_width,
-            });
+            let grid = tg::Grid::new(
+                rendered.cells,
+                tg::GridOptions {
+                    direction,
+                    filling: tg::Filling::Spaces(4),
+                    width: self.console_width,
+                },
+            );
 
             write!(w, "{grid}")
-        }
-        else {
+        } else {
             self.give_up().render(w).map(|_| ())
         }
     }
 
     fn find_fitting_grid(&mut self) -> Option<RenderedGrid> {
-        let options = self.details.table.as_ref().expect("Details table options not given!");
+        let options = self
+            .details
+            .table
+            .as_ref()
+            .expect("Details table options not given!");
 
         let drender = self.details_for_column();
 
         let (first_table, _) = self.make_table(options, &drender);
 
-        let rows = self.files.iter()
-                       .map(|file| first_table.row_for_file(file, file_has_xattrs(file)))
-                       .collect::<Vec<_>>();
+        let rows = self
+            .files
+            .iter()
+            .map(|file| first_table.row_for_file(file, file_has_xattrs(file)))
+            .collect::<Vec<_>>();
 
-        let file_names = self.files.iter()
-                             .map(|file| self.file_style.for_file(file, self.theme).paint().promote())
-                             .collect::<Vec<_>>();
+        let file_names = self
+            .files
+            .iter()
+            .map(|file| self.file_style.for_file(file, self.theme).paint().promote())
+            .collect::<Vec<_>>();
 
-        let mut last_working = self.make_rendered_grid(1, options, &file_names, rows.clone(), &drender);
+        let mut last_working =
+            self.make_rendered_grid(1, options, &file_names, rows.clone(), &drender);
 
         if file_names.len() == 1 {
             return Some(last_working);
@@ -183,7 +193,8 @@ impl<'a> Render<'a> {
         // If we can't fit everything in a grid 100 columns wide, then
         // something has gone seriously awry
         for column_count in 2..100 {
-            let rendered = self.make_rendered_grid(column_count, options, &file_names, rows.clone(), &drender);
+            let rendered =
+                self.make_rendered_grid(column_count, options, &file_names, rows.clone(), &drender);
 
             let the_grid_fits = rendered_grid_fits(&rendered, self.console_width);
 
@@ -197,9 +208,10 @@ impl<'a> Render<'a> {
                 // it worthwhile (according to LX_GRID_ROWS), then just resort
                 // to the lines view.
                 if let RowThreshold::MinimumRows(thresh) = self.row_threshold
-                    && last_working.row_count < thresh {
-                        return None;
-                    }
+                    && last_working.row_count < thresh
+                {
+                    return None;
+                }
 
                 return Some(last_working);
             }
@@ -208,11 +220,23 @@ impl<'a> Render<'a> {
         None
     }
 
-    fn make_table(&mut self, options: &'a TableOptions, drender: &DetailsRender<'_>) -> (Table<'a>, Vec<DetailsRow>) {
+    fn make_table(
+        &mut self,
+        options: &'a TableOptions,
+        drender: &DetailsRender<'_>,
+    ) -> (Table<'a>, Vec<DetailsRow>) {
         match (self.vcs, self.dir) {
-            (Some(g), Some(d))  => if ! g.has_anything_for(&d.path) { self.vcs = None },
-            (Some(g), None)     => if ! self.files.iter().any(|f| g.has_anything_for(&f.path)) { self.vcs = None },
-            (None,    _)        => {/* Keep Git how it is */},
+            (Some(g), Some(d)) => {
+                if !g.has_anything_for(&d.path) {
+                    self.vcs = None
+                }
+            }
+            (Some(g), None) => {
+                if !self.files.iter().any(|f| g.has_anything_for(&f.path)) {
+                    self.vcs = None
+                }
+            }
+            (None, _) => { /* Keep Git how it is */ }
         }
 
         let mut table = Table::new(options, self.vcs, self.theme);
@@ -227,9 +251,16 @@ impl<'a> Render<'a> {
         (table, rows)
     }
 
-    fn make_rendered_grid(&mut self, column_count: usize, options: &'a TableOptions, file_names: &[TextCell], rows: Vec<TableRow>, drender: &DetailsRender<'_>) -> RenderedGrid {
+    fn make_rendered_grid(
+        &mut self,
+        column_count: usize,
+        options: &'a TableOptions,
+        file_names: &[TextCell],
+        rows: Vec<TableRow>,
+        drender: &DetailsRender<'_>,
+    ) -> RenderedGrid {
         let mut tables = Vec::new();
-        for _ in 0 .. column_count {
+        for _ in 0..column_count {
             tables.push(self.make_table(options, drender));
         }
 
@@ -243,24 +274,28 @@ impl<'a> Render<'a> {
 
         for (i, (file_name, row)) in file_names.iter().zip(rows.into_iter()).enumerate() {
             let index = if self.grid.across {
-                    i % column_count
-                }
-                else {
-                    i / original_height
-                };
+                i % column_count
+            } else {
+                i / original_height
+            };
 
             let (ref mut table, ref mut rows) = tables[index];
             table.add_widths(&row);
-            let details_row = drender.render_file(row, file_name.clone(), TreeParams::new(TreeDepth::root(), false));
+            let details_row = drender.render_file(
+                row,
+                file_name.clone(),
+                TreeParams::new(TreeDepth::root(), false),
+            );
             rows.push(details_row);
         }
 
         let columns = tables
             .into_iter()
             .map(|(table, details_rows)| {
-                drender.iterate_with_table(table, details_rows)
-                       .collect::<Vec<_>>()
-                })
+                drender
+                    .iterate_with_table(table, details_rows)
+                    .collect::<Vec<_>>()
+            })
             .collect::<Vec<_>>();
 
         // Build the cell strings in the order expected by the grid.
@@ -269,15 +304,14 @@ impl<'a> Render<'a> {
         let mut cells = Vec::new();
 
         if self.grid.across {
-            for row in 0 .. height {
+            for row in 0..height {
                 for column in &columns {
                     if row < column.len() {
                         cells.push(AnsiStrings(&column[row].contents).to_string());
                     }
                 }
             }
-        }
-        else {
+        } else {
             for column in &columns {
                 for cell in column {
                     cells.push(AnsiStrings(&cell.contents).to_string());
@@ -292,7 +326,6 @@ impl<'a> Render<'a> {
         }
     }
 }
-
 
 /// Check whether a rendered grid fits within the given console width by
 /// computing the maximum visual width per column and summing with spacing.
@@ -311,12 +344,15 @@ fn rendered_grid_fits(rendered: &RenderedGrid, console_width: usize) -> bool {
     }
 
     // Total width = sum of column widths + 4 spaces between each pair
-    let spacing = if rendered.column_count > 1 { 4 * (rendered.column_count - 1) } else { 0 };
+    let spacing = if rendered.column_count > 1 {
+        4 * (rendered.column_count - 1)
+    } else {
+        0
+    };
     let total: usize = col_widths.iter().sum::<usize>() + spacing;
 
     total <= console_width
 }
-
 
 /// Compute the visual width of a string, stripping ANSI escape sequences.
 fn visual_width(s: &str) -> usize {
@@ -342,7 +378,6 @@ fn visual_width(s: &str) -> usize {
     width
 }
 
-
 fn divide_rounding_up(a: usize, b: usize) -> usize {
     let mut result = a / b;
 
@@ -353,10 +388,9 @@ fn divide_rounding_up(a: usize, b: usize) -> usize {
     result
 }
 
-
 fn file_has_xattrs(file: &File<'_>) -> bool {
     match file.path.attributes() {
-        Ok(attrs)  => ! attrs.is_empty(),
-        Err(_)     => false,
+        Ok(attrs) => !attrs.is_empty(),
+        Err(_) => false,
     }
 }

--- a/src/output/icons.rs
+++ b/src/output/icons.rs
@@ -4,12 +4,10 @@ use crate::fs::File;
 use std::collections::HashMap;
 use std::sync::LazyLock;
 
-
 /// Icons for media-type classes (audio, image, video).
 const ICON_AUDIO: char = '\u{f001}'; //
 const ICON_IMAGE: char = '\u{f1c5}'; //
 const ICON_VIDEO: char = '\u{f03d}'; //
-
 
 /// Converts the style used to paint a file name into the style that should be
 /// used to paint an icon.
@@ -20,57 +18,57 @@ const ICON_VIDEO: char = '\u{f03d}'; //
 /// - Attributes such as bold or underline should not be used to paint the
 ///   icon, as they can make it look weird.
 pub fn iconify_style(style: Style) -> Style {
-    style.background.or(style.foreground)
-         .map(Style::from)
-         .unwrap_or_default()
+    style
+        .background
+        .or(style.foreground)
+        .map(Style::from)
+        .unwrap_or_default()
 }
 
-
-
 static MAP_BY_NAME: LazyLock<HashMap<&'static str, char>> = LazyLock::new(|| {
-        let mut m = HashMap::new();
-        m.insert(".Trash", '\u{f1f8}'); // 
-        m.insert(".atom", '\u{e764}'); // 
-        m.insert(".bashprofile", '\u{e615}'); // 
-        m.insert(".bashrc", '\u{f489}'); // 
-        m.insert(".git", '\u{f1d3}'); // 
-        m.insert(".gitattributes", '\u{f1d3}'); // 
-        m.insert(".gitconfig", '\u{f1d3}'); // 
-        m.insert(".github", '\u{f408}'); // 
-        m.insert(".gitignore", '\u{f1d3}'); // 
-        m.insert(".gitmodules", '\u{f1d3}'); // 
-        m.insert(".rvm", '\u{e21e}'); // 
-        m.insert(".vimrc", '\u{e62b}'); // 
-        m.insert(".vscode", '\u{e70c}'); // 
-        m.insert(".zshrc", '\u{f489}'); // 
-        m.insert("Cargo.lock", '\u{e7a8}'); // 
-        m.insert("bin", '\u{e5fc}'); // 
-        m.insert("config", '\u{e5fc}'); // 
-        m.insert("docker-compose.yml", '\u{f308}'); // 
-        m.insert("Dockerfile", '\u{f308}'); // 
-        m.insert("ds_store", '\u{f179}'); // 
-        m.insert("gitignore_global", '\u{f1d3}'); // 
-        m.insert("go.mod", '\u{e626}'); // 
-        m.insert("go.sum", '\u{e626}'); // 
-        m.insert("gradle", '\u{e256}'); // 
-        m.insert("gruntfile.coffee", '\u{e611}'); // 
-        m.insert("gruntfile.js", '\u{e611}'); // 
-        m.insert("gruntfile.ls", '\u{e611}'); // 
-        m.insert("gulpfile.coffee", '\u{e610}'); // 
-        m.insert("gulpfile.js", '\u{e610}'); // 
-        m.insert("gulpfile.ls", '\u{e610}'); // 
-        m.insert("hidden", '\u{f023}'); // 
-        m.insert("include", '\u{e5fc}'); // 
-        m.insert("lib", '\u{f121}'); // 
-        m.insert("localized", '\u{f179}'); // 
-        m.insert("Makefile", '\u{f489}'); // 
-        m.insert("node_modules", '\u{e718}'); // 
-        m.insert("npmignore", '\u{e71e}'); // 
-        m.insert("PKGBUILD", '\u{f303}'); // 
-        m.insert("rubydoc", '\u{e73b}'); // 
-        m.insert("yarn.lock", '\u{e718}'); // 
+    let mut m = HashMap::new();
+    m.insert(".Trash", '\u{f1f8}'); // 
+    m.insert(".atom", '\u{e764}'); // 
+    m.insert(".bashprofile", '\u{e615}'); // 
+    m.insert(".bashrc", '\u{f489}'); // 
+    m.insert(".git", '\u{f1d3}'); // 
+    m.insert(".gitattributes", '\u{f1d3}'); // 
+    m.insert(".gitconfig", '\u{f1d3}'); // 
+    m.insert(".github", '\u{f408}'); // 
+    m.insert(".gitignore", '\u{f1d3}'); // 
+    m.insert(".gitmodules", '\u{f1d3}'); // 
+    m.insert(".rvm", '\u{e21e}'); // 
+    m.insert(".vimrc", '\u{e62b}'); // 
+    m.insert(".vscode", '\u{e70c}'); // 
+    m.insert(".zshrc", '\u{f489}'); // 
+    m.insert("Cargo.lock", '\u{e7a8}'); // 
+    m.insert("bin", '\u{e5fc}'); // 
+    m.insert("config", '\u{e5fc}'); // 
+    m.insert("docker-compose.yml", '\u{f308}'); // 
+    m.insert("Dockerfile", '\u{f308}'); // 
+    m.insert("ds_store", '\u{f179}'); // 
+    m.insert("gitignore_global", '\u{f1d3}'); // 
+    m.insert("go.mod", '\u{e626}'); // 
+    m.insert("go.sum", '\u{e626}'); // 
+    m.insert("gradle", '\u{e256}'); // 
+    m.insert("gruntfile.coffee", '\u{e611}'); // 
+    m.insert("gruntfile.js", '\u{e611}'); // 
+    m.insert("gruntfile.ls", '\u{e611}'); // 
+    m.insert("gulpfile.coffee", '\u{e610}'); // 
+    m.insert("gulpfile.js", '\u{e610}'); // 
+    m.insert("gulpfile.ls", '\u{e610}'); // 
+    m.insert("hidden", '\u{f023}'); // 
+    m.insert("include", '\u{e5fc}'); // 
+    m.insert("lib", '\u{f121}'); // 
+    m.insert("localized", '\u{f179}'); // 
+    m.insert("Makefile", '\u{f489}'); // 
+    m.insert("node_modules", '\u{e718}'); // 
+    m.insert("npmignore", '\u{e71e}'); // 
+    m.insert("PKGBUILD", '\u{f303}'); // 
+    m.insert("rubydoc", '\u{e73b}'); // 
+    m.insert("yarn.lock", '\u{e718}'); // 
 
-        m
+    m
 });
 
 /// Check if a file matches a media-type class and return its icon.
@@ -81,10 +79,10 @@ fn class_icon(file: &File<'_>) -> Option<char> {
         let mut mappings = Vec::new();
 
         let class_to_icon: &[(&str, char)] = &[
-            ("music",    ICON_AUDIO),
+            ("music", ICON_AUDIO),
             ("lossless", ICON_AUDIO),
-            ("image",    ICON_IMAGE),
-            ("video",    ICON_VIDEO),
+            ("image", ICON_IMAGE),
+            ("video", ICON_VIDEO),
         ];
 
         for &(class_name, icon) in class_to_icon {
@@ -100,285 +98,286 @@ fn class_icon(file: &File<'_>) -> Option<char> {
     });
 
     let name = &file.name;
-    CLASS_ICONS.iter()
+    CLASS_ICONS
+        .iter()
         .find(|(pat, _)| pat.matches(name))
         .map(|(_, icon)| *icon)
 }
 
 pub fn icon_for_file(file: &File<'_>) -> char {
-    if let Some(icon) = MAP_BY_NAME.get(file.name.as_str()) { *icon }
-    else if file.points_to_directory() {
+    if let Some(icon) = MAP_BY_NAME.get(file.name.as_str()) {
+        *icon
+    } else if file.points_to_directory() {
         match file.name.as_str() {
-            "bin"           => '\u{e5fc}', // 
-            ".git"          => '\u{f1d3}', // 
-            ".idea"         => '\u{e7b5}', // 
-            _               => '\u{f115}'  // 
+            "bin" => '\u{e5fc}',   // 
+            ".git" => '\u{f1d3}',  // 
+            ".idea" => '\u{e7b5}', // 
+            _ => '\u{f115}',       // 
         }
-    }
-    else if let Some(icon) = class_icon(file) { icon }
-    else if let Some(ext) = file.ext.as_ref() {
+    } else if let Some(icon) = class_icon(file) {
+        icon
+    } else if let Some(ext) = file.ext.as_ref() {
         match ext.as_str() {
-            "ai"            => '\u{e7b4}', // 
-            "android"       => '\u{e70e}', // 
-            "apk"           => '\u{e70e}', // 
-            "apple"         => '\u{f179}', // 
-            "avi"           => '\u{f03d}', // 
-            "avif"          => '\u{f1c5}', // 
-            "avro"          => '\u{e60b}', // 
-            "awk"           => '\u{f489}', // 
-            "bash"          => '\u{f489}', // 
-            "bash_history"  => '\u{f489}', // 
-            "bash_profile"  => '\u{f489}', // 
-            "bashrc"        => '\u{f489}', // 
-            "bat"           => '\u{f17a}', // 
-            "bats"          => '\u{f489}', // 
-            "bmp"           => '\u{f1c5}', // 
-            "bz"            => '\u{f410}', // 
-            "bz2"           => '\u{f410}', // 
-            "c"             => '\u{e61e}', // 
-            "c++"           => '\u{e61d}', // 
-            "cab"           => '\u{e70f}', // 
-            "cc"            => '\u{e61d}', // 
-            "cfg"           => '\u{e615}', // 
-            "class"         => '\u{e256}', // 
-            "clj"           => '\u{e768}', // 
-            "cljs"          => '\u{e76a}', // 
-            "cls"           => '\u{f034}', // 
-            "cmd"           => '\u{e70f}', // 
-            "coffee"        => '\u{f0f4}', // 
-            "conf"          => '\u{e615}', // 
-            "cp"            => '\u{e61d}', // 
-            "cpio"          => '\u{f410}', // 
-            "cpp"           => '\u{e61d}', // 
-            "cs"            => '\u{f031b}', // 󰌛
-            "csh"           => '\u{f489}', // 
-            "cshtml"        => '\u{f1fa}', // 
-            "csproj"        => '\u{f031b}', // 󰌛
-            "css"           => '\u{e749}', // 
-            "csv"           => '\u{f1c3}', // 
-            "csx"           => '\u{f031b}', // 󰌛
-            "cxx"           => '\u{e61d}', // 
-            "d"             => '\u{e7af}', // 
-            "dart"          => '\u{e798}', // 
-            "db"            => '\u{f1c0}', // 
-            "deb"           => '\u{e77d}', // 
-            "diff"          => '\u{f440}', // 
-            "djvu"          => '\u{f02d}', // 
-            "dll"           => '\u{e70f}', // 
-            "doc"           => '\u{f1c2}', // 
-            "docx"          => '\u{f1c2}', // 
-            "ds_store"      => '\u{f179}', // 
-            "DS_store"      => '\u{f179}', // 
-            "dump"          => '\u{f1c0}', // 
-            "ebook"         => '\u{e28b}', // 
-            "ebuild"        => '\u{f30d}', // 
-            "editorconfig"  => '\u{e615}', // 
-            "ejs"           => '\u{e618}', // 
-            "elm"           => '\u{e62c}', // 
-            "env"           => '\u{f462}', // 
-            "eot"           => '\u{f031}', // 
-            "epub"          => '\u{e28a}', // 
-            "erb"           => '\u{e73b}', // 
-            "erl"           => '\u{e7b1}', // 
-            "ex"            => '\u{e62d}', // 
-            "exe"           => '\u{f17a}', // 
-            "exs"           => '\u{e62d}', // 
-            "fish"          => '\u{f489}', // 
-            "flac"          => '\u{f001}', // 
-            "flv"           => '\u{f03d}', // 
-            "font"          => '\u{f031}', // 
-            "fs"            => '\u{e7a7}', // 
-            "fsi"           => '\u{e7a7}', // 
-            "fsx"           => '\u{e7a7}', // 
-            "gdoc"          => '\u{f1c2}', // 
-            "gem"           => '\u{e21e}', // 
-            "gemfile"       => '\u{e21e}', // 
-            "gemspec"       => '\u{e21e}', // 
-            "gform"         => '\u{f298}', // 
-            "gif"           => '\u{f1c5}', // 
-            "git"           => '\u{f1d3}', // 
-            "gitattributes" => '\u{f1d3}', // 
-            "gitignore"     => '\u{f1d3}', // 
-            "gitmodules"    => '\u{f1d3}', // 
-            "go"            => '\u{e626}', // 
-            "gradle"        => '\u{e256}', // 
-            "groovy"        => '\u{e775}', // 
-            "gsheet"        => '\u{f1c3}', // 
-            "gslides"       => '\u{f1c4}', // 
-            "guardfile"     => '\u{e21e}', // 
-            "gz"            => '\u{f410}', // 
-            "h"             => '\u{f0fd}', // 
-            "hbs"           => '\u{e60f}', // 
-            "hpp"           => '\u{f0fd}', // 
-            "hs"            => '\u{e777}', // 
-            "htm"           => '\u{f13b}', // 
-            "html"          => '\u{f13b}', // 
-            "hxx"           => '\u{f0fd}', // 
-            "ico"           => '\u{f1c5}', // 
-            "image"         => '\u{f1c5}', // 
-            "img"           => '\u{e271}', // 
-            "iml"           => '\u{e7b5}', // 
-            "ini"           => '\u{f17a}', // 
-            "ipynb"         => '\u{e678}', // 
-            "iso"           => '\u{e271}', // 
-            "j2c"           => '\u{f1c5}', // 
-            "j2k"           => '\u{f1c5}', // 
-            "jad"           => '\u{e256}', // 
-            "jar"           => '\u{e256}', // 
-            "java"          => '\u{e256}', // 
-            "jfi"           => '\u{f1c5}', // 
-            "jfif"          => '\u{f1c5}', // 
-            "jif"           => '\u{f1c5}', // 
-            "jl"            => '\u{e624}', // 
-            "jmd"           => '\u{f48a}', // 
-            "jp2"           => '\u{f1c5}', // 
-            "jpe"           => '\u{f1c5}', // 
-            "jpeg"          => '\u{f1c5}', // 
-            "jpg"           => '\u{f1c5}', // 
-            "jpx"           => '\u{f1c5}', // 
-            "js"            => '\u{e74e}', // 
-            "json"          => '\u{e60b}', // 
-            "jsx"           => '\u{e7ba}', // 
-            "jxl"           => '\u{f1c5}', // 
-            "ksh"           => '\u{f489}', // 
-            "latex"         => '\u{f034}', // 
-            "less"          => '\u{e758}', // 
-            "lhs"           => '\u{e777}', // 
-            "license"       => '\u{f0219}', // 󰈙
-            "localized"     => '\u{f179}', // 
-            "lock"          => '\u{f023}', // 
-            "log"           => '\u{f18d}', // 
-            "lua"           => '\u{e620}', // 
-            "lz"            => '\u{f410}', // 
-            "lz4"           => '\u{f410}', // 
-            "lzh"           => '\u{f410}', // 
-            "lzma"          => '\u{f410}', // 
-            "lzo"           => '\u{f410}', // 
-            "m"             => '\u{e61e}', // 
-            "mm"            => '\u{e61d}', // 
-            "m4a"           => '\u{f001}', // 
-            "markdown"      => '\u{f48a}', // 
-            "md"            => '\u{f48a}', // 
-            "mjs"           => '\u{e74e}', // 
-            "mk"            => '\u{f489}', // 
-            "mkd"           => '\u{f48a}', // 
-            "mkv"           => '\u{f03d}', // 
-            "mobi"          => '\u{e28b}', // 
-            "mov"           => '\u{f03d}', // 
-            "mp3"           => '\u{f001}', // 
-            "mp4"           => '\u{f03d}', // 
-            "msi"           => '\u{e70f}', // 
-            "mustache"      => '\u{e60f}', // 
-            "nix"           => '\u{f313}', // 
-            "node"          => '\u{f0399}', // 󰎙
-            "npmignore"     => '\u{e71e}', // 
-            "odp"           => '\u{f1c4}', // 
-            "ods"           => '\u{f1c3}', // 
-            "odt"           => '\u{f1c2}', // 
-            "ogg"           => '\u{f001}', // 
-            "ogv"           => '\u{f03d}', // 
-            "otf"           => '\u{f031}', // 
-            "part"          => '\u{f43a}', // 
-            "patch"         => '\u{f440}', // 
-            "pdf"           => '\u{f1c1}', // 
-            "php"           => '\u{e73d}', // 
-            "pl"            => '\u{e769}', // 
-            "plx"           => '\u{e769}', // 
-            "pm"            => '\u{e769}', // 
-            "png"           => '\u{f1c5}', // 
-            "pod"           => '\u{e769}', // 
-            "ppt"           => '\u{f1c4}', // 
-            "pptx"          => '\u{f1c4}', // 
-            "procfile"      => '\u{e21e}', // 
-            "properties"    => '\u{e60b}', // 
-            "ps1"           => '\u{f489}', // 
-            "psd"           => '\u{e7b8}', // 
-            "pxm"           => '\u{f1c5}', // 
-            "py"            => '\u{e606}', // 
-            "pyc"           => '\u{e606}', // 
-            "r"             => '\u{f25d}', // 
-            "rakefile"      => '\u{e21e}', // 
-            "rar"           => '\u{f410}', // 
-            "razor"         => '\u{f1fa}', // 
-            "rb"            => '\u{e21e}', // 
-            "rdata"         => '\u{f25d}', // 
-            "rdb"           => '\u{e76d}', // 
-            "rdoc"          => '\u{f48a}', // 
-            "rds"           => '\u{f25d}', // 
-            "readme"        => '\u{f48a}', // 
-            "rlib"          => '\u{e7a8}', // 
-            "rmd"           => '\u{f48a}', // 
-            "rpm"           => '\u{e7bb}', // 
-            "rs"            => '\u{e7a8}', // 
-            "rspec"         => '\u{e21e}', // 
-            "rspec_parallel"=> '\u{e21e}', // 
-            "rspec_status"  => '\u{e21e}', // 
-            "rss"           => '\u{f09e}', // 
-            "rtf"           => '\u{f0219}', // 󰈙
-            "ru"            => '\u{e21e}', // 
-            "rubydoc"       => '\u{e73b}', // 
-            "sass"          => '\u{e603}', // 
-            "scala"         => '\u{e737}', // 
-            "scss"          => '\u{e749}', // 
-            "sh"            => '\u{f489}', // 
-            "shell"         => '\u{f489}', // 
-            "slim"          => '\u{e73b}', // 
-            "sln"           => '\u{e70c}', // 
-            "so"            => '\u{f17c}', // 
-            "sql"           => '\u{f1c0}', // 
-            "sqlite3"       => '\u{e7c4}', // 
-            "sty"           => '\u{f034}', // 
-            "styl"          => '\u{e600}', // 
-            "stylus"        => '\u{e600}', // 
-            "svg"           => '\u{f1c5}', // 
-            "swift"         => '\u{e755}', // 
-            "t"             => '\u{e769}', // 
-            "tar"           => '\u{f410}', // 
-            "taz"           => '\u{f410}', // 
-            "tbz"           => '\u{f410}', // 
-            "tbz2"          => '\u{f410}', // 
-            "tex"           => '\u{f034}', // 
-            "tgz"           => '\u{f410}', // 
-            "tiff"          => '\u{f1c5}', // 
-            "tlz"           => '\u{f410}', // 
-            "toml"          => '\u{e615}', // 
-            "torrent"       => '\u{e275}', // 
-            "ts"            => '\u{e628}', // 
-            "tsv"           => '\u{f1c3}', // 
-            "tsx"           => '\u{e7ba}', // 
-            "ttf"           => '\u{f031}', // 
-            "twig"          => '\u{e61c}', // 
-            "txt"           => '\u{f15c}', // 
-            "txz"           => '\u{f410}', // 
-            "tz"            => '\u{f410}', // 
-            "tzo"           => '\u{f410}', // 
-            "video"         => '\u{f03d}', // 
-            "vim"           => '\u{e62b}', // 
-            "vue"           => '\u{f0844}', // 󰡄
-            "war"           => '\u{e256}', // 
-            "wav"           => '\u{f001}', // 
-            "webm"          => '\u{f03d}', // 
-            "webp"          => '\u{f1c5}', // 
-            "windows"       => '\u{f17a}', // 
-            "woff"          => '\u{f031}', // 
-            "woff2"         => '\u{f031}', // 
-            "xhtml"         => '\u{f13b}', // 
-            "xls"           => '\u{f1c3}', // 
-            "xlsx"          => '\u{f1c3}', // 
-            "xml"           => '\u{f05c0}', // 󰗀
-            "xul"           => '\u{f05c0}', // 󰗀
-            "xz"            => '\u{f410}', // 
-            "yaml"          => '\u{f481}', // 
-            "yml"           => '\u{f481}', // 
-            "zip"           => '\u{f410}', // 
-            "zsh"           => '\u{f489}', // 
-            "zsh-theme"     => '\u{f489}', // 
-            "zshrc"         => '\u{f489}', // 
-            "zst"           => '\u{f410}', // 
-            _               => '\u{f15b}'  // 
+            "ai" => '\u{e7b4}',             // 
+            "android" => '\u{e70e}',        // 
+            "apk" => '\u{e70e}',            // 
+            "apple" => '\u{f179}',          // 
+            "avi" => '\u{f03d}',            // 
+            "avif" => '\u{f1c5}',           // 
+            "avro" => '\u{e60b}',           // 
+            "awk" => '\u{f489}',            // 
+            "bash" => '\u{f489}',           // 
+            "bash_history" => '\u{f489}',   // 
+            "bash_profile" => '\u{f489}',   // 
+            "bashrc" => '\u{f489}',         // 
+            "bat" => '\u{f17a}',            // 
+            "bats" => '\u{f489}',           // 
+            "bmp" => '\u{f1c5}',            // 
+            "bz" => '\u{f410}',             // 
+            "bz2" => '\u{f410}',            // 
+            "c" => '\u{e61e}',              // 
+            "c++" => '\u{e61d}',            // 
+            "cab" => '\u{e70f}',            // 
+            "cc" => '\u{e61d}',             // 
+            "cfg" => '\u{e615}',            // 
+            "class" => '\u{e256}',          // 
+            "clj" => '\u{e768}',            // 
+            "cljs" => '\u{e76a}',           // 
+            "cls" => '\u{f034}',            // 
+            "cmd" => '\u{e70f}',            // 
+            "coffee" => '\u{f0f4}',         // 
+            "conf" => '\u{e615}',           // 
+            "cp" => '\u{e61d}',             // 
+            "cpio" => '\u{f410}',           // 
+            "cpp" => '\u{e61d}',            // 
+            "cs" => '\u{f031b}',            // 󰌛
+            "csh" => '\u{f489}',            // 
+            "cshtml" => '\u{f1fa}',         // 
+            "csproj" => '\u{f031b}',        // 󰌛
+            "css" => '\u{e749}',            // 
+            "csv" => '\u{f1c3}',            // 
+            "csx" => '\u{f031b}',           // 󰌛
+            "cxx" => '\u{e61d}',            // 
+            "d" => '\u{e7af}',              // 
+            "dart" => '\u{e798}',           // 
+            "db" => '\u{f1c0}',             // 
+            "deb" => '\u{e77d}',            // 
+            "diff" => '\u{f440}',           // 
+            "djvu" => '\u{f02d}',           // 
+            "dll" => '\u{e70f}',            // 
+            "doc" => '\u{f1c2}',            // 
+            "docx" => '\u{f1c2}',           // 
+            "ds_store" => '\u{f179}',       // 
+            "DS_store" => '\u{f179}',       // 
+            "dump" => '\u{f1c0}',           // 
+            "ebook" => '\u{e28b}',          // 
+            "ebuild" => '\u{f30d}',         // 
+            "editorconfig" => '\u{e615}',   // 
+            "ejs" => '\u{e618}',            // 
+            "elm" => '\u{e62c}',            // 
+            "env" => '\u{f462}',            // 
+            "eot" => '\u{f031}',            // 
+            "epub" => '\u{e28a}',           // 
+            "erb" => '\u{e73b}',            // 
+            "erl" => '\u{e7b1}',            // 
+            "ex" => '\u{e62d}',             // 
+            "exe" => '\u{f17a}',            // 
+            "exs" => '\u{e62d}',            // 
+            "fish" => '\u{f489}',           // 
+            "flac" => '\u{f001}',           // 
+            "flv" => '\u{f03d}',            // 
+            "font" => '\u{f031}',           // 
+            "fs" => '\u{e7a7}',             // 
+            "fsi" => '\u{e7a7}',            // 
+            "fsx" => '\u{e7a7}',            // 
+            "gdoc" => '\u{f1c2}',           // 
+            "gem" => '\u{e21e}',            // 
+            "gemfile" => '\u{e21e}',        // 
+            "gemspec" => '\u{e21e}',        // 
+            "gform" => '\u{f298}',          // 
+            "gif" => '\u{f1c5}',            // 
+            "git" => '\u{f1d3}',            // 
+            "gitattributes" => '\u{f1d3}',  // 
+            "gitignore" => '\u{f1d3}',      // 
+            "gitmodules" => '\u{f1d3}',     // 
+            "go" => '\u{e626}',             // 
+            "gradle" => '\u{e256}',         // 
+            "groovy" => '\u{e775}',         // 
+            "gsheet" => '\u{f1c3}',         // 
+            "gslides" => '\u{f1c4}',        // 
+            "guardfile" => '\u{e21e}',      // 
+            "gz" => '\u{f410}',             // 
+            "h" => '\u{f0fd}',              // 
+            "hbs" => '\u{e60f}',            // 
+            "hpp" => '\u{f0fd}',            // 
+            "hs" => '\u{e777}',             // 
+            "htm" => '\u{f13b}',            // 
+            "html" => '\u{f13b}',           // 
+            "hxx" => '\u{f0fd}',            // 
+            "ico" => '\u{f1c5}',            // 
+            "image" => '\u{f1c5}',          // 
+            "img" => '\u{e271}',            // 
+            "iml" => '\u{e7b5}',            // 
+            "ini" => '\u{f17a}',            // 
+            "ipynb" => '\u{e678}',          // 
+            "iso" => '\u{e271}',            // 
+            "j2c" => '\u{f1c5}',            // 
+            "j2k" => '\u{f1c5}',            // 
+            "jad" => '\u{e256}',            // 
+            "jar" => '\u{e256}',            // 
+            "java" => '\u{e256}',           // 
+            "jfi" => '\u{f1c5}',            // 
+            "jfif" => '\u{f1c5}',           // 
+            "jif" => '\u{f1c5}',            // 
+            "jl" => '\u{e624}',             // 
+            "jmd" => '\u{f48a}',            // 
+            "jp2" => '\u{f1c5}',            // 
+            "jpe" => '\u{f1c5}',            // 
+            "jpeg" => '\u{f1c5}',           // 
+            "jpg" => '\u{f1c5}',            // 
+            "jpx" => '\u{f1c5}',            // 
+            "js" => '\u{e74e}',             // 
+            "json" => '\u{e60b}',           // 
+            "jsx" => '\u{e7ba}',            // 
+            "jxl" => '\u{f1c5}',            // 
+            "ksh" => '\u{f489}',            // 
+            "latex" => '\u{f034}',          // 
+            "less" => '\u{e758}',           // 
+            "lhs" => '\u{e777}',            // 
+            "license" => '\u{f0219}',       // 󰈙
+            "localized" => '\u{f179}',      // 
+            "lock" => '\u{f023}',           // 
+            "log" => '\u{f18d}',            // 
+            "lua" => '\u{e620}',            // 
+            "lz" => '\u{f410}',             // 
+            "lz4" => '\u{f410}',            // 
+            "lzh" => '\u{f410}',            // 
+            "lzma" => '\u{f410}',           // 
+            "lzo" => '\u{f410}',            // 
+            "m" => '\u{e61e}',              // 
+            "mm" => '\u{e61d}',             // 
+            "m4a" => '\u{f001}',            // 
+            "markdown" => '\u{f48a}',       // 
+            "md" => '\u{f48a}',             // 
+            "mjs" => '\u{e74e}',            // 
+            "mk" => '\u{f489}',             // 
+            "mkd" => '\u{f48a}',            // 
+            "mkv" => '\u{f03d}',            // 
+            "mobi" => '\u{e28b}',           // 
+            "mov" => '\u{f03d}',            // 
+            "mp3" => '\u{f001}',            // 
+            "mp4" => '\u{f03d}',            // 
+            "msi" => '\u{e70f}',            // 
+            "mustache" => '\u{e60f}',       // 
+            "nix" => '\u{f313}',            // 
+            "node" => '\u{f0399}',          // 󰎙
+            "npmignore" => '\u{e71e}',      // 
+            "odp" => '\u{f1c4}',            // 
+            "ods" => '\u{f1c3}',            // 
+            "odt" => '\u{f1c2}',            // 
+            "ogg" => '\u{f001}',            // 
+            "ogv" => '\u{f03d}',            // 
+            "otf" => '\u{f031}',            // 
+            "part" => '\u{f43a}',           // 
+            "patch" => '\u{f440}',          // 
+            "pdf" => '\u{f1c1}',            // 
+            "php" => '\u{e73d}',            // 
+            "pl" => '\u{e769}',             // 
+            "plx" => '\u{e769}',            // 
+            "pm" => '\u{e769}',             // 
+            "png" => '\u{f1c5}',            // 
+            "pod" => '\u{e769}',            // 
+            "ppt" => '\u{f1c4}',            // 
+            "pptx" => '\u{f1c4}',           // 
+            "procfile" => '\u{e21e}',       // 
+            "properties" => '\u{e60b}',     // 
+            "ps1" => '\u{f489}',            // 
+            "psd" => '\u{e7b8}',            // 
+            "pxm" => '\u{f1c5}',            // 
+            "py" => '\u{e606}',             // 
+            "pyc" => '\u{e606}',            // 
+            "r" => '\u{f25d}',              // 
+            "rakefile" => '\u{e21e}',       // 
+            "rar" => '\u{f410}',            // 
+            "razor" => '\u{f1fa}',          // 
+            "rb" => '\u{e21e}',             // 
+            "rdata" => '\u{f25d}',          // 
+            "rdb" => '\u{e76d}',            // 
+            "rdoc" => '\u{f48a}',           // 
+            "rds" => '\u{f25d}',            // 
+            "readme" => '\u{f48a}',         // 
+            "rlib" => '\u{e7a8}',           // 
+            "rmd" => '\u{f48a}',            // 
+            "rpm" => '\u{e7bb}',            // 
+            "rs" => '\u{e7a8}',             // 
+            "rspec" => '\u{e21e}',          // 
+            "rspec_parallel" => '\u{e21e}', // 
+            "rspec_status" => '\u{e21e}',   // 
+            "rss" => '\u{f09e}',            // 
+            "rtf" => '\u{f0219}',           // 󰈙
+            "ru" => '\u{e21e}',             // 
+            "rubydoc" => '\u{e73b}',        // 
+            "sass" => '\u{e603}',           // 
+            "scala" => '\u{e737}',          // 
+            "scss" => '\u{e749}',           // 
+            "sh" => '\u{f489}',             // 
+            "shell" => '\u{f489}',          // 
+            "slim" => '\u{e73b}',           // 
+            "sln" => '\u{e70c}',            // 
+            "so" => '\u{f17c}',             // 
+            "sql" => '\u{f1c0}',            // 
+            "sqlite3" => '\u{e7c4}',        // 
+            "sty" => '\u{f034}',            // 
+            "styl" => '\u{e600}',           // 
+            "stylus" => '\u{e600}',         // 
+            "svg" => '\u{f1c5}',            // 
+            "swift" => '\u{e755}',          // 
+            "t" => '\u{e769}',              // 
+            "tar" => '\u{f410}',            // 
+            "taz" => '\u{f410}',            // 
+            "tbz" => '\u{f410}',            // 
+            "tbz2" => '\u{f410}',           // 
+            "tex" => '\u{f034}',            // 
+            "tgz" => '\u{f410}',            // 
+            "tiff" => '\u{f1c5}',           // 
+            "tlz" => '\u{f410}',            // 
+            "toml" => '\u{e615}',           // 
+            "torrent" => '\u{e275}',        // 
+            "ts" => '\u{e628}',             // 
+            "tsv" => '\u{f1c3}',            // 
+            "tsx" => '\u{e7ba}',            // 
+            "ttf" => '\u{f031}',            // 
+            "twig" => '\u{e61c}',           // 
+            "txt" => '\u{f15c}',            // 
+            "txz" => '\u{f410}',            // 
+            "tz" => '\u{f410}',             // 
+            "tzo" => '\u{f410}',            // 
+            "video" => '\u{f03d}',          // 
+            "vim" => '\u{e62b}',            // 
+            "vue" => '\u{f0844}',           // 󰡄
+            "war" => '\u{e256}',            // 
+            "wav" => '\u{f001}',            // 
+            "webm" => '\u{f03d}',           // 
+            "webp" => '\u{f1c5}',           // 
+            "windows" => '\u{f17a}',        // 
+            "woff" => '\u{f031}',           // 
+            "woff2" => '\u{f031}',          // 
+            "xhtml" => '\u{f13b}',          // 
+            "xls" => '\u{f1c3}',            // 
+            "xlsx" => '\u{f1c3}',           // 
+            "xml" => '\u{f05c0}',           // 󰗀
+            "xul" => '\u{f05c0}',           // 󰗀
+            "xz" => '\u{f410}',             // 
+            "yaml" => '\u{f481}',           // 
+            "yml" => '\u{f481}',            // 
+            "zip" => '\u{f410}',            // 
+            "zsh" => '\u{f489}',            // 
+            "zsh-theme" => '\u{f489}',      // 
+            "zshrc" => '\u{f489}',          // 
+            "zst" => '\u{f410}',            // 
+            _ => '\u{f15b}',                // 
         }
-    }
-    else {
+    } else {
         '\u{f016}'
     }
 }

--- a/src/output/lines.rs
+++ b/src/output/lines.rs
@@ -5,9 +5,8 @@ use nu_ansi_term::AnsiStrings;
 use crate::fs::File;
 use crate::fs::filter::FileFilter;
 use crate::output::cell::TextCellContents;
-use crate::output::file_name::{Options as FileStyle};
+use crate::output::file_name::Options as FileStyle;
 use crate::theme::Theme;
-
 
 /// The lines view literally just displays each file, line-by-line.
 pub struct Render<'a> {

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,5 +1,6 @@
 pub use self::escape::escape;
 
+pub mod column_registry;
 pub mod details;
 pub mod file_name;
 pub mod grid;
@@ -9,12 +10,10 @@ pub mod lines;
 pub mod render;
 pub mod table;
 pub mod time;
-pub mod column_registry;
 
 mod cell;
 mod escape;
 mod tree;
-
 
 /// The **view** contains all information about how to format output.
 #[derive(Debug)]
@@ -53,7 +52,6 @@ impl View {
     }
 }
 
-
 /// The **mode** is the “type” of output.
 #[derive(PartialEq, Eq, Debug)]
 #[allow(clippy::large_enum_variant)]
@@ -64,11 +62,9 @@ pub enum Mode {
     Lines,
 }
 
-
 /// The width of the terminal requested by the user.
 #[derive(PartialEq, Eq, Debug, Copy, Clone)]
 pub enum TerminalWidth {
-
     /// The user requested this specific number of columns.
     Set(usize),
 
@@ -83,8 +79,8 @@ impl TerminalWidth {
         // where the output goes.
 
         match self {
-            Self::Set(width)  => Some(width),
-            Self::Automatic   => terminal_size::terminal_size().map(|(w, _)| w.0.into()),
+            Self::Set(width) => Some(width),
+            Self::Automatic => terminal_size::terminal_size().map(|(w, _)| w.0.into()),
         }
     }
 }

--- a/src/output/render/blocks.rs
+++ b/src/output/render/blocks.rs
@@ -3,40 +3,39 @@ use nu_ansi_term::Style;
 use crate::fs::fields as f;
 use crate::output::cell::TextCell;
 
-
 impl f::Blocks {
     pub fn render<C: Colours>(&self, colours: &C) -> TextCell {
         match self {
-            Self::Some(blk)  => TextCell::paint(colours.block_count(), blk.to_string()),
-            Self::None       => TextCell::blank(colours.no_blocks()),
+            Self::Some(blk) => TextCell::paint(colours.block_count(), blk.to_string()),
+            Self::None => TextCell::blank(colours.no_blocks()),
         }
     }
 }
-
 
 pub trait Colours {
     fn block_count(&self) -> Style;
     fn no_blocks(&self) -> Style;
 }
 
-
 #[cfg(test)]
 pub mod test {
-    use nu_ansi_term::Style;
     use nu_ansi_term::Color::*;
+    use nu_ansi_term::Style;
 
     use super::Colours;
-    use crate::output::cell::TextCell;
     use crate::fs::fields as f;
-
+    use crate::output::cell::TextCell;
 
     struct TestColours;
 
     impl Colours for TestColours {
-        fn block_count(&self) -> Style { Red.blink() }
-        fn no_blocks(&self)   -> Style { Green.italic() }
+        fn block_count(&self) -> Style {
+            Red.blink()
+        }
+        fn no_blocks(&self) -> Style {
+            Green.italic()
+        }
     }
-
 
     #[test]
     fn blocklessness() {
@@ -45,7 +44,6 @@ pub mod test {
 
         assert_eq!(expected, blox.render(&TestColours));
     }
-
 
     #[test]
     fn blockfulity() {

--- a/src/output/render/filetype.rs
+++ b/src/output/render/filetype.rs
@@ -2,22 +2,20 @@ use nu_ansi_term::{AnsiString, Style};
 
 use crate::fs::fields as f;
 
-
 impl f::Type {
     pub fn render<C: Colours>(self, colours: &C) -> AnsiString<'static> {
         match self {
-            Self::File         => colours.normal().paint("."),
-            Self::Directory    => colours.directory().paint("d"),
-            Self::Pipe         => colours.pipe().paint("|"),
-            Self::Link         => colours.symlink().paint("l"),
-            Self::BlockDevice  => colours.block_device().paint("b"),
-            Self::CharDevice   => colours.char_device().paint("c"),
-            Self::Socket       => colours.socket().paint("s"),
-            Self::Special      => colours.special().paint("?"),
+            Self::File => colours.normal().paint("."),
+            Self::Directory => colours.directory().paint("d"),
+            Self::Pipe => colours.pipe().paint("|"),
+            Self::Link => colours.symlink().paint("l"),
+            Self::BlockDevice => colours.block_device().paint("b"),
+            Self::CharDevice => colours.char_device().paint("c"),
+            Self::Socket => colours.socket().paint("s"),
+            Self::Special => colours.special().paint("?"),
         }
     }
 }
-
 
 pub trait Colours {
     fn normal(&self) -> Style;

--- a/src/output/render/flags.rs
+++ b/src/output/render/flags.rs
@@ -3,7 +3,6 @@ use nu_ansi_term::Style;
 use crate::fs::fields as f;
 use crate::output::cell::TextCell;
 
-
 impl f::FileFlags {
     pub fn render(self, style: Style) -> TextCell {
         TextCell::paint(style, self.to_short_string())

--- a/src/output/render/groups.rs
+++ b/src/output/render/groups.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::sync::LazyLock;
 
 use nu_ansi_term::Style;
-use uzers::{Users, Groups};
+use uzers::{Groups, Users};
 
 use crate::fs::fields as f;
 use crate::output::cell::TextCell;
@@ -26,15 +26,14 @@ static MY_GROUPS: LazyLock<HashSet<u32>> = LazyLock::new(|| {
     groups
 });
 
-
 impl f::Group {
     /// Render the group as its name, falling back to the numeric GID
     /// if the name can't be resolved.  Used for the `--group` column.
-    pub fn render<C: Colours, U: Users+Groups>(self, colours: &C, users: &U) -> TextCell {
+    pub fn render<C: Colours, U: Users + Groups>(self, colours: &C, users: &U) -> TextCell {
         let style = self.style(colours, users, /* gid_column= */ false);
         match self.lookup_name(users) {
             Some(name) => TextCell::paint(style, name),
-            None       => TextCell::paint(style, self.0.to_string()),
+            None => TextCell::paint(style, self.0.to_string()),
         }
     }
 
@@ -42,12 +41,16 @@ impl f::Group {
     /// column.  Uses the dedicated `gid_*` style slots so themes can
     /// distinguish it visually from the name column while still
     /// cascading from the `group_*` slots when unset.
-    pub fn render_gid<C: Colours, U: Users+Groups>(self, colours: &C, users: &U) -> TextCell {
-        TextCell::paint(self.style(colours, users, /* gid_column= */ true), self.0.to_string())
+    pub fn render_gid<C: Colours, U: Users + Groups>(self, colours: &C, users: &U) -> TextCell {
+        TextCell::paint(
+            self.style(colours, users, /* gid_column= */ true),
+            self.0.to_string(),
+        )
     }
 
-    fn lookup_name<U: Users+Groups>(self, users: &U) -> Option<String> {
-        users.get_group_by_gid(self.0)
+    fn lookup_name<U: Users + Groups>(self, users: &U) -> Option<String> {
+        users
+            .get_group_by_gid(self.0)
             .map(|g| g.name().to_string_lossy().into())
     }
 
@@ -57,7 +60,12 @@ impl f::Group {
     /// `/etc/group` membership lists, so macOS Directory Services
     /// groups and LDAP groups are handled correctly.
     /// `gid_column` selects the `gid_*` style slots.
-    fn style<C: Colours, U: Users+Groups>(self, colours: &C, _users: &U, gid_column: bool) -> Style {
+    fn style<C: Colours, U: Users + Groups>(
+        self,
+        colours: &C,
+        _users: &U,
+        gid_column: bool,
+    ) -> Style {
         let tier = if self.0 == uzers::get_effective_gid() {
             GroupTier::Primary
         } else if MY_GROUPS.contains(&self.0) {
@@ -68,11 +76,11 @@ impl f::Group {
 
         match (gid_column, tier) {
             (false, GroupTier::Primary) => colours.yours(),
-            (false, GroupTier::Member)  => colours.member(),
-            (false, GroupTier::Other)   => colours.not_yours(),
-            (true,  GroupTier::Primary) => colours.gid_yours(),
-            (true,  GroupTier::Member)  => colours.gid_member(),
-            (true,  GroupTier::Other)   => colours.gid_not_yours(),
+            (false, GroupTier::Member) => colours.member(),
+            (false, GroupTier::Other) => colours.not_yours(),
+            (true, GroupTier::Primary) => colours.gid_yours(),
+            (true, GroupTier::Member) => colours.gid_member(),
+            (true, GroupTier::Other) => colours.gid_not_yours(),
         }
     }
 }
@@ -82,7 +90,6 @@ enum GroupTier {
     Member,
     Other,
 }
-
 
 pub trait Colours {
     fn yours(&self) -> Style;
@@ -94,7 +101,6 @@ pub trait Colours {
     fn gid_not_yours(&self) -> Style;
 }
 
-
 #[cfg(test)]
 #[allow(unused_results)]
 pub mod test {
@@ -102,11 +108,10 @@ pub mod test {
     use crate::fs::fields as f;
     use crate::output::cell::TextCell;
 
-    use uzers::Group;
-    use uzers::mock::MockUsers;
     use nu_ansi_term::Color::*;
     use nu_ansi_term::Style;
-
+    use uzers::Group;
+    use uzers::mock::MockUsers;
 
     /// Test colours with distinct slots for name/GID columns so
     /// tests can verify `render_gid` picks up the GID-specific
@@ -115,14 +120,25 @@ pub mod test {
     struct TestColours;
 
     impl Colours for TestColours {
-        fn yours(&self)         -> Style { Fixed(80).normal() }
-        fn member(&self)        -> Style { Fixed(84).normal() }
-        fn not_yours(&self)     -> Style { Fixed(81).normal() }
-        fn gid_yours(&self)     -> Style { Fixed(82).normal() }
-        fn gid_member(&self)    -> Style { Fixed(85).normal() }
-        fn gid_not_yours(&self) -> Style { Fixed(83).normal() }
+        fn yours(&self) -> Style {
+            Fixed(80).normal()
+        }
+        fn member(&self) -> Style {
+            Fixed(84).normal()
+        }
+        fn not_yours(&self) -> Style {
+            Fixed(81).normal()
+        }
+        fn gid_yours(&self) -> Style {
+            Fixed(82).normal()
+        }
+        fn gid_member(&self) -> Style {
+            Fixed(85).normal()
+        }
+        fn gid_not_yours(&self) -> Style {
+            Fixed(83).normal()
+        }
     }
-
 
     /// Use a GID that's guaranteed not in the test runner's real
     /// supplementary group set.
@@ -168,9 +184,7 @@ pub mod test {
     fn member_group() {
         // Pick a supplementary group that isn't the primary.
         let egid = uzers::get_effective_gid();
-        let member_gid = super::MY_GROUPS.iter()
-            .find(|&&g| g != egid)
-            .copied();
+        let member_gid = super::MY_GROUPS.iter().find(|&&g| g != egid).copied();
 
         if let Some(gid) = member_gid {
             let mut users = MockUsers::with_current_uid(uzers::get_current_uid());
@@ -187,6 +201,9 @@ pub mod test {
     fn overflow() {
         let group = f::Group(2_147_483_648);
         let expected = TextCell::paint_str(Fixed(83).normal(), "2147483648");
-        assert_eq!(expected, group.render_gid(&TestColours, &MockUsers::with_current_uid(0)));
+        assert_eq!(
+            expected,
+            group.render_gid(&TestColours, &MockUsers::with_current_uid(0))
+        );
     }
 }

--- a/src/output/render/inode.rs
+++ b/src/output/render/inode.rs
@@ -3,21 +3,18 @@ use nu_ansi_term::Style;
 use crate::fs::fields as f;
 use crate::output::cell::TextCell;
 
-
 impl f::Inode {
     pub fn render(self, style: Style) -> TextCell {
         TextCell::paint(style, self.0.to_string())
     }
 }
 
-
 #[cfg(test)]
 pub mod test {
-    use crate::output::cell::TextCell;
     use crate::fs::fields as f;
+    use crate::output::cell::TextCell;
 
     use nu_ansi_term::Color::*;
-
 
     #[test]
     fn blocklessness() {

--- a/src/output/render/links.rs
+++ b/src/output/render/links.rs
@@ -1,87 +1,98 @@
-use nu_ansi_term::Style;
 use locale::Numeric as NumericLocale;
+use nu_ansi_term::Style;
 
 use crate::fs::fields as f;
 use crate::output::cell::TextCell;
 
-
 impl f::Links {
     pub fn render<C: Colours>(&self, colours: &C, numeric: &NumericLocale) -> TextCell {
-        let style = if self.multiple { colours.multi_link_file() }
-                                else { colours.normal() };
+        let style = if self.multiple {
+            colours.multi_link_file()
+        } else {
+            colours.normal()
+        };
 
         TextCell::paint(style, numeric.format_int(self.count))
     }
 }
-
 
 pub trait Colours {
     fn normal(&self) -> Style;
     fn multi_link_file(&self) -> Style;
 }
 
-
 #[cfg(test)]
 pub mod test {
     use super::Colours;
-    use crate::output::cell::{TextCell, DisplayWidth};
     use crate::fs::fields as f;
+    use crate::output::cell::{DisplayWidth, TextCell};
 
+    use locale;
     use nu_ansi_term::Color::*;
     use nu_ansi_term::Style;
-    use locale;
-
 
     struct TestColours;
 
     impl Colours for TestColours {
-        fn normal(&self)           -> Style { Blue.normal() }
-        fn multi_link_file(&self)  -> Style { Blue.on(Red) }
+        fn normal(&self) -> Style {
+            Blue.normal()
+        }
+        fn multi_link_file(&self) -> Style {
+            Blue.on(Red)
+        }
     }
-
 
     #[test]
     fn regular_file() {
         let stati = f::Links {
-            count:    1,
+            count: 1,
             multiple: false,
         };
 
         let expected = TextCell {
             width: DisplayWidth::from(1),
-            contents: vec![ Blue.paint("1") ].into(),
+            contents: vec![Blue.paint("1")].into(),
         };
 
-        assert_eq!(expected, stati.render(&TestColours, &locale::Numeric::english()));
+        assert_eq!(
+            expected,
+            stati.render(&TestColours, &locale::Numeric::english())
+        );
     }
 
     #[test]
     fn regular_directory() {
         let stati = f::Links {
-            count:    3005,
+            count: 3005,
             multiple: false,
         };
 
         let expected = TextCell {
             width: DisplayWidth::from(5),
-            contents: vec![ Blue.paint("3,005") ].into(),
+            contents: vec![Blue.paint("3,005")].into(),
         };
 
-        assert_eq!(expected, stati.render(&TestColours, &locale::Numeric::english()));
+        assert_eq!(
+            expected,
+            stati.render(&TestColours, &locale::Numeric::english())
+        );
     }
 
     #[test]
     fn popular_file() {
         let stati = f::Links {
-            count:    3005,
+            count: 3005,
             multiple: true,
         };
 
         let expected = TextCell {
             width: DisplayWidth::from(5),
-            contents: vec![ Blue.on(Red).paint("3,005") ].into(),
+            contents: vec![Blue.on(Red).paint("3,005")].into(),
         };
 
-        assert_eq!(expected, stati.render(&TestColours, &locale::Numeric::english()));
+        assert_eq!(
+            expected,
+            stati.render(&TestColours, &locale::Numeric::english())
+        );
     }
 }

--- a/src/output/render/octal.rs
+++ b/src/output/render/octal.rs
@@ -3,7 +3,6 @@ use nu_ansi_term::Style;
 use crate::fs::fields as f;
 use crate::output::cell::TextCell;
 
-
 impl f::OctalPermissions {
     fn bits_to_octal(r: bool, w: bool, x: bool) -> u8 {
         u8::from(r) * 4 + u8::from(w) * 2 + u8::from(x)
@@ -12,32 +11,44 @@ impl f::OctalPermissions {
     pub fn render(&self, style: Style) -> TextCell {
         let perm = &self.permissions;
         let octal_sticky = Self::bits_to_octal(perm.setuid, perm.setgid, perm.sticky);
-        let octal_owner  = Self::bits_to_octal(perm.user_read, perm.user_write, perm.user_execute);
-        let octal_group  = Self::bits_to_octal(perm.group_read, perm.group_write, perm.group_execute);
-        let octal_other  = Self::bits_to_octal(perm.other_read, perm.other_write, perm.other_execute);
+        let octal_owner = Self::bits_to_octal(perm.user_read, perm.user_write, perm.user_execute);
+        let octal_group =
+            Self::bits_to_octal(perm.group_read, perm.group_write, perm.group_execute);
+        let octal_other =
+            Self::bits_to_octal(perm.other_read, perm.other_write, perm.other_execute);
 
-        TextCell::paint(style, format!("{octal_sticky}{octal_owner}{octal_group}{octal_other}"))
+        TextCell::paint(
+            style,
+            format!("{octal_sticky}{octal_owner}{octal_group}{octal_other}"),
+        )
     }
 }
 
-
 #[cfg(test)]
 pub mod test {
-    use crate::output::cell::TextCell;
     use crate::fs::fields as f;
+    use crate::output::cell::TextCell;
 
     use nu_ansi_term::Color::*;
-
 
     #[test]
     fn normal_folder() {
         let bits = f::Permissions {
-            user_read:  true, user_write:  true,  user_execute:  true, setuid: false,
-            group_read: true, group_write: false, group_execute: true, setgid: false,
-            other_read: true, other_write: false, other_execute: true, sticky: false,
+            user_read: true,
+            user_write: true,
+            user_execute: true,
+            setuid: false,
+            group_read: true,
+            group_write: false,
+            group_execute: true,
+            setgid: false,
+            other_read: true,
+            other_write: false,
+            other_execute: true,
+            sticky: false,
         };
 
-        let octal = f::OctalPermissions{ permissions: bits };
+        let octal = f::OctalPermissions { permissions: bits };
 
         let expected = TextCell::paint_str(Purple.bold(), "0755");
         assert_eq!(expected, octal.render(Purple.bold()));
@@ -46,12 +57,21 @@ pub mod test {
     #[test]
     fn normal_file() {
         let bits = f::Permissions {
-            user_read:  true, user_write:  true,  user_execute:  false, setuid: false,
-            group_read: true, group_write: false, group_execute: false, setgid: false,
-            other_read: true, other_write: false, other_execute: false, sticky: false,
+            user_read: true,
+            user_write: true,
+            user_execute: false,
+            setuid: false,
+            group_read: true,
+            group_write: false,
+            group_execute: false,
+            setgid: false,
+            other_read: true,
+            other_write: false,
+            other_execute: false,
+            sticky: false,
         };
 
-        let octal = f::OctalPermissions{ permissions: bits };
+        let octal = f::OctalPermissions { permissions: bits };
 
         let expected = TextCell::paint_str(Purple.bold(), "0644");
         assert_eq!(expected, octal.render(Purple.bold()));
@@ -60,12 +80,21 @@ pub mod test {
     #[test]
     fn secret_file() {
         let bits = f::Permissions {
-            user_read:  true,  user_write:  true,  user_execute:  false, setuid: false,
-            group_read: false, group_write: false, group_execute: false, setgid: false,
-            other_read: false, other_write: false, other_execute: false, sticky: false,
+            user_read: true,
+            user_write: true,
+            user_execute: false,
+            setuid: false,
+            group_read: false,
+            group_write: false,
+            group_execute: false,
+            setgid: false,
+            other_read: false,
+            other_write: false,
+            other_execute: false,
+            sticky: false,
         };
 
-        let octal = f::OctalPermissions{ permissions: bits };
+        let octal = f::OctalPermissions { permissions: bits };
 
         let expected = TextCell::paint_str(Purple.bold(), "0600");
         assert_eq!(expected, octal.render(Purple.bold()));
@@ -74,27 +103,44 @@ pub mod test {
     #[test]
     fn sticky1() {
         let bits = f::Permissions {
-            user_read:  true, user_write:  true,  user_execute:  true, setuid: true,
-            group_read: true, group_write: true,  group_execute: true, setgid: false,
-            other_read: true, other_write: true,  other_execute: true, sticky: false,
+            user_read: true,
+            user_write: true,
+            user_execute: true,
+            setuid: true,
+            group_read: true,
+            group_write: true,
+            group_execute: true,
+            setgid: false,
+            other_read: true,
+            other_write: true,
+            other_execute: true,
+            sticky: false,
         };
 
-        let octal = f::OctalPermissions{ permissions: bits };
+        let octal = f::OctalPermissions { permissions: bits };
 
         let expected = TextCell::paint_str(Purple.bold(), "4777");
         assert_eq!(expected, octal.render(Purple.bold()));
-
     }
 
     #[test]
     fn sticky2() {
         let bits = f::Permissions {
-            user_read:  true, user_write:  true,  user_execute:  true, setuid: false,
-            group_read: true, group_write: true,  group_execute: true, setgid: true,
-            other_read: true, other_write: true,  other_execute: true, sticky: false,
+            user_read: true,
+            user_write: true,
+            user_execute: true,
+            setuid: false,
+            group_read: true,
+            group_write: true,
+            group_execute: true,
+            setgid: true,
+            other_read: true,
+            other_write: true,
+            other_execute: true,
+            sticky: false,
         };
 
-        let octal = f::OctalPermissions{ permissions: bits };
+        let octal = f::OctalPermissions { permissions: bits };
 
         let expected = TextCell::paint_str(Purple.bold(), "2777");
         assert_eq!(expected, octal.render(Purple.bold()));
@@ -103,12 +149,21 @@ pub mod test {
     #[test]
     fn sticky3() {
         let bits = f::Permissions {
-            user_read:  true, user_write:  true,  user_execute:  true, setuid: false,
-            group_read: true, group_write: true,  group_execute: true, setgid: false,
-            other_read: true, other_write: true,  other_execute: true, sticky: true,
+            user_read: true,
+            user_write: true,
+            user_execute: true,
+            setuid: false,
+            group_read: true,
+            group_write: true,
+            group_execute: true,
+            setgid: false,
+            other_read: true,
+            other_write: true,
+            other_execute: true,
+            sticky: true,
         };
 
-        let octal = f::OctalPermissions{ permissions: bits };
+        let octal = f::OctalPermissions { permissions: bits };
 
         let expected = TextCell::paint_str(Purple.bold(), "1777");
         assert_eq!(expected, octal.render(Purple.bold()));

--- a/src/output/render/permissions.rs
+++ b/src/output/render/permissions.rs
@@ -1,117 +1,129 @@
 use nu_ansi_term::{AnsiString, Style};
 
 use crate::fs::fields as f;
-use crate::output::cell::{TextCell, DisplayWidth};
+use crate::output::cell::{DisplayWidth, TextCell};
 use crate::output::render::FiletypeColours;
-
 
 impl f::PermissionsPlus {
     #[cfg(unix)]
-    pub fn render<C: Colours+FiletypeColours>(&self, colours: &C) -> TextCell {
-        let mut chars = vec![ self.file_type.render(colours) ];
-        chars.extend(self.permissions.render(colours, self.file_type.is_regular_file()));
+    pub fn render<C: Colours + FiletypeColours>(&self, colours: &C) -> TextCell {
+        let mut chars = vec![self.file_type.render(colours)];
+        chars.extend(
+            self.permissions
+                .render(colours, self.file_type.is_regular_file()),
+        );
 
         if self.xattrs {
-           chars.push(colours.attribute().paint("@"));
+            chars.push(colours.attribute().paint("@"));
         }
 
         // As these are all ASCII characters, we can guarantee that they’re
         // all going to be one character wide, and don’t need to compute the
         // cell’s display width.
         TextCell {
-            width:    DisplayWidth::from(chars.len()),
+            width: DisplayWidth::from(chars.len()),
             contents: chars.into(),
         }
     }
 
     #[cfg(windows)]
-    pub fn render<C: Colours+FiletypeColours>(&self, colours: &C) -> TextCell {
-        let mut chars = vec![ self.attributes.render_type(colours) ];
+    pub fn render<C: Colours + FiletypeColours>(&self, colours: &C) -> TextCell {
+        let mut chars = vec![self.attributes.render_type(colours)];
         chars.extend(self.attributes.render(colours));
 
         TextCell {
-            width:    DisplayWidth::from(chars.len()),
+            width: DisplayWidth::from(chars.len()),
             contents: chars.into(),
         }
     }
 }
 
-
 impl f::Permissions {
-    pub fn render<C: Colours>(&self, colours: &C, is_regular_file: bool) -> Vec<AnsiString<'static>> {
-
+    pub fn render<C: Colours>(
+        &self,
+        colours: &C,
+        is_regular_file: bool,
+    ) -> Vec<AnsiString<'static>> {
         let bit = |bit, chr: &'static str, style: Style| {
-            if bit { style.paint(chr) }
-              else { colours.dash().paint("-") }
+            if bit {
+                style.paint(chr)
+            } else {
+                colours.dash().paint("-")
+            }
         };
 
         vec![
-            bit(self.user_read,   "r", colours.user_read()),
-            bit(self.user_write,  "w", colours.user_write()),
+            bit(self.user_read, "r", colours.user_read()),
+            bit(self.user_write, "w", colours.user_write()),
             self.user_execute_bit(colours, is_regular_file),
-            bit(self.group_read,  "r", colours.group_read()),
+            bit(self.group_read, "r", colours.group_read()),
             bit(self.group_write, "w", colours.group_write()),
             self.group_execute_bit(colours),
-            bit(self.other_read,  "r", colours.other_read()),
+            bit(self.other_read, "r", colours.other_read()),
             bit(self.other_write, "w", colours.other_write()),
-            self.other_execute_bit(colours)
+            self.other_execute_bit(colours),
         ]
     }
 
-    fn user_execute_bit<C: Colours>(&self, colours: &C, is_regular_file: bool) -> AnsiString<'static> {
+    fn user_execute_bit<C: Colours>(
+        &self,
+        colours: &C,
+        is_regular_file: bool,
+    ) -> AnsiString<'static> {
         match (self.user_execute, self.setuid, is_regular_file) {
-            (false, false, _)      => colours.dash().paint("-"),
-            (true,  false, false)  => colours.user_execute_other().paint("x"),
-            (true,  false, true)   => colours.user_execute_file().paint("x"),
-            (false, true,  _)      => colours.special_other().paint("S"),
-            (true,  true,  false)  => colours.special_other().paint("s"),
-            (true,  true,  true)   => colours.special_user_file().paint("s"),
+            (false, false, _) => colours.dash().paint("-"),
+            (true, false, false) => colours.user_execute_other().paint("x"),
+            (true, false, true) => colours.user_execute_file().paint("x"),
+            (false, true, _) => colours.special_other().paint("S"),
+            (true, true, false) => colours.special_other().paint("s"),
+            (true, true, true) => colours.special_user_file().paint("s"),
         }
     }
 
     fn group_execute_bit<C: Colours>(&self, colours: &C) -> AnsiString<'static> {
         match (self.group_execute, self.setgid) {
-            (false, false)  => colours.dash().paint("-"),
-            (true,  false)  => colours.group_execute().paint("x"),
-            (false, true)   => colours.special_other().paint("S"),
-            (true,  true)   => colours.special_other().paint("s"),
+            (false, false) => colours.dash().paint("-"),
+            (true, false) => colours.group_execute().paint("x"),
+            (false, true) => colours.special_other().paint("S"),
+            (true, true) => colours.special_other().paint("s"),
         }
     }
 
     fn other_execute_bit<C: Colours>(&self, colours: &C) -> AnsiString<'static> {
         match (self.other_execute, self.sticky) {
-            (false, false)  => colours.dash().paint("-"),
-            (true,  false)  => colours.other_execute().paint("x"),
-            (false, true)   => colours.special_other().paint("T"),
-            (true,  true)   => colours.special_other().paint("t"),
+            (false, false) => colours.dash().paint("-"),
+            (true, false) => colours.other_execute().paint("x"),
+            (false, true) => colours.special_other().paint("T"),
+            (true, true) => colours.special_other().paint("t"),
         }
     }
 }
 
 #[cfg(windows)]
 impl f::Attributes {
-    pub fn render<C: Colours+FiletypeColours>(&self, colours: &C) -> Vec<AnsiString<'static>> {
+    pub fn render<C: Colours + FiletypeColours>(&self, colours: &C) -> Vec<AnsiString<'static>> {
         let bit = |bit, chr: &'static str, style: Style| {
-            if bit { style.paint(chr) }
-              else { colours.dash().paint("-") }
+            if bit {
+                style.paint(chr)
+            } else {
+                colours.dash().paint("-")
+            }
         };
 
         vec![
-            bit(self.archive,   "a", colours.normal()),
-            bit(self.readonly,  "r", colours.user_read()),
-            bit(self.hidden,    "h", colours.special_user_file()),
-            bit(self.system,    "s", colours.special_other()),
+            bit(self.archive, "a", colours.normal()),
+            bit(self.readonly, "r", colours.user_read()),
+            bit(self.hidden, "h", colours.special_user_file()),
+            bit(self.system, "s", colours.special_other()),
         ]
     }
 
-    pub fn render_type<C: Colours+FiletypeColours>(&self, colours: &C) -> AnsiString<'static> {
+    pub fn render_type<C: Colours + FiletypeColours>(&self, colours: &C) -> AnsiString<'static> {
         if self.reparse_point {
             colours.pipe().paint("l")
-        }
-        else if self.directory {
+        } else if self.directory {
             colours.directory().paint("d")
-        }
-        else {
+        } else {
             colours.dash().paint("-")
         }
     }
@@ -139,104 +151,186 @@ pub trait Colours {
     fn attribute(&self) -> Style;
 }
 
-
 #[cfg(test)]
 #[allow(unused_results)]
 pub mod test {
     use super::Colours;
-    use crate::output::cell::TextCellContents;
     use crate::fs::fields as f;
+    use crate::output::cell::TextCellContents;
 
     use nu_ansi_term::Color::*;
     use nu_ansi_term::Style;
 
-
     struct TestColours;
 
     impl Colours for TestColours {
-        fn dash(&self)                -> Style { Fixed(11).normal() }
-        fn user_read(&self)           -> Style { Fixed(101).normal() }
-        fn user_write(&self)          -> Style { Fixed(102).normal() }
-        fn user_execute_file(&self)   -> Style { Fixed(103).normal() }
-        fn user_execute_other(&self)  -> Style { Fixed(113).normal() }
-        fn group_read(&self)          -> Style { Fixed(104).normal() }
-        fn group_write(&self)         -> Style { Fixed(105).normal() }
-        fn group_execute(&self)       -> Style { Fixed(106).normal() }
-        fn other_read(&self)          -> Style { Fixed(107).normal() }
-        fn other_write(&self)         -> Style { Fixed(108).normal() }
-        fn other_execute(&self)       -> Style { Fixed(109).normal() }
-        fn special_user_file(&self)   -> Style { Fixed(110).normal() }
-        fn special_other(&self)       -> Style { Fixed(111).normal() }
-        fn attribute(&self)           -> Style { Fixed(112).normal() }
+        fn dash(&self) -> Style {
+            Fixed(11).normal()
+        }
+        fn user_read(&self) -> Style {
+            Fixed(101).normal()
+        }
+        fn user_write(&self) -> Style {
+            Fixed(102).normal()
+        }
+        fn user_execute_file(&self) -> Style {
+            Fixed(103).normal()
+        }
+        fn user_execute_other(&self) -> Style {
+            Fixed(113).normal()
+        }
+        fn group_read(&self) -> Style {
+            Fixed(104).normal()
+        }
+        fn group_write(&self) -> Style {
+            Fixed(105).normal()
+        }
+        fn group_execute(&self) -> Style {
+            Fixed(106).normal()
+        }
+        fn other_read(&self) -> Style {
+            Fixed(107).normal()
+        }
+        fn other_write(&self) -> Style {
+            Fixed(108).normal()
+        }
+        fn other_execute(&self) -> Style {
+            Fixed(109).normal()
+        }
+        fn special_user_file(&self) -> Style {
+            Fixed(110).normal()
+        }
+        fn special_other(&self) -> Style {
+            Fixed(111).normal()
+        }
+        fn attribute(&self) -> Style {
+            Fixed(112).normal()
+        }
     }
-
 
     #[test]
     fn negate() {
         let bits = f::Permissions {
-            user_read:  false,  user_write:  false,  user_execute:  false,  setuid: false,
-            group_read: false,  group_write: false,  group_execute: false,  setgid: false,
-            other_read: false,  other_write: false,  other_execute: false,  sticky: false,
+            user_read: false,
+            user_write: false,
+            user_execute: false,
+            setuid: false,
+            group_read: false,
+            group_write: false,
+            group_execute: false,
+            setgid: false,
+            other_read: false,
+            other_write: false,
+            other_execute: false,
+            sticky: false,
         };
 
         let expected = TextCellContents::from(vec![
-            Fixed(11).paint("-"),  Fixed(11).paint("-"),  Fixed(11).paint("-"),
-            Fixed(11).paint("-"),  Fixed(11).paint("-"),  Fixed(11).paint("-"),
-            Fixed(11).paint("-"),  Fixed(11).paint("-"),  Fixed(11).paint("-"),
+            Fixed(11).paint("-"),
+            Fixed(11).paint("-"),
+            Fixed(11).paint("-"),
+            Fixed(11).paint("-"),
+            Fixed(11).paint("-"),
+            Fixed(11).paint("-"),
+            Fixed(11).paint("-"),
+            Fixed(11).paint("-"),
+            Fixed(11).paint("-"),
         ]);
 
         assert_eq!(expected, bits.render(&TestColours, false).into())
     }
 
-
     #[test]
     fn affirm() {
         let bits = f::Permissions {
-            user_read:  true,  user_write:  true,  user_execute:  true,  setuid: false,
-            group_read: true,  group_write: true,  group_execute: true,  setgid: false,
-            other_read: true,  other_write: true,  other_execute: true,  sticky: false,
+            user_read: true,
+            user_write: true,
+            user_execute: true,
+            setuid: false,
+            group_read: true,
+            group_write: true,
+            group_execute: true,
+            setgid: false,
+            other_read: true,
+            other_write: true,
+            other_execute: true,
+            sticky: false,
         };
 
         let expected = TextCellContents::from(vec![
-            Fixed(101).paint("r"),  Fixed(102).paint("w"),  Fixed(103).paint("x"),
-            Fixed(104).paint("r"),  Fixed(105).paint("w"),  Fixed(106).paint("x"),
-            Fixed(107).paint("r"),  Fixed(108).paint("w"),  Fixed(109).paint("x"),
+            Fixed(101).paint("r"),
+            Fixed(102).paint("w"),
+            Fixed(103).paint("x"),
+            Fixed(104).paint("r"),
+            Fixed(105).paint("w"),
+            Fixed(106).paint("x"),
+            Fixed(107).paint("r"),
+            Fixed(108).paint("w"),
+            Fixed(109).paint("x"),
         ]);
 
         assert_eq!(expected, bits.render(&TestColours, true).into())
     }
-
 
     #[test]
     fn specials() {
         let bits = f::Permissions {
-            user_read:  false,  user_write:  false,  user_execute:  true,  setuid: true,
-            group_read: false,  group_write: false,  group_execute: true,  setgid: true,
-            other_read: false,  other_write: false,  other_execute: true,  sticky: true,
+            user_read: false,
+            user_write: false,
+            user_execute: true,
+            setuid: true,
+            group_read: false,
+            group_write: false,
+            group_execute: true,
+            setgid: true,
+            other_read: false,
+            other_write: false,
+            other_execute: true,
+            sticky: true,
         };
 
         let expected = TextCellContents::from(vec![
-            Fixed(11).paint("-"),  Fixed(11).paint("-"),  Fixed(110).paint("s"),
-            Fixed(11).paint("-"),  Fixed(11).paint("-"),  Fixed(111).paint("s"),
-            Fixed(11).paint("-"),  Fixed(11).paint("-"),  Fixed(111).paint("t"),
+            Fixed(11).paint("-"),
+            Fixed(11).paint("-"),
+            Fixed(110).paint("s"),
+            Fixed(11).paint("-"),
+            Fixed(11).paint("-"),
+            Fixed(111).paint("s"),
+            Fixed(11).paint("-"),
+            Fixed(11).paint("-"),
+            Fixed(111).paint("t"),
         ]);
 
         assert_eq!(expected, bits.render(&TestColours, true).into())
     }
 
-
     #[test]
     fn extra_specials() {
         let bits = f::Permissions {
-            user_read:  false,  user_write:  false,  user_execute:  false,  setuid: true,
-            group_read: false,  group_write: false,  group_execute: false,  setgid: true,
-            other_read: false,  other_write: false,  other_execute: false,  sticky: true,
+            user_read: false,
+            user_write: false,
+            user_execute: false,
+            setuid: true,
+            group_read: false,
+            group_write: false,
+            group_execute: false,
+            setgid: true,
+            other_read: false,
+            other_write: false,
+            other_execute: false,
+            sticky: true,
         };
 
         let expected = TextCellContents::from(vec![
-            Fixed(11).paint("-"),  Fixed(11).paint("-"),  Fixed(111).paint("S"),
-            Fixed(11).paint("-"),  Fixed(11).paint("-"),  Fixed(111).paint("S"),
-            Fixed(11).paint("-"),  Fixed(11).paint("-"),  Fixed(111).paint("T"),
+            Fixed(11).paint("-"),
+            Fixed(11).paint("-"),
+            Fixed(111).paint("S"),
+            Fixed(11).paint("-"),
+            Fixed(11).paint("-"),
+            Fixed(111).paint("S"),
+            Fixed(11).paint("-"),
+            Fixed(11).paint("-"),
+            Fixed(111).paint("T"),
         ]);
 
         assert_eq!(expected, bits.render(&TestColours, true).into())

--- a/src/output/render/size.rs
+++ b/src/output/render/size.rs
@@ -1,31 +1,34 @@
-use nu_ansi_term::Style;
 use locale::Numeric as NumericLocale;
+use nu_ansi_term::Style;
 use unit_prefix::Prefix;
 
 use crate::fs::fields as f;
-use crate::output::cell::{TextCell, DisplayWidth};
+use crate::output::cell::{DisplayWidth, TextCell};
 use crate::output::table::SizeFormat;
 
-
 impl f::Size {
-    pub fn render<C: Colours>(self, colours: &C, size_format: SizeFormat, numerics: &NumericLocale) -> TextCell {
+    pub fn render<C: Colours>(
+        self,
+        colours: &C,
+        size_format: SizeFormat,
+        numerics: &NumericLocale,
+    ) -> TextCell {
         use unit_prefix::NumberPrefix;
 
         let size = match self {
-            Self::Some(s)             => s,
-            Self::None                => return TextCell::blank(colours.no_size()),
-            Self::DeviceIDs(ref ids)  => return ids.render(colours),
+            Self::Some(s) => s,
+            Self::None => return TextCell::blank(colours.no_size()),
+            Self::DeviceIDs(ref ids) => return ids.render(colours),
         };
 
         let result = match size_format {
-            SizeFormat::DecimalBytes  => NumberPrefix::decimal(size as f64),
-            SizeFormat::BinaryBytes   => NumberPrefix::binary(size as f64),
-            SizeFormat::JustBytes     => {
-
+            SizeFormat::DecimalBytes => NumberPrefix::decimal(size as f64),
+            SizeFormat::BinaryBytes => NumberPrefix::binary(size as f64),
+            SizeFormat::JustBytes => {
                 // Use the binary prefix to select a style.
                 let prefix = match NumberPrefix::binary(size as f64) {
-                    NumberPrefix::Standalone(_)   => None,
-                    NumberPrefix::Prefixed(p, _)  => Some(p),
+                    NumberPrefix::Standalone(_) => None,
+                    NumberPrefix::Prefixed(p, _) => Some(p),
                 };
 
                 // But format the number directly using the locale.
@@ -36,8 +39,10 @@ impl f::Size {
         };
 
         let (prefix, n) = match result {
-            NumberPrefix::Standalone(b)   => return TextCell::paint(colours.size(size, None), numerics.format_int(b)),
-            NumberPrefix::Prefixed(p, n)  => (p, n),
+            NumberPrefix::Standalone(b) => {
+                return TextCell::paint(colours.size(size, None), numerics.format_int(b));
+            }
+            NumberPrefix::Prefixed(p, n) => (p, n),
         };
 
         let symbol = prefix.symbol();
@@ -53,11 +58,11 @@ impl f::Size {
             contents: vec![
                 colours.size(size, Some(prefix)).paint(number),
                 colours.unit(Some(prefix)).paint(symbol),
-            ].into(),
+            ]
+            .into(),
         }
     }
 }
-
 
 impl f::DeviceIDs {
     fn render<C: Colours>(self, colours: &C) -> TextCell {
@@ -70,11 +75,11 @@ impl f::DeviceIDs {
                 colours.major().paint(major),
                 colours.comma().paint(","),
                 colours.minor().paint(minor),
-            ].into(),
+            ]
+            .into(),
         }
     }
 }
-
 
 pub trait Colours {
     /// Pick the style for a file-size number.
@@ -94,97 +99,133 @@ pub trait Colours {
     fn minor(&self) -> Style;
 }
 
-
 #[cfg(test)]
 pub mod test {
     use super::Colours;
-    use crate::output::cell::{TextCell, DisplayWidth};
-    use crate::output::table::SizeFormat;
     use crate::fs::fields as f;
+    use crate::output::cell::{DisplayWidth, TextCell};
+    use crate::output::table::SizeFormat;
 
     use locale::Numeric as NumericLocale;
     use nu_ansi_term::Color::*;
     use nu_ansi_term::Style;
     use unit_prefix::Prefix;
 
-
     struct TestColours;
 
     impl Colours for TestColours {
-        fn size(&self, _bytes: u64, _prefix: Option<Prefix>) -> Style { Fixed(66).normal() }
-        fn unit(&self, _prefix: Option<Prefix>) -> Style { Fixed(77).bold() }
-        fn no_size(&self)          -> Style { Black.italic() }
+        fn size(&self, _bytes: u64, _prefix: Option<Prefix>) -> Style {
+            Fixed(66).normal()
+        }
+        fn unit(&self, _prefix: Option<Prefix>) -> Style {
+            Fixed(77).bold()
+        }
+        fn no_size(&self) -> Style {
+            Black.italic()
+        }
 
-        fn major(&self) -> Style { Blue.on(Red) }
-        fn comma(&self) -> Style { Green.italic() }
-        fn minor(&self) -> Style { Cyan.on(Yellow) }
+        fn major(&self) -> Style {
+            Blue.on(Red)
+        }
+        fn comma(&self) -> Style {
+            Green.italic()
+        }
+        fn minor(&self) -> Style {
+            Cyan.on(Yellow)
+        }
     }
-
 
     #[test]
     fn directory() {
         let directory = f::Size::None;
         let expected = TextCell::blank(Black.italic());
-        assert_eq!(expected, directory.render(&TestColours, SizeFormat::JustBytes, &NumericLocale::english()))
+        assert_eq!(
+            expected,
+            directory.render(
+                &TestColours,
+                SizeFormat::JustBytes,
+                &NumericLocale::english()
+            )
+        )
     }
-
 
     #[test]
     fn file_decimal() {
         let directory = f::Size::Some(2_100_000);
         let expected = TextCell {
             width: DisplayWidth::from(4),
-            contents: vec![
-                Fixed(66).paint("2.1"),
-                Fixed(77).bold().paint("M"),
-            ].into(),
+            contents: vec![Fixed(66).paint("2.1"), Fixed(77).bold().paint("M")].into(),
         };
 
-        assert_eq!(expected, directory.render(&TestColours, SizeFormat::DecimalBytes, &NumericLocale::english()))
+        assert_eq!(
+            expected,
+            directory.render(
+                &TestColours,
+                SizeFormat::DecimalBytes,
+                &NumericLocale::english()
+            )
+        )
     }
-
 
     #[test]
     fn file_binary() {
         let directory = f::Size::Some(1_048_576);
         let expected = TextCell {
             width: DisplayWidth::from(5),
-            contents: vec![
-                Fixed(66).paint("1.0"),
-                Fixed(77).bold().paint("Mi"),
-            ].into(),
+            contents: vec![Fixed(66).paint("1.0"), Fixed(77).bold().paint("Mi")].into(),
         };
 
-        assert_eq!(expected, directory.render(&TestColours, SizeFormat::BinaryBytes, &NumericLocale::english()))
+        assert_eq!(
+            expected,
+            directory.render(
+                &TestColours,
+                SizeFormat::BinaryBytes,
+                &NumericLocale::english()
+            )
+        )
     }
-
 
     #[test]
     fn file_bytes() {
         let directory = f::Size::Some(1_048_576);
         let expected = TextCell {
             width: DisplayWidth::from(9),
-            contents: vec![
-                Fixed(66).paint("1,048,576"),
-            ].into(),
+            contents: vec![Fixed(66).paint("1,048,576")].into(),
         };
 
-        assert_eq!(expected, directory.render(&TestColours, SizeFormat::JustBytes, &NumericLocale::english()))
+        assert_eq!(
+            expected,
+            directory.render(
+                &TestColours,
+                SizeFormat::JustBytes,
+                &NumericLocale::english()
+            )
+        )
     }
-
 
     #[test]
     fn device_ids() {
-        let directory = f::Size::DeviceIDs(f::DeviceIDs { major: 10, minor: 80 });
+        let directory = f::Size::DeviceIDs(f::DeviceIDs {
+            major: 10,
+            minor: 80,
+        });
         let expected = TextCell {
             width: DisplayWidth::from(5),
             contents: vec![
                 Blue.on(Red).paint("10"),
                 Green.italic().paint(","),
                 Cyan.on(Yellow).paint("80"),
-            ].into(),
+            ]
+            .into(),
         };
 
-        assert_eq!(expected, directory.render(&TestColours, SizeFormat::JustBytes, &NumericLocale::english()))
+        assert_eq!(
+            expected,
+            directory.render(
+                &TestColours,
+                SizeFormat::JustBytes,
+                &NumericLocale::english()
+            )
+        )
     }
 }

--- a/src/output/render/times.rs
+++ b/src/output/render/times.rs
@@ -6,7 +6,6 @@ use crate::output::cell::TextCell;
 use crate::output::time::TimeFormat;
 use crate::theme::{DateAge, age_to_position};
 
-
 pub trait Render {
     /// Render a timestamp into a `TextCell`.
     ///

--- a/src/output/render/users.rs
+++ b/src/output/render/users.rs
@@ -4,13 +4,12 @@ use uzers::Users;
 use crate::fs::fields as f;
 use crate::output::cell::TextCell;
 
-
 impl f::User {
     /// Render the owner as their name, falling back to the numeric
     /// UID if the name can't be resolved.  Used for the `--user` column.
     pub fn render<C: Colours, U: Users>(self, colours: &C, users: &U) -> TextCell {
         let user_name = match users.get_user_by_uid(self.0) {
-            None       => self.0.to_string(),
+            None => self.0.to_string(),
             Some(user) => user.name().to_string_lossy().into(),
         };
 
@@ -26,16 +25,21 @@ impl f::User {
     }
 
     fn style<C: Colours, U: Users>(self, colours: &C, users: &U) -> Style {
-        if users.get_current_uid() == self.0 { colours.you() }
-        else                                  { colours.someone_else() }
+        if users.get_current_uid() == self.0 {
+            colours.you()
+        } else {
+            colours.someone_else()
+        }
     }
 
     fn uid_style<C: Colours, U: Users>(self, colours: &C, users: &U) -> Style {
-        if users.get_current_uid() == self.0 { colours.uid_you() }
-        else                                  { colours.uid_someone_else() }
+        if users.get_current_uid() == self.0 {
+            colours.uid_you()
+        } else {
+            colours.uid_someone_else()
+        }
     }
 }
-
 
 pub trait Colours {
     fn you(&self) -> Style;
@@ -51,7 +55,6 @@ pub trait Colours {
     fn uid_someone_else(&self) -> Style;
 }
 
-
 #[cfg(test)]
 #[allow(unused_results)]
 pub mod test {
@@ -59,11 +62,10 @@ pub mod test {
     use crate::fs::fields as f;
     use crate::output::cell::TextCell;
 
-    use uzers::User;
-    use uzers::mock::MockUsers;
     use nu_ansi_term::Color::*;
     use nu_ansi_term::Style;
-
+    use uzers::User;
+    use uzers::mock::MockUsers;
 
     /// Cascading test colours: the `uid_*` methods return slightly
     /// different styles than the `user_*` methods, so the tests can
@@ -73,12 +75,19 @@ pub mod test {
     struct TestColours;
 
     impl Colours for TestColours {
-        fn you(&self)              -> Style { Red.bold() }
-        fn someone_else(&self)     -> Style { Blue.underline() }
-        fn uid_you(&self)          -> Style { Red.normal() }
-        fn uid_someone_else(&self) -> Style { Blue.normal() }
+        fn you(&self) -> Style {
+            Red.bold()
+        }
+        fn someone_else(&self) -> Style {
+            Blue.underline()
+        }
+        fn uid_you(&self) -> Style {
+            Red.normal()
+        }
+        fn uid_someone_else(&self) -> Style {
+            Blue.normal()
+        }
     }
-
 
     #[test]
     fn named() {
@@ -122,13 +131,19 @@ pub mod test {
     fn different_unnamed_uid() {
         let user = f::User(1000);
         let expected = TextCell::paint_str(Blue.normal(), "1000");
-        assert_eq!(expected, user.render_uid(&TestColours, &MockUsers::with_current_uid(0)));
+        assert_eq!(
+            expected,
+            user.render_uid(&TestColours, &MockUsers::with_current_uid(0))
+        );
     }
 
     #[test]
     fn overflow() {
         let user = f::User(2_147_483_648);
         let expected = TextCell::paint_str(Blue.normal(), "2147483648");
-        assert_eq!(expected, user.render_uid(&TestColours, &MockUsers::with_current_uid(0)));
+        assert_eq!(
+            expected,
+            user.render_uid(&TestColours, &MockUsers::with_current_uid(0))
+        );
     }
 }

--- a/src/output/render/vcs.rs
+++ b/src/output/render/vcs.rs
@@ -1,8 +1,7 @@
 use nu_ansi_term::{AnsiString, Style};
 
-use crate::output::cell::{TextCell, DisplayWidth};
 use crate::fs::fields as f;
-
+use crate::output::cell::{DisplayWidth, TextCell};
 
 impl f::VcsFileStatus {
     pub fn render(self, colours: &dyn Colours, backend: &str) -> TextCell {
@@ -13,7 +12,8 @@ impl f::VcsFileStatus {
                 contents: vec![
                     self.unstaged.render(colours, backend),
                     colours.not_modified().paint(" "),
-                ].into(),
+                ]
+                .into(),
             }
         } else {
             // Two-column display (git staged + unstaged).
@@ -22,30 +22,29 @@ impl f::VcsFileStatus {
                 contents: vec![
                     self.staged.render(colours, backend),
                     self.unstaged.render(colours, backend),
-                ].into(),
+                ]
+                .into(),
             }
         }
     }
 }
 
-
 impl f::VcsStatus {
     fn render(self, colours: &dyn Colours, backend: &str) -> AnsiString<'static> {
         match self {
-            Self::NotModified  => colours.not_modified().paint("-"),
-            Self::New          => colours.new().paint(if backend == "JJ" { "A" } else { "N" }),
-            Self::Modified     => colours.modified().paint("M"),
-            Self::Deleted      => colours.deleted().paint("D"),
-            Self::Renamed      => colours.renamed().paint("R"),
-            Self::TypeChange   => colours.type_change().paint("T"),
-            Self::Ignored      => colours.ignored().paint("I"),
-            Self::Conflicted   => colours.conflicted().paint("!"),
-            Self::Copied       => colours.renamed().paint("C"),
-            Self::Untracked    => colours.ignored().paint("U"),
+            Self::NotModified => colours.not_modified().paint("-"),
+            Self::New => colours.new().paint(if backend == "JJ" { "A" } else { "N" }),
+            Self::Modified => colours.modified().paint("M"),
+            Self::Deleted => colours.deleted().paint("D"),
+            Self::Renamed => colours.renamed().paint("R"),
+            Self::TypeChange => colours.type_change().paint("T"),
+            Self::Ignored => colours.ignored().paint("I"),
+            Self::Conflicted => colours.conflicted().paint("!"),
+            Self::Copied => colours.renamed().paint("C"),
+            Self::Untracked => colours.ignored().paint("U"),
         }
     }
 }
-
 
 pub trait Colours {
     fn not_modified(&self) -> Style;
@@ -59,64 +58,70 @@ pub trait Colours {
     fn conflicted(&self) -> Style;
 }
 
-
 #[cfg(test)]
 pub mod test {
     use super::Colours;
-    use crate::output::cell::{TextCell, DisplayWidth};
     use crate::fs::fields as f;
+    use crate::output::cell::{DisplayWidth, TextCell};
 
     use nu_ansi_term::Color::*;
     use nu_ansi_term::Style;
 
-
     struct TestColours;
 
     impl Colours for TestColours {
-        fn not_modified(&self) -> Style { Fixed(90).normal() }
-        fn new(&self)          -> Style { Fixed(91).normal() }
-        fn modified(&self)     -> Style { Fixed(92).normal() }
-        fn deleted(&self)      -> Style { Fixed(93).normal() }
-        fn renamed(&self)      -> Style { Fixed(94).normal() }
-        fn type_change(&self)  -> Style { Fixed(95).normal() }
-        fn ignored(&self)      -> Style { Fixed(96).normal() }
-        fn conflicted(&self)   -> Style { Fixed(97).normal() }
+        fn not_modified(&self) -> Style {
+            Fixed(90).normal()
+        }
+        fn new(&self) -> Style {
+            Fixed(91).normal()
+        }
+        fn modified(&self) -> Style {
+            Fixed(92).normal()
+        }
+        fn deleted(&self) -> Style {
+            Fixed(93).normal()
+        }
+        fn renamed(&self) -> Style {
+            Fixed(94).normal()
+        }
+        fn type_change(&self) -> Style {
+            Fixed(95).normal()
+        }
+        fn ignored(&self) -> Style {
+            Fixed(96).normal()
+        }
+        fn conflicted(&self) -> Style {
+            Fixed(97).normal()
+        }
     }
-
 
     #[test]
     fn vcs_blank() {
         let stati = f::VcsFileStatus {
-            staged:   f::VcsStatus::NotModified,
+            staged: f::VcsStatus::NotModified,
             unstaged: f::VcsStatus::NotModified,
         };
 
         // Equal statuses → single-column display (char + space).
         let expected = TextCell {
             width: DisplayWidth::from(2),
-            contents: vec![
-                Fixed(90).paint("-"),
-                Fixed(90).paint(" "),
-            ].into(),
+            contents: vec![Fixed(90).paint("-"), Fixed(90).paint(" ")].into(),
         };
 
         assert_eq!(expected, stati.render(&TestColours, "Git"))
     }
 
-
     #[test]
     fn vcs_staged_unstaged_differ() {
         let stati = f::VcsFileStatus {
-            staged:   f::VcsStatus::New,
+            staged: f::VcsStatus::New,
             unstaged: f::VcsStatus::Modified,
         };
 
         let expected = TextCell {
             width: DisplayWidth::from(2),
-            contents: vec![
-                Fixed(91).paint("N"),
-                Fixed(92).paint("M"),
-            ].into(),
+            contents: vec![Fixed(91).paint("N"), Fixed(92).paint("M")].into(),
         };
 
         assert_eq!(expected, stati.render(&TestColours, "Git"))
@@ -125,16 +130,13 @@ pub mod test {
     #[test]
     fn vcs_jj_new_shows_a() {
         let stati = f::VcsFileStatus {
-            staged:   f::VcsStatus::New,
+            staged: f::VcsStatus::New,
             unstaged: f::VcsStatus::New,
         };
 
         let expected = TextCell {
             width: DisplayWidth::from(2),
-            contents: vec![
-                Fixed(91).paint("A"),
-                Fixed(90).paint(" "),
-            ].into(),
+            contents: vec![Fixed(91).paint("A"), Fixed(90).paint(" ")].into(),
         };
 
         assert_eq!(expected, stati.render(&TestColours, "JJ"))

--- a/src/output/render/vcs_repos.rs
+++ b/src/output/render/vcs_repos.rs
@@ -1,14 +1,17 @@
 use nu_ansi_term::Style;
 
-use crate::output::cell::TextCell;
 use crate::fs::fields as f;
-
+use crate::output::cell::TextCell;
 
 impl f::VcsRepoStatus {
     pub fn render(&self, colours: &dyn Colours) -> TextCell {
         match self {
             Self::None => TextCell::paint(colours.not_a_repo(), "-".to_string()),
-            Self::Repo { backend, clean, branch } => {
+            Self::Repo {
+                backend,
+                clean,
+                branch,
+            } => {
                 let indicator = match *backend {
                     "jj" => "J",
                     "git" => "G",
@@ -31,7 +34,6 @@ impl f::VcsRepoStatus {
         }
     }
 }
-
 
 pub trait Colours {
     fn not_a_repo(&self) -> Style;

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -13,7 +13,6 @@ use crate::output::cell::TextCell;
 use crate::output::time::TimeFormat;
 use crate::theme::Theme;
 
-
 /// Options for displaying a table.
 #[derive(PartialEq, Eq, Debug)]
 pub struct Options {
@@ -27,7 +26,6 @@ pub struct Options {
     /// Override the locale's thousands separator (e.g. ",").  Empty = no grouping.
     pub thousands_separator: Option<String>,
 }
-
 
 /// A table contains these.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -83,7 +81,6 @@ pub enum Alignment {
 }
 
 impl Column {
-
     /// Get the alignment this column should use.
     pub fn alignment(self) -> Alignment {
         super::column_registry::ColumnDef::for_column(self).alignment
@@ -96,13 +93,10 @@ impl Column {
     }
 }
 
-
 /// Formatting options for file sizes.
 #[allow(clippy::enum_variant_names)]
-#[derive(PartialEq, Eq, Debug, Copy, Clone)]
-#[derive(Default)]
+#[derive(PartialEq, Eq, Debug, Copy, Clone, Default)]
 pub enum SizeFormat {
-
     /// Format the file size using **decimal** prefixes, such as “kilo”,
     /// “mega”, or “giga”.
     #[default]
@@ -120,7 +114,6 @@ pub enum SizeFormat {
 /// across most (all?) operating systems.
 #[derive(PartialEq, Eq, Debug, Copy, Clone)]
 pub enum TimeType {
-
     /// The file’s modified time (`st_mtime`).
     Modified,
 
@@ -135,27 +128,22 @@ pub enum TimeType {
 }
 
 impl TimeType {
-
     /// Returns the text to use for a column’s heading in the columns output.
     pub fn header(self) -> &'static str {
         match self {
-            Self::Modified  => "Date Modified",
-            Self::Changed   => "Date Changed",
-            Self::Accessed  => "Date Accessed",
-            Self::Created   => "Date Created",
+            Self::Modified => "Date Modified",
+            Self::Changed => "Date Changed",
+            Self::Accessed => "Date Accessed",
+            Self::Created => "Date Created",
         }
     }
 }
-
-
-
 
 /// The **environment** struct contains any data that could change between
 /// running instances of lx, depending on the user’s computer’s configuration.
 ///
 /// Any environment field should be able to be mocked up for test runs.
 pub struct Environment {
-
     /// Localisation rules for formatting numbers.
     pub numeric: locale::Numeric,
 
@@ -171,13 +159,17 @@ impl Environment {
     }
 
     fn load_all() -> Self {
-        let numeric = locale::Numeric::load_user_locale()
-                             .unwrap_or_else(|_| locale::Numeric::english());
+        let numeric =
+            locale::Numeric::load_user_locale().unwrap_or_else(|_| locale::Numeric::english());
 
         #[cfg(unix)]
         let users = Mutex::new(UsersCache::new());
 
-        Self { numeric, #[cfg(unix)] users }
+        Self {
+            numeric,
+            #[cfg(unix)]
+            users,
+        }
     }
 }
 
@@ -189,7 +181,6 @@ static ENVIRONMENT: LazyLock<Environment> = LazyLock::new(Environment::load_all)
 pub fn environment() -> &'static Environment {
     &ENVIRONMENT
 }
-
 
 pub struct Table<'a> {
     columns: Vec<Column>,
@@ -215,7 +206,9 @@ impl<'a> Table<'a> {
 
     pub fn new(options: &'a Options, vcs: Option<&'a dyn VcsCache>, theme: &'a Theme) -> Table<'a> {
         // Filter out VcsStatus column if no VCS cache is available.
-        let columns: Vec<Column> = options.columns.iter()
+        let columns: Vec<Column> = options
+            .columns
+            .iter()
             .copied()
             .filter(|c| !matches!(c, Column::VcsStatus) || vcs.is_some())
             .collect();
@@ -249,24 +242,30 @@ impl<'a> Table<'a> {
     }
 
     pub fn header_row(&self) -> Row {
-        let cells = self.columns.iter()
-                        .map(|c| {
-                            let name = if *c == Column::VcsStatus {
-                                self.vcs.map(super::super::fs::feature::VcsCache::header_name).unwrap_or("VCS")
-                            } else {
-                                c.header()
-                            };
-                            TextCell::paint_str(self.theme.ui.header, name)
-                        })
-                        .collect();
+        let cells = self
+            .columns
+            .iter()
+            .map(|c| {
+                let name = if *c == Column::VcsStatus {
+                    self.vcs
+                        .map(super::super::fs::feature::VcsCache::header_name)
+                        .unwrap_or("VCS")
+                } else {
+                    c.header()
+                };
+                TextCell::paint_str(self.theme.ui.header, name)
+            })
+            .collect();
 
         Row { cells }
     }
 
     pub fn row_for_file(&self, file: &File<'_>, xattrs: bool) -> Row {
-        let cells = self.columns.iter()
-                        .map(|c| self.display(file, *c, xattrs))
-                        .collect();
+        let cells = self
+            .columns
+            .iter()
+            .map(|c| self.display(file, *c, xattrs))
+            .collect();
 
         Row { cells }
     }
@@ -293,9 +292,7 @@ impl<'a> Table<'a> {
     pub fn render(&self, row: Row) -> TextCell {
         let mut cell = TextCell::default();
 
-        let iter = row.cells.into_iter()
-                      .zip(self.widths.iter())
-                      .enumerate();
+        let iter = row.cells.into_iter().zip(self.widths.iter()).enumerate();
 
         for (n, (this_cell, width)) in iter {
             let padding = width - *this_cell.width;
@@ -317,7 +314,6 @@ impl<'a> Table<'a> {
         cell
     }
 }
-
 
 pub struct TableWidths(Vec<usize>);
 

--- a/src/output/time.rs
+++ b/src/output/time.rs
@@ -6,7 +6,6 @@ use std::time::SystemTime;
 use chrono::{DateTime, Datelike, Local, Timelike};
 use unicode_width::UnicodeWidthStr;
 
-
 /// Every timestamp in lx needs to be rendered by a **time format**.
 /// Formatting times is tricky, because how a timestamp is rendered can
 /// depend on one or more of the following:
@@ -18,7 +17,6 @@ use unicode_width::UnicodeWidthStr;
 /// - The formatting style that the user asked for on the command-line.
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub enum TimeFormat {
-
     /// The **default format** uses the user's locale to print month names,
     /// and specifies the timestamp down to the minute for recent times, and
     /// day for older times.
@@ -51,48 +49,61 @@ impl TimeFormat {
     pub fn format(&self, time: SystemTime) -> String {
         let dt: DateTime<Local> = time.into();
         match self {
-            Self::DefaultFormat  => default(dt),
-            Self::ISOFormat      => iso(dt),
-            Self::LongISO        => long(dt),
-            Self::FullISO        => full(dt),
-            Self::Relative       => relative(dt),
-            Self::Custom(fmt)    => dt.format(fmt).to_string(),
+            Self::DefaultFormat => default(dt),
+            Self::ISOFormat => iso(dt),
+            Self::LongISO => long(dt),
+            Self::FullISO => full(dt),
+            Self::Relative => relative(dt),
+            Self::Custom(fmt) => dt.format(fmt).to_string(),
         }
     }
 }
-
 
 fn default(date: DateTime<Local>) -> String {
     let month_name = LOCALE.short_month_name(date.month0() as usize);
 
     if is_recent(&date) {
         match *MAXIMUM_MONTH_WIDTH {
-            4 => format!("{:>2} {:<4} {:02}:{:02}",
-                         date.day(), month_name,
-                         date.hour(), date.minute()),
-            5 => format!("{:>2} {:<5} {:02}:{:02}",
-                         date.day(), month_name,
-                         date.hour(), date.minute()),
-            _ => format!("{:>2} {} {:02}:{:02}",
-                         date.day(), month_name,
-                         date.hour(), date.minute()),
+            4 => format!(
+                "{:>2} {:<4} {:02}:{:02}",
+                date.day(),
+                month_name,
+                date.hour(),
+                date.minute()
+            ),
+            5 => format!(
+                "{:>2} {:<5} {:02}:{:02}",
+                date.day(),
+                month_name,
+                date.hour(),
+                date.minute()
+            ),
+            _ => format!(
+                "{:>2} {} {:02}:{:02}",
+                date.day(),
+                month_name,
+                date.hour(),
+                date.minute()
+            ),
         }
     } else {
         match *MAXIMUM_MONTH_WIDTH {
-            4 => format!("{:>2} {:<4} {:>5}",
-                         date.day(), month_name, date.year()),
-            5 => format!("{:>2} {:<5} {:>5}",
-                         date.day(), month_name, date.year()),
-            _ => format!("{:>2} {} {:>5}",
-                         date.day(), month_name, date.year()),
+            4 => format!("{:>2} {:<4} {:>5}", date.day(), month_name, date.year()),
+            5 => format!("{:>2} {:<5} {:>5}", date.day(), month_name, date.year()),
+            _ => format!("{:>2} {} {:>5}", date.day(), month_name, date.year()),
         }
     }
 }
 
 fn long(date: DateTime<Local>) -> String {
-    format!("{:04}-{:02}-{:02} {:02}:{:02}",
-            date.year(), date.month(), date.day(),
-            date.hour(), date.minute())
+    format!(
+        "{:04}-{:02}-{:02} {:02}:{:02}",
+        date.year(),
+        date.month(),
+        date.day(),
+        date.hour(),
+        date.minute()
+    )
 }
 
 fn full(date: DateTime<Local>) -> String {
@@ -100,21 +111,31 @@ fn full(date: DateTime<Local>) -> String {
     let offset_hours = offset / 3600;
     let offset_minutes = (offset % 3600).abs() / 60;
     let nanos = date.timestamp_subsec_nanos();
-    format!("{:04}-{:02}-{:02} {:02}:{:02}:{:02}.{:09} {:+03}{:02}",
-            date.year(), date.month(), date.day(),
-            date.hour(), date.minute(), date.second(), nanos,
-            offset_hours, offset_minutes)
+    format!(
+        "{:04}-{:02}-{:02} {:02}:{:02}:{:02}.{:09} {:+03}{:02}",
+        date.year(),
+        date.month(),
+        date.day(),
+        date.hour(),
+        date.minute(),
+        date.second(),
+        nanos,
+        offset_hours,
+        offset_minutes
+    )
 }
 
 fn iso(date: DateTime<Local>) -> String {
     if is_recent(&date) {
-        format!("{:02}-{:02} {:02}:{:02}",
-                date.month(), date.day(),
-                date.hour(), date.minute())
-    }
-    else {
-        format!("{:04}-{:02}-{:02}",
-                date.year(), date.month(), date.day())
+        format!(
+            "{:02}-{:02} {:02}:{:02}",
+            date.month(),
+            date.day(),
+            date.hour(),
+            date.minute()
+        )
+    } else {
+        format!("{:04}-{:02}-{:02}", date.year(), date.month(), date.day())
     }
 }
 
@@ -167,13 +188,10 @@ fn is_recent(date: &DateTime<Local>) -> bool {
     date.year() == *CURRENT_YEAR
 }
 
-
 static CURRENT_YEAR: LazyLock<i32> = LazyLock::new(|| Local::now().year());
 
-static LOCALE: LazyLock<locale::Time> = LazyLock::new(|| {
-    locale::Time::load_user_locale()
-        .unwrap_or_else(|_| locale::Time::english())
-});
+static LOCALE: LazyLock<locale::Time> =
+    LazyLock::new(|| locale::Time::load_user_locale().unwrap_or_else(|_| locale::Time::english()));
 
 static MAXIMUM_MONTH_WIDTH: LazyLock<usize> = LazyLock::new(|| {
     // Some locales use a three-character wide month name (Jan to Dec);

--- a/src/output/tree.rs
+++ b/src/output/tree.rs
@@ -38,10 +38,8 @@
 //! successfully `stat`ted, we don’t know how many files are going to exist in
 //! each directory)
 
-
 #[derive(PartialEq, Eq, Debug, Copy, Clone)]
 pub enum TreePart {
-
     /// Rightmost column, *not* the last in the directory.
     Edge,
 
@@ -56,24 +54,21 @@ pub enum TreePart {
 }
 
 impl TreePart {
-
     /// Turn this tree part into ASCII-licious box drawing characters!
     /// (Warning: not actually ASCII)
     pub fn ascii_art(self) -> &'static str {
         match self {
-            Self::Edge    => "├──",
-            Self::Line    => "│  ",
-            Self::Corner  => "└──",
-            Self::Blank   => "   ",
+            Self::Edge => "├──",
+            Self::Line => "│  ",
+            Self::Corner => "└──",
+            Self::Blank => "   ",
         }
     }
 }
 
-
 /// A **tree trunk** builds up arrays of tree parts over multiple depths.
 #[derive(Debug, Default)]
 pub struct TreeTrunk {
-
     /// A stack tracks which tree characters should be printed. It’s
     /// necessary to maintain information about the previously-printed
     /// lines, as the output will change based on any previous entries.
@@ -85,7 +80,6 @@ pub struct TreeTrunk {
 
 #[derive(Debug, Copy, Clone)]
 pub struct TreeParams {
-
     /// How many directories deep into the tree structure this is. Directories
     /// on top have depth 0.
     depth: TreeDepth,
@@ -98,7 +92,6 @@ pub struct TreeParams {
 pub struct TreeDepth(pub usize);
 
 impl TreeTrunk {
-
     /// Calculates the tree parts for an entry at the given depth and
     /// last-ness. The depth is used to determine where in the stack the tree
     /// part should be inserted, and the last-ness is used to determine which
@@ -107,19 +100,24 @@ impl TreeTrunk {
     /// This takes a `&mut self` because the results of each file are stored
     /// and used in future rows.
     pub fn new_row(&mut self, params: TreeParams) -> &[TreePart] {
-
         // If this isn’t our first iteration, then update the tree parts thus
         // far to account for there being another row after it.
         if let Some(last) = self.last_params {
-            self.stack[last.depth.0] = if last.last { TreePart::Blank }
-                                               else { TreePart::Line };
+            self.stack[last.depth.0] = if last.last {
+                TreePart::Blank
+            } else {
+                TreePart::Line
+            };
         }
 
         // Make sure the stack has enough space, then add or modify another
         // part into it.
         self.stack.resize(params.depth.0 + 1, TreePart::Edge);
-        self.stack[params.depth.0] = if params.last { TreePart::Corner }
-                                               else { TreePart::Edge };
+        self.stack[params.depth.0] = if params.last {
+            TreePart::Corner
+        } else {
+            TreePart::Edge
+        };
 
         self.last_params = Some(params);
 
@@ -162,12 +160,15 @@ impl TreeDepth {
     /// Creates an iterator that, as well as yielding each value, yields a
     /// `TreeParams` with the current depth and last flag filled in.
     pub fn iterate_over<I, T>(self, inner: I) -> Iter<I>
-    where I: ExactSizeIterator + Iterator<Item = T>
+    where
+        I: ExactSizeIterator + Iterator<Item = T>,
     {
-        Iter { current_depth: self, inner }
+        Iter {
+            current_depth: self,
+            inner,
+        }
     }
 }
-
 
 pub struct Iter<I> {
     current_depth: TreeDepth,
@@ -175,7 +176,8 @@ pub struct Iter<I> {
 }
 
 impl<I, T> Iterator for Iter<I>
-where I: ExactSizeIterator + Iterator<Item = T>
+where
+    I: ExactSizeIterator + Iterator<Item = T>,
 {
     type Item = (TreeParams, T);
 
@@ -188,7 +190,6 @@ where I: ExactSizeIterator + Iterator<Item = T>
     }
 }
 
-
 #[cfg(test)]
 mod trunk_test {
     use super::*;
@@ -200,51 +201,62 @@ mod trunk_test {
     #[test]
     fn empty_at_first() {
         let mut tt = TreeTrunk::default();
-        assert_eq!(tt.new_row(params(0, true)),  &[ ]);
+        assert_eq!(tt.new_row(params(0, true)), &[]);
     }
 
     #[test]
     fn one_child() {
         let mut tt = TreeTrunk::default();
-        assert_eq!(tt.new_row(params(0, true)),  &[ ]);
-        assert_eq!(tt.new_row(params(1, true)),  &[ TreePart::Corner ]);
+        assert_eq!(tt.new_row(params(0, true)), &[]);
+        assert_eq!(tt.new_row(params(1, true)), &[TreePart::Corner]);
     }
 
     #[test]
     fn two_children() {
         let mut tt = TreeTrunk::default();
-        assert_eq!(tt.new_row(params(0, true)),  &[ ]);
-        assert_eq!(tt.new_row(params(1, false)), &[ TreePart::Edge ]);
-        assert_eq!(tt.new_row(params(1, true)),  &[ TreePart::Corner ]);
+        assert_eq!(tt.new_row(params(0, true)), &[]);
+        assert_eq!(tt.new_row(params(1, false)), &[TreePart::Edge]);
+        assert_eq!(tt.new_row(params(1, true)), &[TreePart::Corner]);
     }
 
     #[test]
     fn two_times_two_children() {
         let mut tt = TreeTrunk::default();
-        assert_eq!(tt.new_row(params(0, false)), &[ ]);
-        assert_eq!(tt.new_row(params(1, false)), &[ TreePart::Edge ]);
-        assert_eq!(tt.new_row(params(1, true)),  &[ TreePart::Corner ]);
+        assert_eq!(tt.new_row(params(0, false)), &[]);
+        assert_eq!(tt.new_row(params(1, false)), &[TreePart::Edge]);
+        assert_eq!(tt.new_row(params(1, true)), &[TreePart::Corner]);
 
-        assert_eq!(tt.new_row(params(0, true)),  &[ ]);
-        assert_eq!(tt.new_row(params(1, false)), &[ TreePart::Edge ]);
-        assert_eq!(tt.new_row(params(1, true)),  &[ TreePart::Corner ]);
+        assert_eq!(tt.new_row(params(0, true)), &[]);
+        assert_eq!(tt.new_row(params(1, false)), &[TreePart::Edge]);
+        assert_eq!(tt.new_row(params(1, true)), &[TreePart::Corner]);
     }
 
     #[test]
     fn two_times_two_nested_children() {
         let mut tt = TreeTrunk::default();
-        assert_eq!(tt.new_row(params(0, true)),  &[ ]);
+        assert_eq!(tt.new_row(params(0, true)), &[]);
 
-        assert_eq!(tt.new_row(params(1, false)), &[ TreePart::Edge ]);
-        assert_eq!(tt.new_row(params(2, false)), &[ TreePart::Line, TreePart::Edge ]);
-        assert_eq!(tt.new_row(params(2, true)),  &[ TreePart::Line, TreePart::Corner ]);
+        assert_eq!(tt.new_row(params(1, false)), &[TreePart::Edge]);
+        assert_eq!(
+            tt.new_row(params(2, false)),
+            &[TreePart::Line, TreePart::Edge]
+        );
+        assert_eq!(
+            tt.new_row(params(2, true)),
+            &[TreePart::Line, TreePart::Corner]
+        );
 
-        assert_eq!(tt.new_row(params(1, true)),  &[ TreePart::Corner ]);
-        assert_eq!(tt.new_row(params(2, false)), &[ TreePart::Blank, TreePart::Edge ]);
-        assert_eq!(tt.new_row(params(2, true)),  &[ TreePart::Blank, TreePart::Corner ]);
+        assert_eq!(tt.new_row(params(1, true)), &[TreePart::Corner]);
+        assert_eq!(
+            tt.new_row(params(2, false)),
+            &[TreePart::Blank, TreePart::Edge]
+        );
+        assert_eq!(
+            tt.new_row(params(2, true)),
+            &[TreePart::Blank, TreePart::Corner]
+        );
     }
 }
-
 
 #[cfg(test)]
 mod iter_test {
@@ -252,7 +264,7 @@ mod iter_test {
 
     #[test]
     fn test_iteration() {
-        let foos = &[ "first", "middle", "last" ];
+        let foos = &["first", "middle", "last"];
         let mut iter = TreeDepth::root().iterate_over(foos.iter());
 
         let next = iter.next().unwrap();

--- a/src/theme/default_theme.rs
+++ b/src/theme/default_theme.rs
@@ -1,11 +1,11 @@
-use nu_ansi_term::Style;
 use nu_ansi_term::Color::*;
+use nu_ansi_term::Style;
 
 use crate::theme::smooth::SmoothLuts;
 use crate::theme::ui_styles::*;
 
-
 impl UiStyles {
+    #[rustfmt::skip]
     pub fn default_theme() -> Self {
         // ANSI date "gradient" collapses to a single colour —
         // matches the historical exa behaviour.  The age-based
@@ -128,12 +128,12 @@ impl UiStyles {
     }
 }
 
-
 impl UiStyles {
     /// The compiled-in `lx-256` theme: refined, recognisably
     /// exa-derived, but using the 256-colour xterm palette for
     /// smoother gradients and tasteful chrome.  Designed to look
     /// good on both light and dark backgrounds.
+    #[rustfmt::skip]
     pub fn lx_256_theme() -> Self {
         // Smooth date gradient: cyan → blue → grey.
         // Mid-tone blues: visible on both light and dark.
@@ -254,7 +254,6 @@ impl UiStyles {
     }
 }
 
-
 impl UiStyles {
     /// The compiled-in `lx-24bit` theme: refined, recognisably
     /// exa-derived, using 24-bit truecolour for the smoothest
@@ -264,6 +263,7 @@ impl UiStyles {
     /// Same hue families as `lx-256`, just with hand-picked RGB
     /// values for cleaner integration with various background
     /// luminances.
+    #[rustfmt::skip]
     pub fn lx_24bit_theme() -> Self {
         // Hand-picked RGB constants for the lx-24bit palette.
         // Mid-saturation tones that work on both light and dark
@@ -404,5 +404,3 @@ impl UiStyles {
         }
     }
 }
-
-

--- a/src/theme/error.rs
+++ b/src/theme/error.rs
@@ -2,7 +2,6 @@
 
 use thiserror::Error;
 
-
 /// Things that can go wrong when applying a configured theme.
 ///
 /// `apply_style()` and `apply_theme_def()` continue to use `warn!`
@@ -11,7 +10,6 @@ use thiserror::Error;
 /// "I can't even find the theme" path becomes a hard error.
 #[derive(Debug, Error)]
 pub enum ThemeError {
-
     /// `--theme=NAME` (or a name reached via inheritance) does not
     /// match a built-in theme or a `[theme.NAME]` config section.
     #[error("unknown theme '{name}'")]

--- a/src/theme/lsc.rs
+++ b/src/theme/lsc.rs
@@ -1,9 +1,8 @@
 use std::iter::Peekable;
 use std::ops::FnMut;
 
-use nu_ansi_term::{Color, Style};
 use nu_ansi_term::Color::*;
-
+use nu_ansi_term::{Color, Style};
 
 // Parsing the LS_COLORS environment variable into a map of names to Style values.
 //
@@ -18,31 +17,34 @@ pub struct LSColors<'var>(pub &'var str);
 
 impl<'var> LSColors<'var> {
     pub fn each_pair<C>(&mut self, mut callback: C)
-    where C: FnMut(Pair<'var>)
+    where
+        C: FnMut(Pair<'var>),
     {
         for next in self.0.split(':') {
-            let bits = next.split('=')
-                           .take(3)
-                           .collect::<Vec<_>>();
+            let bits = next.split('=').take(3).collect::<Vec<_>>();
 
-            if bits.len() == 2 && ! bits[0].is_empty() && ! bits[1].is_empty() {
-                callback(Pair { key: bits[0], value: bits[1] });
+            if bits.len() == 2 && !bits[0].is_empty() && !bits[1].is_empty() {
+                callback(Pair {
+                    key: bits[0],
+                    value: bits[1],
+                });
             }
         }
     }
 }
 
-
 fn parse_into_high_colour<'a, I>(iter: &mut Peekable<I>) -> Option<Color>
-where I: Iterator<Item = &'a str>
+where
+    I: Iterator<Item = &'a str>,
 {
     match iter.peek() {
         Some(&"5") => {
             let _ = iter.next();
             if let Some(byte) = iter.next()
-                && let Ok(num) = byte.parse() {
-                    return Some(Fixed(num));
-                }
+                && let Ok(num) = byte.parse()
+            {
+                return Some(Fixed(num));
+            }
         }
 
         Some(&"2") => {
@@ -60,21 +62,21 @@ where I: Iterator<Item = &'a str>
                     }
                 }*/
 
-                if let (Some(r), Some(g), Some(b)) = (hexes.parse().ok(),
-                                                      iter.next().and_then(|s| s.parse().ok()),
-                                                      iter.next().and_then(|s| s.parse().ok()))
-                {
+                if let (Some(r), Some(g), Some(b)) = (
+                    hexes.parse().ok(),
+                    iter.next().and_then(|s| s.parse().ok()),
+                    iter.next().and_then(|s| s.parse().ok()),
+                ) {
                     return Some(Rgb(r, g, b));
                 }
             }
         }
 
-        _ => {},
+        _ => {}
     }
 
     None
 }
-
 
 pub struct Pair<'var> {
     pub key: &'var str,
@@ -88,7 +90,6 @@ impl Pair<'_> {
 
         while let Some(num) = iter.next() {
             match num.trim_start_matches('0') {
-
                 // Bold and italic
                 "1" => style = style.bold(),
                 "2" => style = style.dimmed(),
@@ -109,7 +110,11 @@ impl Pair<'_> {
                 "35" => style = style.fg(Purple),
                 "36" => style = style.fg(Cyan),
                 "37" => style = style.fg(White),
-                "38" => if let Some(c) = parse_into_high_colour(&mut iter) { style = style.fg(c) },
+                "38" => {
+                    if let Some(c) = parse_into_high_colour(&mut iter) {
+                        style = style.fg(c)
+                    }
+                }
 
                 // Background colours
                 "40" => style = style.on(Black),
@@ -120,16 +125,19 @@ impl Pair<'_> {
                 "45" => style = style.on(Purple),
                 "46" => style = style.on(Cyan),
                 "47" => style = style.on(White),
-                "48" => if let Some(c) = parse_into_high_colour(&mut iter) { style = style.on(c) },
+                "48" => {
+                    if let Some(c) = parse_into_high_colour(&mut iter) {
+                        style = style.on(c)
+                    }
+                }
 
-                 _   => {/* ignore the error and do nothing */},
+                _ => { /* ignore the error and do nothing */ }
             }
         }
 
         style
     }
 }
-
 
 // ── Human-readable colour parser ────────────────────────────────
 //
@@ -168,14 +176,38 @@ pub fn parse_style(value: &str) -> Style {
 
         // Check modifiers first.
         match lower.as_str() {
-            "bold" => { style = style.bold(); continue; }
-            "dimmed" | "dim" => { style = style.dimmed(); continue; }
-            "italic" => { style = style.italic(); continue; }
-            "underline" => { style = style.underline(); continue; }
-            "strikethrough" => { style = style.strikethrough(); continue; }
-            "blink" => { style = style.blink(); continue; }
-            "reverse" => { style = style.reverse(); continue; }
-            "hidden" => { style = style.hidden(); continue; }
+            "bold" => {
+                style = style.bold();
+                continue;
+            }
+            "dimmed" | "dim" => {
+                style = style.dimmed();
+                continue;
+            }
+            "italic" => {
+                style = style.italic();
+                continue;
+            }
+            "underline" => {
+                style = style.underline();
+                continue;
+            }
+            "strikethrough" => {
+                style = style.strikethrough();
+                continue;
+            }
+            "blink" => {
+                style = style.blink();
+                continue;
+            }
+            "reverse" => {
+                style = style.reverse();
+                continue;
+            }
+            "hidden" => {
+                style = style.hidden();
+                continue;
+            }
             _ => {}
         }
 
@@ -203,7 +235,11 @@ pub fn parse_style(value: &str) -> Style {
         // If it looks like ANSI codes embedded in the string (e.g.
         // "bold 38;5;208"), parse just this token as ANSI.
         if token.contains(';') || token.chars().all(|c| c.is_ascii_digit()) {
-            let sub = Pair { key: "", value: token }.to_style();
+            let sub = Pair {
+                key: "",
+                value: token,
+            }
+            .to_style();
             if sub.foreground.is_some() && !has_fg {
                 style.foreground = sub.foreground;
                 has_fg = true;
@@ -212,14 +248,30 @@ pub fn parse_style(value: &str) -> Style {
                 style.background = sub.background;
             }
             // Merge attributes.
-            if sub.is_bold      { style = style.bold(); }
-            if sub.is_dimmed    { style = style.dimmed(); }
-            if sub.is_italic    { style = style.italic(); }
-            if sub.is_underline { style = style.underline(); }
-            if sub.is_blink     { style = style.blink(); }
-            if sub.is_reverse   { style = style.reverse(); }
-            if sub.is_hidden    { style = style.hidden(); }
-            if sub.is_strikethrough { style = style.strikethrough(); }
+            if sub.is_bold {
+                style = style.bold();
+            }
+            if sub.is_dimmed {
+                style = style.dimmed();
+            }
+            if sub.is_italic {
+                style = style.italic();
+            }
+            if sub.is_underline {
+                style = style.underline();
+            }
+            if sub.is_blink {
+                style = style.blink();
+            }
+            if sub.is_reverse {
+                style = style.reverse();
+            }
+            if sub.is_hidden {
+                style = style.hidden();
+            }
+            if sub.is_strikethrough {
+                style = style.strikethrough();
+            }
             continue;
         }
 
@@ -239,14 +291,14 @@ fn looks_like_ansi(s: &str) -> bool {
 /// Map basic ANSI colour names to `Color` values.
 fn basic_colour(name: &str) -> Option<Color> {
     match name {
-        "black"   => Some(Black),
-        "red"     => Some(Red),
-        "green"   => Some(Green),
-        "yellow"  => Some(Yellow),
-        "blue"    => Some(Blue),
+        "black" => Some(Black),
+        "red" => Some(Red),
+        "green" => Some(Green),
+        "yellow" => Some(Yellow),
+        "blue" => Some(Blue),
         "purple" | "magenta" => Some(Purple),
-        "cyan"    => Some(Cyan),
-        "white"   => Some(White),
+        "cyan" => Some(Cyan),
+        "white" => Some(White),
         _ => None,
     }
 }
@@ -270,7 +322,6 @@ fn parse_hex(s: &str) -> Option<Color> {
         _ => None,
     }
 }
-
 
 /// X11/CSS colour names → RGB values.
 ///
@@ -418,7 +469,6 @@ static X11_COLOURS: phf::Map<&'static str, (u8, u8, u8)> = phf::phf_map! {
     "yellowgreen" => (154, 205, 50),
 };
 
-
 #[cfg(test)]
 mod ansi_test {
     use super::*;
@@ -428,7 +478,14 @@ mod ansi_test {
         ($name:ident: $input:expr => $result:expr) => {
             #[test]
             fn $name() {
-                assert_eq!(Pair { key: "", value: $input }.to_style(), $result);
+                assert_eq!(
+                    Pair {
+                        key: "",
+                        value: $input
+                    }
+                    .to_style(),
+                    $result
+                );
             }
         };
     }
@@ -469,7 +526,6 @@ mod ansi_test {
     test!(toohi: "48;5;999"           => Style::default());
 }
 
-
 #[cfg(test)]
 mod test {
     use super::*;
@@ -479,7 +535,7 @@ mod test {
             #[test]
             fn $name() {
                 let mut lscs = Vec::new();
-                LSColors($input).each_pair(|p| lscs.push( (p.key.clone(), p.to_style()) ));
+                LSColors($input).each_pair(|p| lscs.push((p.key.clone(), p.to_style())));
                 assert_eq!(lscs, $result.to_vec());
             }
         };
@@ -512,7 +568,6 @@ mod test {
     test!(more:  "me=43;21;55;34:yu=1;4;1"  => [ ("me", Blue.on(Yellow)), ("yu", Style::default().bold().underline()) ]);
     test!(many:  "red=31:green=32:blue=34"  => [ ("red", Red.normal()), ("green", Green.normal()), ("blue", Blue.normal()) ]);
 }
-
 
 #[cfg(test)]
 mod parse_style_test {
@@ -548,7 +603,10 @@ mod parse_style_test {
 
     #[test]
     fn multiple_modifiers() {
-        assert_eq!(parse_style("bold underline"), Style::default().bold().underline());
+        assert_eq!(
+            parse_style("bold underline"),
+            Style::default().bold().underline()
+        );
     }
 
     #[test]
@@ -563,7 +621,10 @@ mod parse_style_test {
 
     #[test]
     fn hex_colour_6() {
-        assert_eq!(parse_style("#ff8700"), Style::default().fg(Rgb(255, 135, 0)));
+        assert_eq!(
+            parse_style("#ff8700"),
+            Style::default().fg(Rgb(255, 135, 0))
+        );
     }
 
     #[test]
@@ -574,7 +635,10 @@ mod parse_style_test {
 
     #[test]
     fn bold_hex() {
-        assert_eq!(parse_style("bold #ff8700"), Style::default().fg(Rgb(255, 135, 0)).bold());
+        assert_eq!(
+            parse_style("bold #ff8700"),
+            Style::default().fg(Rgb(255, 135, 0)).bold()
+        );
     }
 
     #[test]
@@ -584,12 +648,18 @@ mod parse_style_test {
 
     #[test]
     fn bold_x11() {
-        assert_eq!(parse_style("bold tomato"), Style::default().fg(Rgb(255, 99, 71)).bold());
+        assert_eq!(
+            parse_style("bold tomato"),
+            Style::default().fg(Rgb(255, 99, 71)).bold()
+        );
     }
 
     #[test]
     fn x11_cornflowerblue() {
-        assert_eq!(parse_style("cornflowerblue"), Style::default().fg(Rgb(100, 149, 237)));
+        assert_eq!(
+            parse_style("cornflowerblue"),
+            Style::default().fg(Rgb(100, 149, 237))
+        );
     }
 
     #[test]

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -5,7 +5,7 @@ use crate::output::file_name::Colours as FileNameColours;
 use crate::output::render;
 
 mod ui_styles;
-pub use self::ui_styles::{UiStyles, DateAge};
+pub use self::ui_styles::{DateAge, UiStyles};
 
 mod lsc;
 pub use self::lsc::LSColors;
@@ -19,10 +19,8 @@ mod oklab;
 mod smooth;
 pub use self::smooth::age_to_position;
 
-
 #[derive(PartialEq, Eq, Debug)]
 pub struct Options {
-
     pub use_colours: UseColours,
 
     pub gradient: GradientFlags,
@@ -51,11 +49,11 @@ pub struct Options {
 #[derive(PartialEq, Eq, Debug, Copy, Clone)]
 #[allow(clippy::struct_excessive_bools)] // one bool per gradient column is the natural shape
 pub struct GradientFlags {
-    pub size:     bool,
+    pub size: bool,
     pub modified: bool,
     pub accessed: bool,
-    pub changed:  bool,
-    pub created:  bool,
+    pub changed: bool,
+    pub created: bool,
 
     /// Whether to smooth the gradients into a 256-stop
     /// perceptually-uniform interpolation between the theme's
@@ -69,24 +67,24 @@ impl GradientFlags {
     /// All gradients on.  This is the default — themes that ship
     /// gradient values are designed to show them.
     pub const ALL: Self = Self {
-        size:     true,
+        size: true,
         modified: true,
         accessed: true,
-        changed:  true,
-        created:  true,
-        smooth:   false,
+        changed: true,
+        created: true,
+        smooth: false,
     };
 
     /// All gradients off.  Each column collapses to its theme's
     /// flat colour (`size.major`/`size.minor` for size, the
     /// per-column `date_*.flat` for each timestamp).
     pub const NONE: Self = Self {
-        size:     false,
+        size: false,
         modified: false,
         accessed: false,
-        changed:  false,
-        created:  false,
-        smooth:   false,
+        changed: false,
+        created: false,
+        smooth: false,
     };
 }
 
@@ -105,7 +103,6 @@ impl Default for GradientFlags {
 /// this check and only displays colours when they can be truly appreciated.
 #[derive(PartialEq, Eq, Debug, Copy, Clone)]
 pub enum UseColours {
-
     /// Display them even when output isn’t going to a terminal.
     Always,
 
@@ -121,15 +118,13 @@ pub struct Definitions {
     pub ls: Option<String>,
 }
 
-
 pub struct Theme {
     pub ui: UiStyles,
     pub exts: Box<dyn FileColours>,
 }
 
 impl Options {
-
-    #[allow(trivial_casts)]   // the `as Box<_>` stuff below warns about this for some reason
+    #[allow(trivial_casts)] // the `as Box<_>` stuff below warns about this for some reason
     pub fn to_theme(&self, isatty: bool) -> Result<Theme, ThemeError> {
         // Validate the theme name early — even when colours are off,
         // the user should know if they've misspelled a theme name.
@@ -139,7 +134,9 @@ impl Options {
             Self::validate_theme_name(name, cfg)?;
         }
 
-        if self.use_colours == UseColours::Never || (self.use_colours == UseColours::Automatic && ! isatty) {
+        if self.use_colours == UseColours::Never
+            || (self.use_colours == UseColours::Automatic && !isatty)
+        {
             let ui = UiStyles::plain();
             let exts = Box::new(NoFileColours);
             return Ok(Theme { ui, exts });
@@ -210,7 +207,9 @@ impl Options {
             } else if let Some(theme) = cfg.theme.get(tname) {
                 current = theme.inherits.clone();
             } else {
-                return Err(ThemeError::Unknown { name: tname.clone() });
+                return Err(ThemeError::Unknown {
+                    name: tname.clone(),
+                });
             }
         }
 
@@ -231,7 +230,7 @@ impl Options {
         exts: &mut ExtensionMappings,
     ) -> Result<(), ThemeError> {
         let Some(ref name) = self.theme_override else {
-            return Ok(());  // no theme selected
+            return Ok(()); // no theme selected
         };
 
         // Build the inheritance chain: [leaf, ..., root].
@@ -275,7 +274,9 @@ impl Options {
                 // Should not reach here — validate_theme_name catches
                 // unknown names early — but be defensive in case the
                 // chain reaches an inherits target that isn't defined.
-                return Err(ThemeError::Unknown { name: tname.clone() });
+                return Err(ThemeError::Unknown {
+                    name: tname.clone(),
+                });
             }
         }
 
@@ -361,7 +362,6 @@ impl Options {
     }
 }
 
-
 /// Specificity bucket for a theme key.  [`Self::apply_theme_def`]
 /// sorts theme entries by this value before applying them, so
 /// more generic setters run before more specific ones and the
@@ -401,7 +401,11 @@ fn theme_key_precedence(key: &str) -> u8 {
 
     // `date-<col>-<tier>` → most specific.
     for col in COLUMNS {
-        if rest.strip_prefix(col).and_then(|r| r.strip_prefix('-')).is_some() {
+        if rest
+            .strip_prefix(col)
+            .and_then(|r| r.strip_prefix('-'))
+            .is_some()
+        {
             return 3;
         }
     }
@@ -453,13 +457,9 @@ mod theme_key_precedence_test {
         // must put generic first, specific last.
         assert!(theme_key_precedence("date") < theme_key_precedence("date-now"));
         assert!(theme_key_precedence("date-now") < theme_key_precedence("date-modified"));
-        assert!(
-            theme_key_precedence("date-modified")
-                < theme_key_precedence("date-modified-now")
-        );
+        assert!(theme_key_precedence("date-modified") < theme_key_precedence("date-modified-now"));
     }
 }
-
 
 #[cfg(test)]
 mod apply_theme_def_test {
@@ -493,7 +493,11 @@ mod apply_theme_def_test {
         for (k, v) in entries {
             ui.insert(k.into(), v.into());
         }
-        ThemeDef { inherits: None, use_style: None, ui }
+        ThemeDef {
+            inherits: None,
+            use_style: None,
+            ui,
+        }
     }
 
     fn apply(theme: &ThemeDef) -> UiStyles {
@@ -511,19 +515,16 @@ mod apply_theme_def_test {
         // just one cell.  Before the precedence-sort fix this was
         // nondeterministic — the bulk setter would sometimes run
         // last and clobber the per-column override.
-        let theme = theme_def_with([
-            ("date", "blue"),
-            ("date-modified-now", "bright green"),
-        ]);
+        let theme = theme_def_with([("date", "blue"), ("date-modified-now", "bright green")]);
         let ui = apply(&theme);
 
         assert_eq!(ui.date_modified.now, parse_style("bright green"));
         // Every other slot on every column falls through to the
         // bulk setter.
         assert_eq!(ui.date_modified.today, parse_style("blue"));
-        assert_eq!(ui.date_accessed.now,   parse_style("blue"));
-        assert_eq!(ui.date_changed.now,    parse_style("blue"));
-        assert_eq!(ui.date_created.now,    parse_style("blue"));
+        assert_eq!(ui.date_accessed.now, parse_style("blue"));
+        assert_eq!(ui.date_changed.now, parse_style("blue"));
+        assert_eq!(ui.date_created.now, parse_style("blue"));
     }
 
     #[test]
@@ -544,19 +545,19 @@ mod apply_theme_def_test {
         // modified column:
         //   - `now` tier overridden at bucket 3 → bright green
         //   - every other tier overridden at bucket 2 → white
-        assert_eq!(ui.date_modified.now,   parse_style("bright green"));
+        assert_eq!(ui.date_modified.now, parse_style("bright green"));
         assert_eq!(ui.date_modified.today, parse_style("white"));
-        assert_eq!(ui.date_modified.flat,  parse_style("white"));
+        assert_eq!(ui.date_modified.flat, parse_style("white"));
 
         // accessed/changed/created columns:
         //   - `now` tier overridden at bucket 1 → bright cyan
         //   - every other tier set at bucket 0 → blue
-        assert_eq!(ui.date_accessed.now,   parse_style("bright cyan"));
+        assert_eq!(ui.date_accessed.now, parse_style("bright cyan"));
         assert_eq!(ui.date_accessed.today, parse_style("blue"));
-        assert_eq!(ui.date_changed.now,    parse_style("bright cyan"));
-        assert_eq!(ui.date_changed.today,  parse_style("blue"));
-        assert_eq!(ui.date_created.now,    parse_style("bright cyan"));
-        assert_eq!(ui.date_created.today,  parse_style("blue"));
+        assert_eq!(ui.date_changed.now, parse_style("bright cyan"));
+        assert_eq!(ui.date_changed.today, parse_style("blue"));
+        assert_eq!(ui.date_created.now, parse_style("bright cyan"));
+        assert_eq!(ui.date_created.today, parse_style("blue"));
     }
 
     #[test]
@@ -567,15 +568,15 @@ mod apply_theme_def_test {
         let theme = theme_def_with([
             ("date-modified-now", "cyan"),
             ("date-accessed-now", "green"),
-            ("date-changed-now",  "magenta"),
-            ("date-created-now",  "red"),
+            ("date-changed-now", "magenta"),
+            ("date-created-now", "red"),
         ]);
         let ui = apply(&theme);
 
         assert_eq!(ui.date_modified.now, parse_style("cyan"));
         assert_eq!(ui.date_accessed.now, parse_style("green"));
-        assert_eq!(ui.date_changed.now,  parse_style("magenta"));
-        assert_eq!(ui.date_created.now,  parse_style("red"));
+        assert_eq!(ui.date_changed.now, parse_style("magenta"));
+        assert_eq!(ui.date_created.now, parse_style("red"));
     }
 
     #[test]
@@ -583,24 +584,22 @@ mod apply_theme_def_test {
         // `date-modified = "red"` should set every tier (now,
         // today, week, month, year, old, flat) on the modified
         // column, leaving the other three untouched.
-        let theme = theme_def_with([
-            ("date-modified", "red"),
-        ]);
+        let theme = theme_def_with([("date-modified", "red")]);
         let ui = apply(&theme);
 
         let red = parse_style("red");
-        assert_eq!(ui.date_modified.now,   red);
+        assert_eq!(ui.date_modified.now, red);
         assert_eq!(ui.date_modified.today, red);
-        assert_eq!(ui.date_modified.week,  red);
+        assert_eq!(ui.date_modified.week, red);
         assert_eq!(ui.date_modified.month, red);
-        assert_eq!(ui.date_modified.year,  red);
-        assert_eq!(ui.date_modified.old,   red);
-        assert_eq!(ui.date_modified.flat,  red);
+        assert_eq!(ui.date_modified.year, red);
+        assert_eq!(ui.date_modified.old, red);
+        assert_eq!(ui.date_modified.flat, red);
 
         // Untouched columns keep the default (empty) style.
         assert_eq!(ui.date_accessed.now, Style::default());
-        assert_eq!(ui.date_changed.now,  Style::default());
-        assert_eq!(ui.date_created.now,  Style::default());
+        assert_eq!(ui.date_changed.now, Style::default());
+        assert_eq!(ui.date_created.now, Style::default());
     }
 
     #[test]
@@ -619,34 +618,34 @@ mod apply_theme_def_test {
 
                 let red = parse_style("red");
                 let actual = match (col, tier) {
-                    ("modified", "now")   => ui.date_modified.now,
+                    ("modified", "now") => ui.date_modified.now,
                     ("modified", "today") => ui.date_modified.today,
-                    ("modified", "week")  => ui.date_modified.week,
+                    ("modified", "week") => ui.date_modified.week,
                     ("modified", "month") => ui.date_modified.month,
-                    ("modified", "year")  => ui.date_modified.year,
-                    ("modified", "old")   => ui.date_modified.old,
-                    ("modified", "flat")  => ui.date_modified.flat,
-                    ("accessed", "now")   => ui.date_accessed.now,
+                    ("modified", "year") => ui.date_modified.year,
+                    ("modified", "old") => ui.date_modified.old,
+                    ("modified", "flat") => ui.date_modified.flat,
+                    ("accessed", "now") => ui.date_accessed.now,
                     ("accessed", "today") => ui.date_accessed.today,
-                    ("accessed", "week")  => ui.date_accessed.week,
+                    ("accessed", "week") => ui.date_accessed.week,
                     ("accessed", "month") => ui.date_accessed.month,
-                    ("accessed", "year")  => ui.date_accessed.year,
-                    ("accessed", "old")   => ui.date_accessed.old,
-                    ("accessed", "flat")  => ui.date_accessed.flat,
-                    ("changed",  "now")   => ui.date_changed.now,
-                    ("changed",  "today") => ui.date_changed.today,
-                    ("changed",  "week")  => ui.date_changed.week,
-                    ("changed",  "month") => ui.date_changed.month,
-                    ("changed",  "year")  => ui.date_changed.year,
-                    ("changed",  "old")   => ui.date_changed.old,
-                    ("changed",  "flat")  => ui.date_changed.flat,
-                    ("created",  "now")   => ui.date_created.now,
-                    ("created",  "today") => ui.date_created.today,
-                    ("created",  "week")  => ui.date_created.week,
-                    ("created",  "month") => ui.date_created.month,
-                    ("created",  "year")  => ui.date_created.year,
-                    ("created",  "old")   => ui.date_created.old,
-                    ("created",  "flat")  => ui.date_created.flat,
+                    ("accessed", "year") => ui.date_accessed.year,
+                    ("accessed", "old") => ui.date_accessed.old,
+                    ("accessed", "flat") => ui.date_accessed.flat,
+                    ("changed", "now") => ui.date_changed.now,
+                    ("changed", "today") => ui.date_changed.today,
+                    ("changed", "week") => ui.date_changed.week,
+                    ("changed", "month") => ui.date_changed.month,
+                    ("changed", "year") => ui.date_changed.year,
+                    ("changed", "old") => ui.date_changed.old,
+                    ("changed", "flat") => ui.date_changed.flat,
+                    ("created", "now") => ui.date_created.now,
+                    ("created", "today") => ui.date_created.today,
+                    ("created", "week") => ui.date_created.week,
+                    ("created", "month") => ui.date_created.month,
+                    ("created", "year") => ui.date_created.year,
+                    ("created", "old") => ui.date_created.old,
+                    ("created", "flat") => ui.date_created.flat,
                     _ => unreachable!(),
                 };
                 assert_eq!(
@@ -659,7 +658,6 @@ mod apply_theme_def_test {
 }
 
 impl Definitions {
-
     /// Parse `LS_COLORS` into a pair of outputs: recognised two-letter
     /// file-kind codes modify the mutable `UiStyles`, and any
     /// glob-style entries (e.g. `*.txt=31`) populate the returned
@@ -671,7 +669,7 @@ impl Definitions {
 
         if let Some(lsc) = &self.ls {
             LSColors(lsc).each_pair(|pair| {
-                if ! colours.set_ls(&pair) {
+                if !colours.set_ls(&pair) {
                     match glob::Pattern::new(pair.key) {
                         Ok(pat) => {
                             exts.add(pat, pair.to_style());
@@ -687,7 +685,6 @@ impl Definitions {
         exts
     }
 }
-
 
 pub trait FileColours: std::marker::Sync {
     fn colour_file(&self, file: &File<'_>) -> Option<Style>;
@@ -706,15 +703,16 @@ impl FileColours for NoFileColours {
 // file type associations, while falling back to the default set if not set
 // explicitly.
 impl<A, B> FileColours for (A, B)
-where A: FileColours,
-      B: FileColours,
+where
+    A: FileColours,
+    B: FileColours,
 {
     fn colour_file(&self, file: &File<'_>) -> Option<Style> {
-        self.0.colour_file(file)
+        self.0
+            .colour_file(file)
             .or_else(|| self.1.colour_file(file))
     }
 }
-
 
 #[derive(PartialEq, Debug, Default)]
 struct ExtensionMappings {
@@ -726,15 +724,17 @@ struct ExtensionMappings {
 
 impl FileColours for ExtensionMappings {
     fn colour_file(&self, file: &File<'_>) -> Option<Style> {
-        self.mappings.iter().rev()
+        self.mappings
+            .iter()
+            .rev()
             .find(|t| t.0.matches(&file.name))
-            .map (|t| t.1)
+            .map(|t| t.1)
     }
 }
 
 impl ExtensionMappings {
     fn is_non_empty(&self) -> bool {
-        ! self.mappings.is_empty()
+        !self.mappings.is_empty()
     }
 
     fn add(&mut self, pattern: glob::Pattern, style: Style) {
@@ -742,75 +742,160 @@ impl ExtensionMappings {
     }
 }
 
-
-
-
 impl render::BlocksColours for Theme {
-    fn block_count(&self)  -> Style { self.ui.blocks }
-    fn no_blocks(&self)    -> Style { self.ui.punctuation }
+    fn block_count(&self) -> Style {
+        self.ui.blocks
+    }
+    fn no_blocks(&self) -> Style {
+        self.ui.punctuation
+    }
 }
 
 impl render::FiletypeColours for Theme {
-    fn normal(&self)       -> Style { self.ui.filekinds.normal }
-    fn directory(&self)    -> Style { self.ui.filekinds.directory }
-    fn pipe(&self)         -> Style { self.ui.filekinds.pipe }
-    fn symlink(&self)      -> Style { self.ui.filekinds.symlink }
-    fn block_device(&self) -> Style { self.ui.filekinds.block_device }
-    fn char_device(&self)  -> Style { self.ui.filekinds.char_device }
-    fn socket(&self)       -> Style { self.ui.filekinds.socket }
-    fn special(&self)      -> Style { self.ui.filekinds.special }
+    fn normal(&self) -> Style {
+        self.ui.filekinds.normal
+    }
+    fn directory(&self) -> Style {
+        self.ui.filekinds.directory
+    }
+    fn pipe(&self) -> Style {
+        self.ui.filekinds.pipe
+    }
+    fn symlink(&self) -> Style {
+        self.ui.filekinds.symlink
+    }
+    fn block_device(&self) -> Style {
+        self.ui.filekinds.block_device
+    }
+    fn char_device(&self) -> Style {
+        self.ui.filekinds.char_device
+    }
+    fn socket(&self) -> Style {
+        self.ui.filekinds.socket
+    }
+    fn special(&self) -> Style {
+        self.ui.filekinds.special
+    }
 }
 
 impl render::VcsColours for Theme {
-    fn not_modified(&self)  -> Style { self.ui.punctuation }
+    fn not_modified(&self) -> Style {
+        self.ui.punctuation
+    }
     #[allow(clippy::new_ret_no_self)]
-    fn new(&self)           -> Style { self.ui.vcs.new }
-    fn modified(&self)      -> Style { self.ui.vcs.modified }
-    fn deleted(&self)       -> Style { self.ui.vcs.deleted }
-    fn renamed(&self)       -> Style { self.ui.vcs.renamed }
-    fn type_change(&self)   -> Style { self.ui.vcs.typechange }
-    fn ignored(&self)       -> Style { self.ui.vcs.ignored }
-    fn conflicted(&self)    -> Style { self.ui.vcs.conflicted }
+    fn new(&self) -> Style {
+        self.ui.vcs.new
+    }
+    fn modified(&self) -> Style {
+        self.ui.vcs.modified
+    }
+    fn deleted(&self) -> Style {
+        self.ui.vcs.deleted
+    }
+    fn renamed(&self) -> Style {
+        self.ui.vcs.renamed
+    }
+    fn type_change(&self) -> Style {
+        self.ui.vcs.typechange
+    }
+    fn ignored(&self) -> Style {
+        self.ui.vcs.ignored
+    }
+    fn conflicted(&self) -> Style {
+        self.ui.vcs.conflicted
+    }
 }
 
 impl render::VcsReposColours for Theme {
-    fn not_a_repo(&self)   -> Style { self.ui.punctuation }
-    fn clean_repo(&self)   -> Style { self.ui.vcs.new }       // green-ish
-    fn dirty_repo(&self)   -> Style { self.ui.vcs.modified }  // yellow-ish
-    fn jj_repo(&self)      -> Style { self.ui.vcs.new }       // green-ish (neutral)
+    fn not_a_repo(&self) -> Style {
+        self.ui.punctuation
+    }
+    fn clean_repo(&self) -> Style {
+        self.ui.vcs.new
+    } // green-ish
+    fn dirty_repo(&self) -> Style {
+        self.ui.vcs.modified
+    } // yellow-ish
+    fn jj_repo(&self) -> Style {
+        self.ui.vcs.new
+    } // green-ish (neutral)
 }
 
 #[cfg(unix)]
 impl render::GroupColours for Theme {
-    fn yours(&self)      -> Style { self.ui.users.group_yours }
-    fn member(&self)     -> Style { self.ui.users.group_member }
-    fn not_yours(&self)  -> Style { self.ui.users.group_not_yours }
+    fn yours(&self) -> Style {
+        self.ui.users.group_yours
+    }
+    fn member(&self) -> Style {
+        self.ui.users.group_member
+    }
+    fn not_yours(&self) -> Style {
+        self.ui.users.group_not_yours
+    }
 
-    fn gid_yours(&self)     -> Style { self.ui.users.gid_yours }
-    fn gid_member(&self)    -> Style { self.ui.users.gid_member }
-    fn gid_not_yours(&self) -> Style { self.ui.users.gid_not_yours }
+    fn gid_yours(&self) -> Style {
+        self.ui.users.gid_yours
+    }
+    fn gid_member(&self) -> Style {
+        self.ui.users.gid_member
+    }
+    fn gid_not_yours(&self) -> Style {
+        self.ui.users.gid_not_yours
+    }
 }
 
 impl render::LinksColours for Theme {
-    fn normal(&self)           -> Style { self.ui.links.normal }
-    fn multi_link_file(&self)  -> Style { self.ui.links.multi_link_file }
+    fn normal(&self) -> Style {
+        self.ui.links.normal
+    }
+    fn multi_link_file(&self) -> Style {
+        self.ui.links.multi_link_file
+    }
 }
 
 impl render::PermissionsColours for Theme {
-    fn dash(&self)               -> Style { self.ui.punctuation }
-    fn user_read(&self)          -> Style { self.ui.perms.user_read }
-    fn user_write(&self)         -> Style { self.ui.perms.user_write }
-    fn user_execute_file(&self)  -> Style { self.ui.perms.user_execute_file }
-    fn user_execute_other(&self) -> Style { self.ui.perms.user_execute_other }
-    fn group_read(&self)         -> Style { self.ui.perms.group_read }
-    fn group_write(&self)        -> Style { self.ui.perms.group_write }
-    fn group_execute(&self)      -> Style { self.ui.perms.group_execute }
-    fn other_read(&self)         -> Style { self.ui.perms.other_read }
-    fn other_write(&self)        -> Style { self.ui.perms.other_write }
-    fn other_execute(&self)      -> Style { self.ui.perms.other_execute }
-    fn special_user_file(&self)  -> Style { self.ui.perms.special_user_file }
-    fn special_other(&self)      -> Style { self.ui.perms.special_other }
-    fn attribute(&self)          -> Style { self.ui.perms.attribute }
+    fn dash(&self) -> Style {
+        self.ui.punctuation
+    }
+    fn user_read(&self) -> Style {
+        self.ui.perms.user_read
+    }
+    fn user_write(&self) -> Style {
+        self.ui.perms.user_write
+    }
+    fn user_execute_file(&self) -> Style {
+        self.ui.perms.user_execute_file
+    }
+    fn user_execute_other(&self) -> Style {
+        self.ui.perms.user_execute_other
+    }
+    fn group_read(&self) -> Style {
+        self.ui.perms.group_read
+    }
+    fn group_write(&self) -> Style {
+        self.ui.perms.group_write
+    }
+    fn group_execute(&self) -> Style {
+        self.ui.perms.group_execute
+    }
+    fn other_read(&self) -> Style {
+        self.ui.perms.other_read
+    }
+    fn other_write(&self) -> Style {
+        self.ui.perms.other_write
+    }
+    fn other_execute(&self) -> Style {
+        self.ui.perms.other_execute
+    }
+    fn special_user_file(&self) -> Style {
+        self.ui.perms.special_user_file
+    }
+    fn special_other(&self) -> Style {
+        self.ui.perms.special_other
+    }
+    fn attribute(&self) -> Style {
+        self.ui.perms.attribute
+    }
 }
 
 impl render::SizeColours for Theme {
@@ -830,8 +915,8 @@ impl render::SizeColours for Theme {
             Some(Kilo | Kibi) => self.ui.size.number_kilo,
             Some(Mega | Mebi) => self.ui.size.number_mega,
             Some(Giga | Gibi) => self.ui.size.number_giga,
-            Some(_)           => self.ui.size.number_huge,
-            None              => self.ui.size.number_byte,
+            Some(_) => self.ui.size.number_huge,
+            None => self.ui.size.number_byte,
         }
     }
 
@@ -842,40 +927,71 @@ impl render::SizeColours for Theme {
             Some(Kilo | Kibi) => self.ui.size.unit_kilo,
             Some(Mega | Mebi) => self.ui.size.unit_mega,
             Some(Giga | Gibi) => self.ui.size.unit_giga,
-            Some(_)           => self.ui.size.unit_huge,
-            None              => self.ui.size.unit_byte,
+            Some(_) => self.ui.size.unit_huge,
+            None => self.ui.size.unit_byte,
         }
     }
 
-    fn no_size(&self) -> Style { self.ui.punctuation }
-    fn major(&self)   -> Style { self.ui.size.major }
-    fn comma(&self)   -> Style { self.ui.punctuation }
-    fn minor(&self)   -> Style { self.ui.size.minor }
+    fn no_size(&self) -> Style {
+        self.ui.punctuation
+    }
+    fn major(&self) -> Style {
+        self.ui.size.major
+    }
+    fn comma(&self) -> Style {
+        self.ui.punctuation
+    }
+    fn minor(&self) -> Style {
+        self.ui.size.minor
+    }
 }
 
 #[cfg(unix)]
 impl render::UserColours for Theme {
-    fn you(&self)           -> Style { self.ui.users.user_you }
-    fn someone_else(&self)  -> Style { self.ui.users.user_someone_else }
+    fn you(&self) -> Style {
+        self.ui.users.user_you
+    }
+    fn someone_else(&self) -> Style {
+        self.ui.users.user_someone_else
+    }
 
-    fn uid_you(&self)           -> Style { self.ui.users.uid_you }
-    fn uid_someone_else(&self)  -> Style { self.ui.users.uid_someone_else }
-}
-
-impl FileNameColours for Theme {
-    fn normal_arrow(&self)        -> Style { self.ui.punctuation }
-    fn broken_symlink(&self)      -> Style { self.ui.broken_symlink }
-    fn broken_filename(&self)     -> Style { apply_overlay(self.ui.broken_symlink, self.ui.broken_path_overlay) }
-    fn broken_control_char(&self) -> Style { apply_overlay(self.ui.control_char,   self.ui.broken_path_overlay) }
-    fn control_char(&self)        -> Style { self.ui.control_char }
-    fn symlink_path(&self)        -> Style { self.ui.symlink_path }
-    fn executable_file(&self)     -> Style { self.ui.filekinds.executable }
-
-    fn colour_file(&self, file: &File<'_>) -> Style {
-        self.exts.colour_file(file).unwrap_or(self.ui.filekinds.normal)
+    fn uid_you(&self) -> Style {
+        self.ui.users.uid_you
+    }
+    fn uid_someone_else(&self) -> Style {
+        self.ui.users.uid_someone_else
     }
 }
 
+impl FileNameColours for Theme {
+    fn normal_arrow(&self) -> Style {
+        self.ui.punctuation
+    }
+    fn broken_symlink(&self) -> Style {
+        self.ui.broken_symlink
+    }
+    fn broken_filename(&self) -> Style {
+        apply_overlay(self.ui.broken_symlink, self.ui.broken_path_overlay)
+    }
+    fn broken_control_char(&self) -> Style {
+        apply_overlay(self.ui.control_char, self.ui.broken_path_overlay)
+    }
+    fn control_char(&self) -> Style {
+        self.ui.control_char
+    }
+    fn symlink_path(&self) -> Style {
+        self.ui.symlink_path
+    }
+    fn executable_file(&self) -> Style {
+        self.ui.filekinds.executable
+    }
+
+    fn colour_file(&self, file: &File<'_>) -> Style {
+        self.exts
+            .colour_file(file)
+            .unwrap_or(self.ui.filekinds.normal)
+    }
+}
 
 /// Some of the styles are **overlays**: although they have the same attribute
 /// set as regular styles (foreground and background colours, bold, underline,
@@ -890,22 +1006,41 @@ impl FileNameColours for Theme {
 /// “broken link overlay”, the latter of which is just set to override the
 /// underline attribute on the other two.
 fn apply_overlay(mut base: Style, overlay: Style) -> Style {
-    if let Some(fg) = overlay.foreground { base.foreground = Some(fg); }
-    if let Some(bg) = overlay.background { base.background = Some(bg); }
+    if let Some(fg) = overlay.foreground {
+        base.foreground = Some(fg);
+    }
+    if let Some(bg) = overlay.background {
+        base.background = Some(bg);
+    }
 
-    if overlay.is_bold          { base.is_bold          = true; }
-    if overlay.is_dimmed        { base.is_dimmed        = true; }
-    if overlay.is_italic        { base.is_italic        = true; }
-    if overlay.is_underline     { base.is_underline     = true; }
-    if overlay.is_blink         { base.is_blink         = true; }
-    if overlay.is_reverse       { base.is_reverse       = true; }
-    if overlay.is_hidden        { base.is_hidden        = true; }
-    if overlay.is_strikethrough { base.is_strikethrough = true; }
+    if overlay.is_bold {
+        base.is_bold = true;
+    }
+    if overlay.is_dimmed {
+        base.is_dimmed = true;
+    }
+    if overlay.is_italic {
+        base.is_italic = true;
+    }
+    if overlay.is_underline {
+        base.is_underline = true;
+    }
+    if overlay.is_blink {
+        base.is_blink = true;
+    }
+    if overlay.is_reverse {
+        base.is_reverse = true;
+    }
+    if overlay.is_hidden {
+        base.is_hidden = true;
+    }
+    if overlay.is_strikethrough {
+        base.is_strikethrough = true;
+    }
 
     base
 }
 // TODO: move this function to the nu_ansi_term crate
-
 
 #[cfg(test)]
 mod customs_test {
@@ -932,10 +1067,10 @@ mod customs_test {
         ($name:ident: ls $ls:expr => exts $mappings:expr) => {
             #[test]
             fn $name() {
-                let mappings: Vec<(glob::Pattern, Style)>
-                    = $mappings.iter()
-                               .map(|t| (glob::Pattern::new(t.0).unwrap(), t.1))
-                               .collect();
+                let mappings: Vec<(glob::Pattern, Style)> = $mappings
+                    .iter()
+                    .map(|t| (glob::Pattern::new(t.0).unwrap(), t.1))
+                    .collect();
 
                 let definitions = Definitions {
                     ls: Some($ls.into()),
@@ -946,7 +1081,6 @@ mod customs_test {
             }
         };
     }
-
 
     // LS_COLORS can affect all of these colours:
     test!(ls_di: ls "di=31" => colours c -> { c.filekinds.directory    = Red.normal();    });
@@ -987,7 +1121,6 @@ mod customs_test {
     });
 }
 
-
 #[cfg(test)]
 #[cfg(unix)]
 mod uid_gid_theme_test {
@@ -997,7 +1130,10 @@ mod uid_gid_theme_test {
     use nu_ansi_term::Color::*;
 
     fn theme_with(ui: UiStyles) -> Theme {
-        Theme { ui, exts: Box::new(NoFileColours) }
+        Theme {
+            ui,
+            exts: Box::new(NoFileColours),
+        }
     }
 
     #[test]
@@ -1008,6 +1144,9 @@ mod uid_gid_theme_test {
 
         let theme = theme_with(ui);
         assert_eq!(<Theme as UserColours>::uid_you(&theme), Red.normal());
-        assert_eq!(<Theme as UserColours>::uid_someone_else(&theme), Green.normal());
+        assert_eq!(
+            <Theme as UserColours>::uid_someone_else(&theme),
+            Green.normal()
+        );
     }
 }

--- a/src/theme/oklab.rs
+++ b/src/theme/oklab.rs
@@ -36,8 +36,8 @@ pub fn srgb_to_oklab(r: u8, g: u8, b: u8) -> (f32, f32, f32) {
 
     // Linear sRGB → LMS (Ottosson's M1).
     let l = 0.412_221_46 * r + 0.536_332_55 * g + 0.051_445_995 * b;
-    let m = 0.211_903_5   * r + 0.680_699_5  * g + 0.107_396_96  * b;
-    let s = 0.088_302_46  * r + 0.281_718_85 * g + 0.629_978_7   * b;
+    let m = 0.211_903_5 * r + 0.680_699_5 * g + 0.107_396_96 * b;
+    let s = 0.088_302_46 * r + 0.281_718_85 * g + 0.629_978_7 * b;
 
     // Nonlinearity: cube root.
     let l_ = l.cbrt();
@@ -45,9 +45,9 @@ pub fn srgb_to_oklab(r: u8, g: u8, b: u8) -> (f32, f32, f32) {
     let s_ = s.cbrt();
 
     // L′M′S′ → Oklab (Ottosson's M2).
-    let oklab_l = 0.210_454_26  * l_ + 0.793_617_8   * m_ - 0.004_072_047 * s_;
-    let oklab_a = 1.977_998_5   * l_ - 2.428_592_2   * m_ + 0.450_593_7   * s_;
-    let oklab_b = 0.025_904_037 * l_ + 0.782_771_77  * m_ - 0.808_675_77  * s_;
+    let oklab_l = 0.210_454_26 * l_ + 0.793_617_8 * m_ - 0.004_072_047 * s_;
+    let oklab_a = 1.977_998_5 * l_ - 2.428_592_2 * m_ + 0.450_593_7 * s_;
+    let oklab_b = 0.025_904_037 * l_ + 0.782_771_77 * m_ - 0.808_675_77 * s_;
 
     (oklab_l, oklab_a, oklab_b)
 }
@@ -56,9 +56,9 @@ pub fn srgb_to_oklab(r: u8, g: u8, b: u8) -> (f32, f32, f32) {
 /// (each channel clamped to 0..=255).
 pub fn oklab_to_srgb(l: f32, a: f32, b: f32) -> (u8, u8, u8) {
     // Oklab → L′M′S′ (inverse M2).
-    let l_ = l + 0.396_337_78  * a + 0.215_803_76  * b;
-    let m_ = l - 0.105_561_346 * a - 0.063_854_17  * b;
-    let s_ = l - 0.089_484_18  * a - 1.291_485_5   * b;
+    let l_ = l + 0.396_337_78 * a + 0.215_803_76 * b;
+    let m_ = l - 0.105_561_346 * a - 0.063_854_17 * b;
+    let s_ = l - 0.089_484_18 * a - 1.291_485_5 * b;
 
     // Undo the cube-root nonlinearity.
     let l = l_ * l_ * l_;
@@ -66,9 +66,9 @@ pub fn oklab_to_srgb(l: f32, a: f32, b: f32) -> (u8, u8, u8) {
     let s = s_ * s_ * s_;
 
     // LMS → linear sRGB (inverse M1).
-    let r =  4.076_741_7   * l - 3.307_711_6   * m + 0.230_969_94  * s;
-    let g = -1.268_438     * l + 2.609_757_4   * m - 0.341_319_38  * s;
-    let b = -0.004_196_086 * l - 0.703_418_6   * m + 1.707_614_7   * s;
+    let r = 4.076_741_7 * l - 3.307_711_6 * m + 0.230_969_94 * s;
+    let g = -1.268_438 * l + 2.609_757_4 * m - 0.341_319_38 * s;
+    let b = -0.004_196_086 * l - 0.703_418_6 * m + 1.707_614_7 * s;
 
     (
         to_srgb_byte(linear_to_srgb(r)),
@@ -120,7 +120,6 @@ fn linear_to_srgb(c: f32) -> f32 {
 fn to_srgb_byte(c: f32) -> u8 {
     (c * 255.0).round().clamp(0.0, 255.0) as u8
 }
-
 
 #[cfg(test)]
 mod test {
@@ -246,6 +245,9 @@ mod test {
         assert!(r > 100, "R channel too low at midpoint: {midpoint:?}");
         assert!(g > 100, "G channel too low at midpoint: {midpoint:?}");
         // B should still be close to zero — red↔green carries no blue.
-        assert!(b < 50, "B channel unexpectedly high at midpoint: {midpoint:?}");
+        assert!(
+            b < 50,
+            "B channel unexpectedly high at midpoint: {midpoint:?}"
+        );
     }
 }

--- a/src/theme/smooth.rs
+++ b/src/theme/smooth.rs
@@ -46,11 +46,11 @@ pub type SmoothLut = Box<[Style; LUT_SIZE]>;
 /// per-tier fields on `Size`/`DateAge`.
 #[derive(Debug, Default, PartialEq)]
 pub struct SmoothLuts {
-    pub size:     Option<SmoothLut>,
+    pub size: Option<SmoothLut>,
     pub modified: Option<SmoothLut>,
     pub accessed: Option<SmoothLut>,
-    pub changed:  Option<SmoothLut>,
-    pub created:  Option<SmoothLut>,
+    pub changed: Option<SmoothLut>,
+    pub created: Option<SmoothLut>,
 }
 
 /// Build a 256-stop LUT by interpolating between a sequence of
@@ -212,11 +212,11 @@ pub fn size_to_position(bytes: u64) -> f32 {
 /// upper bound of the `now` tier range), and so on.
 pub fn age_to_position(age_secs: u64) -> f32 {
     const ANCHORS: [u64; 6] = [
-        1,         // `now`   — scale origin (anything ≤ 1 sec clamps here)
-        3_600,     // `today` — 1 hour
-        86_400,    // `week`  — 1 day
-        604_800,   // `month` — 1 week
-        2_592_000, // `year`  — 30 days
+        1,          // `now`   — scale origin (anything ≤ 1 sec clamps here)
+        3_600,      // `today` — 1 hour
+        86_400,     // `week`  — 1 day
+        604_800,    // `month` — 1 week
+        2_592_000,  // `year`  — 30 days
         31_536_000, // `old`  — 1 year
     ];
     const POSITIONS: [f32; 6] = [0.0, 0.2, 0.4, 0.6, 0.8, 1.0];
@@ -270,7 +270,6 @@ pub(crate) fn date_anchors(date: &DateAge) -> [(f32, Style); 6] {
     ]
 }
 
-
 #[cfg(test)]
 #[allow(clippy::float_cmp)] // test assertions use exact f32 literals we control
 mod test {
@@ -290,12 +289,12 @@ mod test {
     /// tolerances on interpolated midpoints.
     fn synthetic_date() -> [(f32, Style); 6] {
         [
-            (0.0, rgb_bold(255, 0, 0)),       // red, bold
-            (0.2, rgb(255, 128, 0)),          // orange
-            (0.4, rgb(255, 255, 0)),          // yellow
-            (0.6, rgb(0, 255, 0)),            // green
-            (0.8, rgb(0, 0, 255)),            // blue
-            (1.0, rgb(128, 0, 128)),          // purple
+            (0.0, rgb_bold(255, 0, 0)), // red, bold
+            (0.2, rgb(255, 128, 0)),    // orange
+            (0.4, rgb(255, 255, 0)),    // yellow
+            (0.6, rgb(0, 255, 0)),      // green
+            (0.8, rgb(0, 0, 255)),      // blue
+            (1.0, rgb(128, 0, 128)),    // purple
         ]
     }
 
@@ -320,7 +319,10 @@ mod test {
         // Same foreground...
         assert_eq!(fg(lut[0]), fg(anchors[0].1));
         // ...and same bold attribute.
-        assert!(lut[0].is_bold, "first stop should inherit bold from anchor[0]");
+        assert!(
+            lut[0].is_bold,
+            "first stop should inherit bold from anchor[0]"
+        );
     }
 
     #[test]
@@ -342,8 +344,8 @@ mod test {
         let lut = build_smooth_lut(&anchors);
 
         let expected_buckets = [
-            (0,   anchors[0].1),
-            (51,  anchors[1].1),
+            (0, anchors[0].1),
+            (51, anchors[1].1),
             (102, anchors[2].1),
             (153, anchors[3].1),
             (204, anchors[4].1),
@@ -441,13 +443,13 @@ mod test {
     #[test]
     fn date_anchors_layout_matches_six_tiers() {
         let date = DateAge {
-            now:   rgb(0x10, 0x10, 0x10),
+            now: rgb(0x10, 0x10, 0x10),
             today: rgb(0x20, 0x20, 0x20),
-            week:  rgb(0x30, 0x30, 0x30),
+            week: rgb(0x30, 0x30, 0x30),
             month: rgb(0x40, 0x40, 0x40),
-            year:  rgb(0x50, 0x50, 0x50),
-            old:   rgb(0x60, 0x60, 0x60),
-            flat:  Style::default(),
+            year: rgb(0x50, 0x50, 0x50),
+            old: rgb(0x60, 0x60, 0x60),
+            flat: Style::default(),
         };
 
         let anchors = date_anchors(&date);
@@ -491,9 +493,7 @@ mod test {
 
         #[test]
         fn size_is_monotonic() {
-            let samples: Vec<f32> = (0..=40)
-                .map(|i| size_to_position(1_u64 << i))
-                .collect();
+            let samples: Vec<f32> = (0..=40).map(|i| size_to_position(1_u64 << i)).collect();
             for window in samples.windows(2) {
                 assert!(
                     window[0] <= window[1],
@@ -534,9 +534,7 @@ mod test {
         #[test]
         fn age_is_monotonic() {
             // Log-ish sweep: powers of 2 from 1 sec to ~1 year.
-            let samples: Vec<f32> = (0..=25)
-                .map(|i| age_to_position(1_u64 << i))
-                .collect();
+            let samples: Vec<f32> = (0..=25).map(|i| age_to_position(1_u64 << i)).collect();
             for window in samples.windows(2) {
                 assert!(
                     window[0] <= window[1],
@@ -586,18 +584,18 @@ mod test {
         fn ui_with_24bit_date_gradient() -> UiStyles {
             let mut ui = UiStyles::default();
             let date = DateAge {
-                now:   rgb_bold(0x3D, 0xD7, 0xD7),
+                now: rgb_bold(0x3D, 0xD7, 0xD7),
                 today: rgb(0x3D, 0xD7, 0xD7),
-                week:  rgb(0x3A, 0xAB, 0xAE),
+                week: rgb(0x3A, 0xAB, 0xAE),
                 month: rgb(0x3B, 0x8E, 0xD8),
-                year:  rgb(0x88, 0x88, 0x88),
-                old:   rgb(0x5C, 0x5C, 0x5C),
-                flat:  rgb(0x55, 0x55, 0x55),
+                year: rgb(0x88, 0x88, 0x88),
+                old: rgb(0x5C, 0x5C, 0x5C),
+                flat: rgb(0x55, 0x55, 0x55),
             };
             ui.date_modified = date;
             ui.date_accessed = date;
-            ui.date_changed  = date;
-            ui.date_created  = date;
+            ui.date_changed = date;
+            ui.date_created = date;
             ui.size = Size {
                 major: rgb(0xAA, 0xAA, 0xAA),
                 minor: rgb(0x55, 0x55, 0x55),
@@ -635,10 +633,22 @@ mod test {
             ui.apply_gradient_flags(gradient);
 
             assert!(ui.smooth_luts.size.is_some(), "size LUT should be built");
-            assert!(ui.smooth_luts.modified.is_some(), "modified LUT should be built");
-            assert!(ui.smooth_luts.accessed.is_some(), "accessed LUT should be built");
-            assert!(ui.smooth_luts.changed.is_some(), "changed LUT should be built");
-            assert!(ui.smooth_luts.created.is_some(), "created LUT should be built");
+            assert!(
+                ui.smooth_luts.modified.is_some(),
+                "modified LUT should be built"
+            );
+            assert!(
+                ui.smooth_luts.accessed.is_some(),
+                "accessed LUT should be built"
+            );
+            assert!(
+                ui.smooth_luts.changed.is_some(),
+                "changed LUT should be built"
+            );
+            assert!(
+                ui.smooth_luts.created.is_some(),
+                "created LUT should be built"
+            );
         }
 
         #[test]
@@ -650,7 +660,10 @@ mod test {
             ui.apply_gradient_flags(gradient);
 
             assert!(ui.smooth_luts.size.is_some());
-            assert!(ui.smooth_luts.modified.is_none(), "modified LUT should be skipped");
+            assert!(
+                ui.smooth_luts.modified.is_none(),
+                "modified LUT should be skipped"
+            );
             assert!(ui.smooth_luts.accessed.is_some());
             assert!(ui.smooth_luts.changed.is_some());
             assert!(ui.smooth_luts.created.is_some());
@@ -667,7 +680,10 @@ mod test {
             gradient.smooth = true;
             ui.apply_gradient_flags(gradient);
 
-            assert!(ui.smooth_luts.size.is_none(), "size LUT skipped: non-RGB anchor");
+            assert!(
+                ui.smooth_luts.size.is_none(),
+                "size LUT skipped: non-RGB anchor"
+            );
             // Timestamp columns were untouched and should still build.
             assert!(ui.smooth_luts.modified.is_some());
         }
@@ -720,10 +736,10 @@ mod test {
         // 0, 63.75, 127.5, 191.25, 255.
         // Due to rounding we accept the closest integer bucket.
         let samples = [
-            (0,   size.number_byte),
-            (64,  size.number_kilo),   // round(63.75) = 64
-            (128, size.number_mega),   // round(127.5) = 128
-            (191, size.number_giga),   // round(191.25) = 191
+            (0, size.number_byte),
+            (64, size.number_kilo),  // round(63.75) = 64
+            (128, size.number_mega), // round(127.5) = 128
+            (191, size.number_giga), // round(191.25) = 191
             (255, size.number_huge),
         ];
 

--- a/src/theme/ui_styles.rs
+++ b/src/theme/ui_styles.rs
@@ -3,7 +3,6 @@ use nu_ansi_term::{Color, Style};
 use crate::theme::lsc::Pair;
 use crate::theme::smooth::{self, SmoothLuts};
 
-
 /// Returns `true` iff `style`'s foreground is a 24-bit
 /// `Color::Rgb(...)` — i.e. exactly the case where Oklab
 /// interpolation toward another RGB anchor would produce a
@@ -16,8 +15,8 @@ fn is_rgb_foreground(style: Style) -> bool {
     matches!(style.foreground, Some(Color::Rgb(_, _, _)))
 }
 
-
 #[derive(Debug, Default, PartialEq)]
+#[rustfmt::skip]
 pub struct UiStyles {
     pub colourful: bool,
 
@@ -74,6 +73,7 @@ pub struct FileKinds {
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
+#[rustfmt::skip]
 pub struct Permissions {
     pub user_read:          Style,
     pub user_write:         Style,
@@ -137,6 +137,7 @@ impl Size {
 /// plus a single `flat` colour used when the date column's gradient
 /// is disabled.
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
+#[rustfmt::skip]
 pub struct DateAge {
     pub now:   Style,   // < 1 hour
     pub today: Style,   // < 24 hours
@@ -183,6 +184,7 @@ impl DateAge {
     }
 
     /// Pick the style for a given age in seconds.
+    #[rustfmt::skip]
     pub fn for_age(&self, age_secs: u64) -> Style {
         const HOUR: u64 = 3600;
         const DAY: u64 = 86400;
@@ -283,20 +285,24 @@ impl UiStyles {
                     Some(smooth::build_smooth_lut(&smooth::size_anchors(&self.size)));
             }
             if gradient.modified && self.date_modified.is_smoothable() {
-                self.smooth_luts.modified =
-                    Some(smooth::build_smooth_lut(&smooth::date_anchors(&self.date_modified)));
+                self.smooth_luts.modified = Some(smooth::build_smooth_lut(&smooth::date_anchors(
+                    &self.date_modified,
+                )));
             }
             if gradient.accessed && self.date_accessed.is_smoothable() {
-                self.smooth_luts.accessed =
-                    Some(smooth::build_smooth_lut(&smooth::date_anchors(&self.date_accessed)));
+                self.smooth_luts.accessed = Some(smooth::build_smooth_lut(&smooth::date_anchors(
+                    &self.date_accessed,
+                )));
             }
             if gradient.changed && self.date_changed.is_smoothable() {
-                self.smooth_luts.changed =
-                    Some(smooth::build_smooth_lut(&smooth::date_anchors(&self.date_changed)));
+                self.smooth_luts.changed = Some(smooth::build_smooth_lut(&smooth::date_anchors(
+                    &self.date_changed,
+                )));
             }
             if gradient.created && self.date_created.is_smoothable() {
-                self.smooth_luts.created =
-                    Some(smooth::build_smooth_lut(&smooth::date_anchors(&self.date_created)));
+                self.smooth_luts.created = Some(smooth::build_smooth_lut(&smooth::date_anchors(
+                    &self.date_created,
+                )));
             }
         }
 
@@ -307,16 +313,24 @@ impl UiStyles {
             self.size.number_mega = self.size.major;
             self.size.number_giga = self.size.major;
             self.size.number_huge = self.size.major;
-            self.size.unit_byte   = self.size.minor;
-            self.size.unit_kilo   = self.size.minor;
-            self.size.unit_mega   = self.size.minor;
-            self.size.unit_giga   = self.size.minor;
-            self.size.unit_huge   = self.size.minor;
+            self.size.unit_byte = self.size.minor;
+            self.size.unit_kilo = self.size.minor;
+            self.size.unit_mega = self.size.minor;
+            self.size.unit_giga = self.size.minor;
+            self.size.unit_huge = self.size.minor;
         }
-        if !gradient.modified { flatten_date_age(&mut self.date_modified); }
-        if !gradient.accessed { flatten_date_age(&mut self.date_accessed); }
-        if !gradient.changed  { flatten_date_age(&mut self.date_changed);  }
-        if !gradient.created  { flatten_date_age(&mut self.date_created);  }
+        if !gradient.modified {
+            flatten_date_age(&mut self.date_modified);
+        }
+        if !gradient.accessed {
+            flatten_date_age(&mut self.date_accessed);
+        }
+        if !gradient.changed {
+            flatten_date_age(&mut self.date_changed);
+        }
+        if !gradient.created {
+            flatten_date_age(&mut self.date_created);
+        }
     }
 }
 
@@ -325,35 +339,33 @@ impl UiStyles {
 /// [`UiStyles::apply_gradient_flags`] when a per-timestamp gradient
 /// flag is off.
 fn flatten_date_age(d: &mut DateAge) {
-    d.now   = d.flat;
+    d.now = d.flat;
     d.today = d.flat;
-    d.week  = d.flat;
+    d.week = d.flat;
     d.month = d.flat;
-    d.year  = d.flat;
-    d.old   = d.flat;
+    d.year = d.flat;
+    d.old = d.flat;
 }
 
-
 impl UiStyles {
-
     /// Sets a value on this set of colours using one of the keys understood
     /// by the `LS_COLORS` environment variable. Invalid keys set nothing, but
     /// return false.
     pub fn set_ls(&mut self, pair: &Pair<'_>) -> bool {
         match pair.key {
-            "di" => self.filekinds.directory    = pair.to_style(),  // DIR
-            "ex" => self.filekinds.executable   = pair.to_style(),  // EXEC
-            "fi" => self.filekinds.normal       = pair.to_style(),  // FILE
-            "pi" => self.filekinds.pipe         = pair.to_style(),  // FIFO
-            "so" => self.filekinds.socket       = pair.to_style(),  // SOCK
-            "bd" => self.filekinds.block_device = pair.to_style(),  // BLK
-            "cd" => self.filekinds.char_device  = pair.to_style(),  // CHR
-            "ln" => self.filekinds.symlink      = pair.to_style(),  // LINK
-            "or" => self.broken_symlink         = pair.to_style(),  // ORPHAN
-             _   => return false,
-             // Codes we don’t do anything with:
-             // MULTIHARDLINK, DOOR, SETUID, SETGID, CAPABILITY,
-             // STICKY_OTHER_WRITABLE, OTHER_WRITABLE, STICKY, MISSING
+            "di" => self.filekinds.directory = pair.to_style(), // DIR
+            "ex" => self.filekinds.executable = pair.to_style(), // EXEC
+            "fi" => self.filekinds.normal = pair.to_style(),    // FILE
+            "pi" => self.filekinds.pipe = pair.to_style(),      // FIFO
+            "so" => self.filekinds.socket = pair.to_style(),    // SOCK
+            "bd" => self.filekinds.block_device = pair.to_style(), // BLK
+            "cd" => self.filekinds.char_device = pair.to_style(), // CHR
+            "ln" => self.filekinds.symlink = pair.to_style(),   // LINK
+            "or" => self.broken_symlink = pair.to_style(),      // ORPHAN
+            _ => return false,
+            // Codes we don’t do anything with:
+            // MULTIHARDLINK, DOOR, SETUID, SETGID, CAPABILITY,
+            // STICKY_OTHER_WRITABLE, OTHER_WRITABLE, STICKY, MISSING
         }
         true
     }
@@ -369,7 +381,7 @@ impl UiStyles {
         self.size.number_mega = style;
         self.size.number_giga = style;
         self.size.number_huge = style;
-        self.size.major       = style;
+        self.size.major = style;
     }
 
     pub fn set_unit_style(&mut self, style: Style) {
@@ -381,7 +393,7 @@ impl UiStyles {
         self.size.unit_mega = style;
         self.size.unit_giga = style;
         self.size.unit_huge = style;
-        self.size.minor     = style;
+        self.size.minor = style;
     }
 
     /// Set a UI style from a human-readable config key and value.
@@ -395,15 +407,15 @@ impl UiStyles {
 
         match key {
             // File kinds
-            "normal"           => self.filekinds.normal       = style,
-            "directory"        => self.filekinds.directory     = style,
-            "symlink"          => self.filekinds.symlink       = style,
-            "pipe"             => self.filekinds.pipe          = style,
-            "block-device"     => self.filekinds.block_device  = style,
-            "char-device"      => self.filekinds.char_device   = style,
-            "socket"           => self.filekinds.socket        = style,
-            "special"          => self.filekinds.special       = style,
-            "executable"       => self.filekinds.executable    = style,
+            "normal" => self.filekinds.normal = style,
+            "directory" => self.filekinds.directory = style,
+            "symlink" => self.filekinds.symlink = style,
+            "pipe" => self.filekinds.pipe = style,
+            "block-device" => self.filekinds.block_device = style,
+            "char-device" => self.filekinds.char_device = style,
+            "socket" => self.filekinds.socket = style,
+            "special" => self.filekinds.special = style,
+            "executable" => self.filekinds.executable = style,
 
             // Permissions.  Three accepted prefixes: `permissions-*`
             // (canonical, matches the column name), `perm-*` (legacy
@@ -411,19 +423,45 @@ impl UiStyles {
             // `mode-*` (matches the `--mode` flag alias and the `mode`
             // sort field, so the same vocabulary works on every
             // surface).
-            "permissions-user-read"          | "perm-user-read"        | "mode-user-read"        => self.perms.user_read          = style,
-            "permissions-user-write"         | "perm-user-write"       | "mode-user-write"       => self.perms.user_write         = style,
-            "permissions-user-execute"       | "perm-user-exec"        | "mode-user-exec"        => self.perms.user_execute_file  = style,
-            "permissions-user-execute-other" | "perm-user-exec-other"  | "mode-user-exec-other"  => self.perms.user_execute_other = style,
-            "permissions-group-read"         | "perm-group-read"       | "mode-group-read"       => self.perms.group_read         = style,
-            "permissions-group-write"        | "perm-group-write"      | "mode-group-write"      => self.perms.group_write        = style,
-            "permissions-group-execute"      | "perm-group-exec"       | "mode-group-exec"       => self.perms.group_execute      = style,
-            "permissions-other-read"         | "perm-other-read"       | "mode-other-read"       => self.perms.other_read         = style,
-            "permissions-other-write"        | "perm-other-write"      | "mode-other-write"      => self.perms.other_write        = style,
-            "permissions-other-execute"      | "perm-other-exec"       | "mode-other-exec"       => self.perms.other_execute      = style,
-            "permissions-special-user"       | "perm-special-user"     | "mode-special-user"     => self.perms.special_user_file  = style,
-            "permissions-special-other"      | "perm-special-other"    | "mode-special-other"    => self.perms.special_other      = style,
-            "permissions-attribute"          | "perm-attribute"        | "mode-attribute"        => self.perms.attribute          = style,
+            "permissions-user-read" | "perm-user-read" | "mode-user-read" => {
+                self.perms.user_read = style
+            }
+            "permissions-user-write" | "perm-user-write" | "mode-user-write" => {
+                self.perms.user_write = style
+            }
+            "permissions-user-execute" | "perm-user-exec" | "mode-user-exec" => {
+                self.perms.user_execute_file = style
+            }
+            "permissions-user-execute-other" | "perm-user-exec-other" | "mode-user-exec-other" => {
+                self.perms.user_execute_other = style
+            }
+            "permissions-group-read" | "perm-group-read" | "mode-group-read" => {
+                self.perms.group_read = style
+            }
+            "permissions-group-write" | "perm-group-write" | "mode-group-write" => {
+                self.perms.group_write = style
+            }
+            "permissions-group-execute" | "perm-group-exec" | "mode-group-exec" => {
+                self.perms.group_execute = style
+            }
+            "permissions-other-read" | "perm-other-read" | "mode-other-read" => {
+                self.perms.other_read = style
+            }
+            "permissions-other-write" | "perm-other-write" | "mode-other-write" => {
+                self.perms.other_write = style
+            }
+            "permissions-other-execute" | "perm-other-exec" | "mode-other-exec" => {
+                self.perms.other_execute = style
+            }
+            "permissions-special-user" | "perm-special-user" | "mode-special-user" => {
+                self.perms.special_user_file = style
+            }
+            "permissions-special-other" | "perm-special-other" | "mode-special-other" => {
+                self.perms.special_other = style
+            }
+            "permissions-attribute" | "perm-attribute" | "mode-attribute" => {
+                self.perms.attribute = style
+            }
 
             // Size (individual magnitudes)
             "size-number-byte" => self.size.number_byte = style,
@@ -431,53 +469,53 @@ impl UiStyles {
             "size-number-mega" => self.size.number_mega = style,
             "size-number-giga" => self.size.number_giga = style,
             "size-number-huge" => self.size.number_huge = style,
-            "size-unit-byte"   => self.size.unit_byte   = style,
-            "size-unit-kilo"   => self.size.unit_kilo   = style,
-            "size-unit-mega"   => self.size.unit_mega    = style,
-            "size-unit-giga"   => self.size.unit_giga    = style,
-            "size-unit-huge"   => self.size.unit_huge    = style,
+            "size-unit-byte" => self.size.unit_byte = style,
+            "size-unit-kilo" => self.size.unit_kilo = style,
+            "size-unit-mega" => self.size.unit_mega = style,
+            "size-unit-giga" => self.size.unit_giga = style,
+            "size-unit-huge" => self.size.unit_huge = style,
             // Size (bulk setters)
-            "size-number"      => self.set_number_style(style),
-            "size-unit"        => self.set_unit_style(style),
-            "size-major"       => self.size.major = style,
-            "size-minor"       => self.size.minor = style,
+            "size-number" => self.set_number_style(style),
+            "size-unit" => self.set_unit_style(style),
+            "size-major" => self.size.major = style,
+            "size-minor" => self.size.minor = style,
 
             // Users
-            "user-you"         => self.users.user_you          = style,
-            "user-other"       => self.users.user_someone_else = style,
-            "group-yours"      => self.users.group_yours       = style,
-            "group-member"     => self.users.group_member      = style,
-            "group-other"      => self.users.group_not_yours   = style,
-            "uid-you"          => self.users.uid_you           = style,
-            "uid-other"        => self.users.uid_someone_else  = style,
-            "gid-yours"        => self.users.gid_yours         = style,
-            "gid-member"       => self.users.gid_member        = style,
-            "gid-other"        => self.users.gid_not_yours     = style,
+            "user-you" => self.users.user_you = style,
+            "user-other" => self.users.user_someone_else = style,
+            "group-yours" => self.users.group_yours = style,
+            "group-member" => self.users.group_member = style,
+            "group-other" => self.users.group_not_yours = style,
+            "uid-you" => self.users.uid_you = style,
+            "uid-other" => self.users.uid_someone_else = style,
+            "gid-yours" => self.users.gid_yours = style,
+            "gid-member" => self.users.gid_member = style,
+            "gid-other" => self.users.gid_not_yours = style,
 
             // Links
-            "links"            => self.links.normal            = style,
-            "links-multi"      => self.links.multi_link_file   = style,
+            "links" => self.links.normal = style,
+            "links-multi" => self.links.multi_link_file = style,
 
             // VCS
-            "vcs-new"          => self.vcs.new         = style,
-            "vcs-modified"     => self.vcs.modified     = style,
-            "vcs-deleted"      => self.vcs.deleted      = style,
-            "vcs-renamed"      => self.vcs.renamed      = style,
-            "vcs-typechange"   => self.vcs.typechange    = style,
-            "vcs-ignored"      => self.vcs.ignored       = style,
-            "vcs-conflicted"   => self.vcs.conflicted    = style,
+            "vcs-new" => self.vcs.new = style,
+            "vcs-modified" => self.vcs.modified = style,
+            "vcs-deleted" => self.vcs.deleted = style,
+            "vcs-renamed" => self.vcs.renamed = style,
+            "vcs-typechange" => self.vcs.typechange = style,
+            "vcs-ignored" => self.vcs.ignored = style,
+            "vcs-conflicted" => self.vcs.conflicted = style,
 
             // UI elements
-            "punctuation"      => self.punctuation      = style,
+            "punctuation" => self.punctuation = style,
             // Bulk date setters fan out to all four timestamp columns.
-            "date"             => self.date_for_each(|d| d.set_all(style)),
-            "date-now"         => self.date_for_each(|d| d.now   = style),
-            "date-today"       => self.date_for_each(|d| d.today = style),
-            "date-week"        => self.date_for_each(|d| d.week  = style),
-            "date-month"       => self.date_for_each(|d| d.month = style),
-            "date-year"        => self.date_for_each(|d| d.year  = style),
-            "date-old"         => self.date_for_each(|d| d.old   = style),
-            "date-flat"        => self.date_for_each(|d| d.flat  = style),
+            "date" => self.date_for_each(|d| d.set_all(style)),
+            "date-now" => self.date_for_each(|d| d.now = style),
+            "date-today" => self.date_for_each(|d| d.today = style),
+            "date-week" => self.date_for_each(|d| d.week = style),
+            "date-month" => self.date_for_each(|d| d.month = style),
+            "date-year" => self.date_for_each(|d| d.year = style),
+            "date-old" => self.date_for_each(|d| d.old = style),
+            "date-flat" => self.date_for_each(|d| d.flat = style),
 
             // Per-timestamp-column overrides.  These write directly
             // to the named field, so theme authors can give each
@@ -487,50 +525,50 @@ impl UiStyles {
             // bulk `date*` setters are guaranteed to run before
             // any `date-<col>*` override regardless of the order
             // the keys appear in the theme block.
-            "date-modified"        => self.date_modified.set_all(style),
-            "date-modified-now"    => self.date_modified.now   = style,
-            "date-modified-today"  => self.date_modified.today = style,
-            "date-modified-week"   => self.date_modified.week  = style,
-            "date-modified-month"  => self.date_modified.month = style,
-            "date-modified-year"   => self.date_modified.year  = style,
-            "date-modified-old"    => self.date_modified.old   = style,
-            "date-modified-flat"   => self.date_modified.flat  = style,
+            "date-modified" => self.date_modified.set_all(style),
+            "date-modified-now" => self.date_modified.now = style,
+            "date-modified-today" => self.date_modified.today = style,
+            "date-modified-week" => self.date_modified.week = style,
+            "date-modified-month" => self.date_modified.month = style,
+            "date-modified-year" => self.date_modified.year = style,
+            "date-modified-old" => self.date_modified.old = style,
+            "date-modified-flat" => self.date_modified.flat = style,
 
-            "date-accessed"        => self.date_accessed.set_all(style),
-            "date-accessed-now"    => self.date_accessed.now   = style,
-            "date-accessed-today"  => self.date_accessed.today = style,
-            "date-accessed-week"   => self.date_accessed.week  = style,
-            "date-accessed-month"  => self.date_accessed.month = style,
-            "date-accessed-year"   => self.date_accessed.year  = style,
-            "date-accessed-old"    => self.date_accessed.old   = style,
-            "date-accessed-flat"   => self.date_accessed.flat  = style,
+            "date-accessed" => self.date_accessed.set_all(style),
+            "date-accessed-now" => self.date_accessed.now = style,
+            "date-accessed-today" => self.date_accessed.today = style,
+            "date-accessed-week" => self.date_accessed.week = style,
+            "date-accessed-month" => self.date_accessed.month = style,
+            "date-accessed-year" => self.date_accessed.year = style,
+            "date-accessed-old" => self.date_accessed.old = style,
+            "date-accessed-flat" => self.date_accessed.flat = style,
 
-            "date-changed"         => self.date_changed.set_all(style),
-            "date-changed-now"     => self.date_changed.now   = style,
-            "date-changed-today"   => self.date_changed.today = style,
-            "date-changed-week"    => self.date_changed.week  = style,
-            "date-changed-month"   => self.date_changed.month = style,
-            "date-changed-year"    => self.date_changed.year  = style,
-            "date-changed-old"     => self.date_changed.old   = style,
-            "date-changed-flat"    => self.date_changed.flat  = style,
+            "date-changed" => self.date_changed.set_all(style),
+            "date-changed-now" => self.date_changed.now = style,
+            "date-changed-today" => self.date_changed.today = style,
+            "date-changed-week" => self.date_changed.week = style,
+            "date-changed-month" => self.date_changed.month = style,
+            "date-changed-year" => self.date_changed.year = style,
+            "date-changed-old" => self.date_changed.old = style,
+            "date-changed-flat" => self.date_changed.flat = style,
 
-            "date-created"         => self.date_created.set_all(style),
-            "date-created-now"     => self.date_created.now   = style,
-            "date-created-today"   => self.date_created.today = style,
-            "date-created-week"    => self.date_created.week  = style,
-            "date-created-month"   => self.date_created.month = style,
-            "date-created-year"    => self.date_created.year  = style,
-            "date-created-old"     => self.date_created.old   = style,
-            "date-created-flat"    => self.date_created.flat  = style,
-            "inode"            => self.inode             = style,
-            "blocks"           => self.blocks            = style,
-            "header"           => self.header            = style,
-            "octal"            => self.octal             = style,
-            "flags"            => self.flags             = style,
-            "symlink-path"     => self.symlink_path      = style,
-            "control-char"     => self.control_char      = style,
-            "broken-symlink"   => self.broken_symlink    = style,
-            "broken-overlay"   => self.broken_path_overlay = style,
+            "date-created" => self.date_created.set_all(style),
+            "date-created-now" => self.date_created.now = style,
+            "date-created-today" => self.date_created.today = style,
+            "date-created-week" => self.date_created.week = style,
+            "date-created-month" => self.date_created.month = style,
+            "date-created-year" => self.date_created.year = style,
+            "date-created-old" => self.date_created.old = style,
+            "date-created-flat" => self.date_created.flat = style,
+            "inode" => self.inode = style,
+            "blocks" => self.blocks = style,
+            "header" => self.header = style,
+            "octal" => self.octal = style,
+            "flags" => self.flags = style,
+            "symlink-path" => self.symlink_path = style,
+            "control-char" => self.control_char = style,
+            "broken-symlink" => self.broken_symlink = style,
+            "broken-overlay" => self.broken_path_overlay = style,
 
             _ => return false,
         }
@@ -538,7 +576,6 @@ impl UiStyles {
         true
     }
 }
-
 
 #[cfg(test)]
 mod is_smoothable_test {
@@ -620,13 +657,13 @@ mod is_smoothable_test {
     #[test]
     fn date_all_rgb_is_smoothable() {
         let date = DateAge {
-            now:   rgb(0x3D, 0xD7, 0xD7),
+            now: rgb(0x3D, 0xD7, 0xD7),
             today: rgb(0x3D, 0xD7, 0xD7),
-            week:  rgb(0x3A, 0xAB, 0xAE),
+            week: rgb(0x3A, 0xAB, 0xAE),
             month: rgb(0x3B, 0x8E, 0xD8),
-            year:  rgb(0x88, 0x88, 0x88),
-            old:   rgb(0x5C, 0x5C, 0x5C),
-            flat:  Style::default(),
+            year: rgb(0x88, 0x88, 0x88),
+            old: rgb(0x5C, 0x5C, 0x5C),
+            flat: Style::default(),
         };
         assert!(date.is_smoothable());
     }
@@ -639,13 +676,13 @@ mod is_smoothable_test {
     #[test]
     fn date_one_palette_tier_disqualifies_the_column() {
         let date = DateAge {
-            now:   rgb(0x3D, 0xD7, 0xD7),
+            now: rgb(0x3D, 0xD7, 0xD7),
             today: rgb(0x3D, 0xD7, 0xD7),
-            week:  fixed(30),   // palette
+            week: fixed(30), // palette
             month: rgb(0x3B, 0x8E, 0xD8),
-            year:  rgb(0x88, 0x88, 0x88),
-            old:   rgb(0x5C, 0x5C, 0x5C),
-            flat:  Style::default(),
+            year: rgb(0x88, 0x88, 0x88),
+            old: rgb(0x5C, 0x5C, 0x5C),
+            flat: Style::default(),
         };
         assert!(!date.is_smoothable());
     }
@@ -653,13 +690,13 @@ mod is_smoothable_test {
     #[test]
     fn date_one_unset_tier_disqualifies_the_column() {
         let date = DateAge {
-            now:   rgb(0x3D, 0xD7, 0xD7),
+            now: rgb(0x3D, 0xD7, 0xD7),
             today: Style::default(),
-            week:  rgb(0x3A, 0xAB, 0xAE),
+            week: rgb(0x3A, 0xAB, 0xAE),
             month: rgb(0x3B, 0x8E, 0xD8),
-            year:  rgb(0x88, 0x88, 0x88),
-            old:   rgb(0x5C, 0x5C, 0x5C),
-            flat:  Style::default(),
+            year: rgb(0x88, 0x88, 0x88),
+            old: rgb(0x5C, 0x5C, 0x5C),
+            flat: Style::default(),
         };
         assert!(!date.is_smoothable());
     }
@@ -669,13 +706,13 @@ mod is_smoothable_test {
         // `flat` is the no-gradient fallback; its value must not
         // affect whether the tier chain is smoothable.
         let date = DateAge {
-            now:   rgb(0x3D, 0xD7, 0xD7),
+            now: rgb(0x3D, 0xD7, 0xD7),
             today: rgb(0x3D, 0xD7, 0xD7),
-            week:  rgb(0x3A, 0xAB, 0xAE),
+            week: rgb(0x3A, 0xAB, 0xAE),
             month: rgb(0x3B, 0x8E, 0xD8),
-            year:  rgb(0x88, 0x88, 0x88),
-            old:   rgb(0x5C, 0x5C, 0x5C),
-            flat:  fixed(244), // palette, but doesn't matter
+            year: rgb(0x88, 0x88, 0x88),
+            old: rgb(0x5C, 0x5C, 0x5C),
+            flat: fixed(244), // palette, but doesn't matter
         };
         assert!(date.is_smoothable());
     }

--- a/tests/cli_basics.rs
+++ b/tests/cli_basics.rs
@@ -5,13 +5,11 @@ mod support;
 use predicates::prelude::*;
 use support::{lx, lx_no_colour};
 
-
 // ── Help and version ──────────────────────────────────────────────
 
 #[test]
 fn help_flag() {
-    lx()
-        .arg("--help")
+    lx().arg("--help")
         .assert()
         .success()
         .stdout(predicate::str::contains("personality"));
@@ -19,8 +17,7 @@ fn help_flag() {
 
 #[test]
 fn help_short_flag() {
-    lx()
-        .arg("-?")
+    lx().arg("-?")
         .assert()
         .success()
         .stdout(predicate::str::contains("--oneline"));
@@ -28,8 +25,7 @@ fn help_short_flag() {
 
 #[test]
 fn version_flag() {
-    lx()
-        .arg("--version")
+    lx().arg("--version")
         .assert()
         .success()
         .stdout(predicate::str::contains(env!("CARGO_PKG_VERSION")));
@@ -37,20 +33,17 @@ fn version_flag() {
 
 #[test]
 fn version_short_flag() {
-    lx()
-        .arg("-v")
+    lx().arg("-v")
         .assert()
         .success()
         .stdout(predicate::str::contains("lx"));
 }
 
-
 // ── Invalid options ───────────────────────────────────────────────
 
 #[test]
 fn unknown_short_flag() {
-    lx()
-        .arg("-Y")
+    lx().arg("-Y")
         .assert()
         .failure()
         .stderr(predicate::str::contains("error"));
@@ -59,16 +52,12 @@ fn unknown_short_flag() {
 #[test]
 fn uppercase_f_groups_dirs_first() {
     // -F is now short for --group-dirs=first (was --classify in exa)
-    lx()
-        .arg("-F")
-        .assert()
-        .success();
+    lx().arg("-F").assert().success();
 }
 
 #[test]
 fn unknown_long_flag() {
-    lx()
-        .arg("--ternary")
+    lx().arg("--ternary")
         .assert()
         .failure()
         .stderr(predicate::str::contains("error"));
@@ -76,8 +65,7 @@ fn unknown_long_flag() {
 
 #[test]
 fn invalid_sort_value() {
-    lx()
-        .arg("--sort=colour")
+    lx().arg("--sort=colour")
         .assert()
         .failure()
         .stderr(predicate::str::contains("invalid value"));
@@ -86,18 +74,15 @@ fn invalid_sort_value() {
 #[test]
 fn removed_time_flag_is_rejected() {
     // --time=X was removed in 0.8; it is no longer a valid flag.
-    lx()
-        .arg("--time=modified")
-        .assert()
-        .failure()
-        .stderr(predicate::str::contains("unexpected argument")
-            .or(predicate::str::contains("unrecognized")));
+    lx().arg("--time=modified").assert().failure().stderr(
+        predicate::str::contains("unexpected argument")
+            .or(predicate::str::contains("unrecognized")),
+    );
 }
 
 #[test]
 fn invalid_colour_value() {
-    lx()
-        .arg("--colour=upstream")
+    lx().arg("--colour=upstream")
         .assert()
         .failure()
         .stderr(predicate::str::contains("invalid value"));
@@ -114,14 +99,17 @@ fn unknown_time_style_errors() {
         .assert()
         .failure()
         .code(2)
-        .stderr(predicate::str::contains("invalid value '24-hour' for '--time-style"))
-        .stderr(predicate::str::contains("[possible values: default, iso, long-iso, full-iso, relative, +FORMAT]"));
+        .stderr(predicate::str::contains(
+            "invalid value '24-hour' for '--time-style",
+        ))
+        .stderr(predicate::str::contains(
+            "[possible values: default, iso, long-iso, full-iso, relative, +FORMAT]",
+        ));
 }
 
 #[test]
 fn invalid_level_not_a_number() {
-    lx()
-        .arg("--level=abc")
+    lx().arg("--level=abc")
         .assert()
         .failure()
         .stderr(predicate::str::contains("invalid value"));
@@ -139,41 +127,31 @@ fn time_tier_compounds() {
 
 #[test]
 fn tree_all_all_error() {
-    lx()
-        .args(["-Taa"])
+    lx().args(["-Taa"])
         .assert()
         .failure()
         .stderr(predicate::str::contains("--tree"));
 }
 
-
 // ── Exit codes ────────────────────────────────────────────────────
 
 #[test]
 fn exit_code_success() {
-    lx()
-        .arg(".")
-        .assert()
-        .success();
+    lx().arg(".").assert().success();
 }
 
 #[test]
 fn exit_code_options_error() {
-    lx()
-        .arg("--sort=nope")
-        .assert()
-        .code(2);  // Clap uses exit code 2 for usage errors
+    lx().arg("--sort=nope").assert().code(2); // Clap uses exit code 2 for usage errors
 }
 
 #[test]
 fn nonexistent_path_still_exits() {
     // lx should print an error and exit non-zero for missing paths
-    lx()
-        .arg("/nonexistent/path/that/does/not/exist")
+    lx().arg("/nonexistent/path/that/does/not/exist")
         .assert()
         .failure();
 }
-
 
 // ── Basic listing ─────────────────────────────────────────────────
 
@@ -235,7 +213,6 @@ fn grid_view() {
         .stdout(predicate::str::is_empty().not());
 }
 
-
 // ── View mode combinations ────────────────────────────────────────
 
 #[test]
@@ -265,7 +242,6 @@ fn long_grid_view() {
         .success()
         .stdout(predicate::str::is_empty().not());
 }
-
 
 // ── Filtering ─────────────────────────────────────────────────────
 
@@ -314,7 +290,6 @@ fn only_dirs() {
         .stdout(predicate::str::contains("src"))
         .stdout(predicate::str::contains("Cargo.toml").not());
 }
-
 
 // ── Long-view columns ─────────────────────────────────────────────
 
@@ -365,7 +340,6 @@ fn inode_column() {
         .stdout(predicate::str::contains("Cargo.toml"));
 }
 
-
 // ── Suppressed columns ───────────────────────────────────────────
 
 #[test]
@@ -404,49 +378,42 @@ fn no_time() {
         .stdout(predicate::str::contains("Cargo.toml"));
 }
 
-
 // ── Colour control ────────────────────────────────────────────────
 
 #[test]
 fn colour_always() {
-    lx()
-        .args(["--colour=always", "-1", "Cargo.toml"])
+    lx().args(["--colour=always", "-1", "Cargo.toml"])
         .assert()
         .success();
 }
 
 #[test]
 fn colour_never() {
-    lx()
-        .args(["--colour=never", "-1", "Cargo.toml"])
+    lx().args(["--colour=never", "-1", "Cargo.toml"])
         .assert()
         .success();
 }
 
 #[test]
 fn colour_auto() {
-    lx()
-        .args(["--colour=auto", "-1", "Cargo.toml"])
+    lx().args(["--colour=auto", "-1", "Cargo.toml"])
         .assert()
         .success();
 }
 
 #[test]
 fn no_color_env() {
-    lx()
-        .args(["-1", "Cargo.toml"])
+    lx().args(["-1", "Cargo.toml"])
         .env("NO_COLOR", "1")
         .assert()
         .success();
 }
 
-
 // ── Shell completions ─────────────────────────────────────────────
 
 #[test]
 fn completions_bash() {
-    lx()
-        .arg("--completions=bash")
+    lx().arg("--completions=bash")
         .assert()
         .success()
         .stdout(predicate::str::contains("_lx"));
@@ -454,8 +421,7 @@ fn completions_bash() {
 
 #[test]
 fn completions_zsh() {
-    lx()
-        .arg("--completions=zsh")
+    lx().arg("--completions=zsh")
         .assert()
         .success()
         .stdout(predicate::str::contains("#compdef lx"));
@@ -463,13 +429,11 @@ fn completions_zsh() {
 
 #[test]
 fn completions_fish() {
-    lx()
-        .arg("--completions=fish")
+    lx().arg("--completions=fish")
         .assert()
         .success()
         .stdout(predicate::str::contains("complete -c lx"));
 }
-
 
 // ── Environment variables ─────────────────────────────────────────
 
@@ -503,29 +467,19 @@ fn invalid_lx_grid_rows_env() {
         .stderr(predicate::str::contains("LX_GRID_ROWS"));
 }
 
-
 // ── Long-view flags without --long (silently ignored) ─────────────
 
 #[test]
 fn binary_without_long_is_fine() {
-    lx_no_colour()
-        .args(["--binary", "."])
-        .assert()
-        .success();
+    lx_no_colour().args(["--binary", "."]).assert().success();
 }
 
 #[test]
 fn header_without_long_is_fine() {
-    lx_no_colour()
-        .args(["--header", "."])
-        .assert()
-        .success();
+    lx_no_colour().args(["--header", "."]).assert().success();
 }
 
 #[test]
 fn level_without_recurse_is_fine() {
-    lx_no_colour()
-        .args(["--level=3", "."])
-        .assert()
-        .success();
+    lx_no_colour().args(["--level=3", "."]).assert().success();
 }

--- a/tests/cli_columns.rs
+++ b/tests/cli_columns.rs
@@ -5,7 +5,6 @@ mod support;
 use predicates::prelude::*;
 use support::lx_no_colour;
 
-
 // ── --columns flag ───────────────────────────────────────────────
 
 #[test]
@@ -42,7 +41,12 @@ fn columns_overrides_tier() {
 fn columns_suppression_still_works() {
     // --no-permissions should remove perms even from explicit --columns
     lx_no_colour()
-        .args(["-l", "--columns=perms,size,modified", "--no-permissions", "Cargo.toml"])
+        .args([
+            "-l",
+            "--columns=perms,size,modified",
+            "--no-permissions",
+            "Cargo.toml",
+        ])
         .assert()
         .success()
         .stdout(predicate::str::contains("Cargo.toml"));
@@ -60,10 +64,11 @@ fn columns_unknown_names_error() {
         .assert()
         .failure()
         .code(2)
-        .stderr(predicate::str::contains("invalid value 'bogus' for '--columns"))
+        .stderr(predicate::str::contains(
+            "invalid value 'bogus' for '--columns",
+        ))
         .stderr(predicate::str::contains("[possible values:"));
 }
-
 
 // ── --format flag ────────────────────────────────────────────────
 
@@ -136,7 +141,6 @@ fn format_with_suppression() {
         .stdout(predicate::str::contains("staff").not());
 }
 
-
 // ── Canonical column insertion order ─────────────────────────────
 
 #[test]
@@ -204,7 +208,6 @@ fn no_duplicate_when_already_present() {
     let count = stdout.matches("Group").count();
     assert_eq!(count, 1, "Group should appear once, got {count}: {stdout}");
 }
-
 
 // ── --columns overrides --format ─────────────────────────────────
 

--- a/tests/cli_conditional.rs
+++ b/tests/cli_conditional.rs
@@ -1,9 +1,8 @@
 //! Tests for conditional config: [[personality.NAME.when]] blocks.
 
-use std::fs;
 use predicates::prelude::*;
+use std::fs;
 use tempfile::tempdir;
-
 
 /// Create a config with conditional overrides and return a command.
 fn lx_with_conditional_config(config_content: &str) -> (tempfile::TempDir, assert_cmd::Command) {
@@ -18,24 +17,25 @@ fn lx_with_conditional_config(config_content: &str) -> (tempfile::TempDir, asser
 
     let mut cmd = assert_cmd::Command::cargo_bin("lx").expect("binary lx not found");
     cmd.env("LX_CONFIG", config_path)
-       .env("HOME", "/nonexistent")
-       .arg("--colour=never");
+        .env("HOME", "/nonexistent")
+        .arg("--colour=never");
     (dir, cmd)
 }
-
 
 // ── Basic conditional override ───────────────────────────────────
 
 #[test]
 fn when_env_matches_overrides_setting() {
-    let (_dir, mut cmd) = lx_with_conditional_config(r#"
+    let (_dir, mut cmd) = lx_with_conditional_config(
+        r#"
         [personality.lx]
         sort = "name"
 
         [[personality.lx.when]]
         env.LX_TEST_COND = "yes"
         sort = "size"
-    "#);
+    "#,
+    );
 
     cmd.env("LX_TEST_COND", "yes")
         .args(["--show-config"])
@@ -46,14 +46,16 @@ fn when_env_matches_overrides_setting() {
 
 #[test]
 fn when_env_not_set_uses_base() {
-    let (_dir, mut cmd) = lx_with_conditional_config(r#"
+    let (_dir, mut cmd) = lx_with_conditional_config(
+        r#"
         [personality.lx]
         sort = "name"
 
         [[personality.lx.when]]
         env.LX_TEST_COND = "yes"
         sort = "size"
-    "#);
+    "#,
+    );
 
     // LX_TEST_COND not set — should use base sort = "name"
     cmd.env_remove("LX_TEST_COND")
@@ -65,14 +67,16 @@ fn when_env_not_set_uses_base() {
 
 #[test]
 fn when_env_wrong_value_uses_base() {
-    let (_dir, mut cmd) = lx_with_conditional_config(r#"
+    let (_dir, mut cmd) = lx_with_conditional_config(
+        r#"
         [personality.lx]
         sort = "name"
 
         [[personality.lx.when]]
         env.LX_TEST_COND = "yes"
         sort = "size"
-    "#);
+    "#,
+    );
 
     cmd.env("LX_TEST_COND", "no")
         .args(["--show-config"])
@@ -81,12 +85,12 @@ fn when_env_wrong_value_uses_base() {
         .stdout(predicate::str::contains("sort").and(predicate::str::contains("name")));
 }
 
-
 // ── Multiple conditions (AND) ────────────────────────────────────
 
 #[test]
 fn when_multiple_env_all_must_match() {
-    let (_dir, mut cmd) = lx_with_conditional_config(r#"
+    let (_dir, mut cmd) = lx_with_conditional_config(
+        r#"
         [personality.lx]
         sort = "name"
 
@@ -94,7 +98,8 @@ fn when_multiple_env_all_must_match() {
         env.LX_TEST_A = "one"
         env.LX_TEST_B = "two"
         sort = "size"
-    "#);
+    "#,
+    );
 
     // Only one matches — should NOT override.
     cmd.env("LX_TEST_A", "one")
@@ -107,7 +112,8 @@ fn when_multiple_env_all_must_match() {
 
 #[test]
 fn when_multiple_env_both_match() {
-    let (_dir, mut cmd) = lx_with_conditional_config(r#"
+    let (_dir, mut cmd) = lx_with_conditional_config(
+        r#"
         [personality.lx]
         sort = "name"
 
@@ -115,7 +121,8 @@ fn when_multiple_env_both_match() {
         env.LX_TEST_A = "one"
         env.LX_TEST_B = "two"
         sort = "size"
-    "#);
+    "#,
+    );
 
     cmd.env("LX_TEST_A", "one")
         .env("LX_TEST_B", "two")
@@ -125,12 +132,12 @@ fn when_multiple_env_both_match() {
         .stdout(predicate::str::contains("sort").and(predicate::str::contains("size")));
 }
 
-
 // ── Multiple when blocks (OR, later wins) ────────────────────────
 
 #[test]
 fn when_later_block_overrides_earlier() {
-    let (_dir, mut cmd) = lx_with_conditional_config(r#"
+    let (_dir, mut cmd) = lx_with_conditional_config(
+        r#"
         [personality.lx]
         sort = "name"
 
@@ -141,7 +148,8 @@ fn when_later_block_overrides_earlier() {
         [[personality.lx.when]]
         env.LX_TEST_SECOND = "yes"
         sort = "extension"
-    "#);
+    "#,
+    );
 
     // Both match — second block's sort = "extension" should win.
     cmd.env("LX_TEST_FIRST", "yes")
@@ -152,19 +160,20 @@ fn when_later_block_overrides_earlier() {
         .stdout(predicate::str::contains("sort").and(predicate::str::contains("extension")));
 }
 
-
 // ── env.VAR = true/false (set/unset) ─────────────────────────────
 
 #[test]
 fn when_env_true_matches_when_present() {
-    let (_dir, mut cmd) = lx_with_conditional_config(r#"
+    let (_dir, mut cmd) = lx_with_conditional_config(
+        r#"
         [personality.lx]
         sort = "name"
 
         [[personality.lx.when]]
         env.LX_TEST_SET = true
         sort = "size"
-    "#);
+    "#,
+    );
 
     cmd.env("LX_TEST_SET", "anything")
         .args(["--show-config"])
@@ -175,14 +184,16 @@ fn when_env_true_matches_when_present() {
 
 #[test]
 fn when_env_true_fails_when_absent() {
-    let (_dir, mut cmd) = lx_with_conditional_config(r#"
+    let (_dir, mut cmd) = lx_with_conditional_config(
+        r#"
         [personality.lx]
         sort = "name"
 
         [[personality.lx.when]]
         env.LX_TEST_SET = true
         sort = "size"
-    "#);
+    "#,
+    );
 
     cmd.env_remove("LX_TEST_SET")
         .args(["--show-config"])
@@ -193,14 +204,16 @@ fn when_env_true_fails_when_absent() {
 
 #[test]
 fn when_env_false_matches_when_absent() {
-    let (_dir, mut cmd) = lx_with_conditional_config(r#"
+    let (_dir, mut cmd) = lx_with_conditional_config(
+        r#"
         [personality.lx]
         sort = "name"
 
         [[personality.lx.when]]
         env.LX_TEST_UNSET = false
         sort = "size"
-    "#);
+    "#,
+    );
 
     cmd.env_remove("LX_TEST_UNSET")
         .args(["--show-config"])
@@ -211,14 +224,16 @@ fn when_env_false_matches_when_absent() {
 
 #[test]
 fn when_env_false_fails_when_present() {
-    let (_dir, mut cmd) = lx_with_conditional_config(r#"
+    let (_dir, mut cmd) = lx_with_conditional_config(
+        r#"
         [personality.lx]
         sort = "name"
 
         [[personality.lx.when]]
         env.LX_TEST_UNSET = false
         sort = "size"
-    "#);
+    "#,
+    );
 
     cmd.env("LX_TEST_UNSET", "something")
         .args(["--show-config"])
@@ -229,7 +244,8 @@ fn when_env_false_fails_when_present() {
 
 #[test]
 fn when_env_true_and_exact_combined() {
-    let (_dir, mut cmd) = lx_with_conditional_config(r#"
+    let (_dir, mut cmd) = lx_with_conditional_config(
+        r#"
         [personality.lx]
         sort = "name"
 
@@ -237,7 +253,8 @@ fn when_env_true_and_exact_combined() {
         env.LX_TEST_SSH = true
         env.LX_TEST_TERM = "ghostty"
         sort = "size"
-    "#);
+    "#,
+    );
 
     // Both conditions met.
     cmd.env("LX_TEST_SSH", "1")
@@ -250,7 +267,8 @@ fn when_env_true_and_exact_combined() {
 
 #[test]
 fn when_env_true_and_exact_partial_fail() {
-    let (_dir, mut cmd) = lx_with_conditional_config(r#"
+    let (_dir, mut cmd) = lx_with_conditional_config(
+        r#"
         [personality.lx]
         sort = "name"
 
@@ -258,7 +276,8 @@ fn when_env_true_and_exact_partial_fail() {
         env.LX_TEST_SSH = true
         env.LX_TEST_TERM = "ghostty"
         sort = "size"
-    "#);
+    "#,
+    );
 
     // env-set met but env exact match fails.
     cmd.env("LX_TEST_SSH", "1")
@@ -269,12 +288,12 @@ fn when_env_true_and_exact_partial_fail() {
         .stdout(predicate::str::contains("sort").and(predicate::str::contains("name")));
 }
 
-
 // ── Version warning ──────────────────────────────────────────────
 
 #[test]
 fn when_blocks_in_v03_config_warns() {
-    let (_dir, mut cmd) = lx_with_conditional_config(r#"
+    let (_dir, mut cmd) = lx_with_conditional_config(
+        r#"
         version = "0.3"
 
         [personality.lx]
@@ -283,7 +302,8 @@ fn when_blocks_in_v03_config_warns() {
         [[personality.lx.when]]
         env.LX_TEST_COND = "yes"
         sort = "size"
-    "#);
+    "#,
+    );
 
     cmd.args(["-1", "."])
         .assert()
@@ -293,12 +313,14 @@ fn when_blocks_in_v03_config_warns() {
 
 #[test]
 fn v03_config_without_when_no_warning() {
-    let (_dir, mut cmd) = lx_with_conditional_config(r#"
+    let (_dir, mut cmd) = lx_with_conditional_config(
+        r#"
         version = "0.3"
 
         [personality.lx]
         sort = "name"
-    "#);
+    "#,
+    );
 
     cmd.args(["-1", "."])
         .assert()

--- a/tests/cli_config.rs
+++ b/tests/cli_config.rs
@@ -2,13 +2,12 @@
 
 mod support;
 
+use predicates::prelude::*;
 use std::fs;
 use std::os::unix::fs as unix_fs;
 use std::process::Command as StdCommand;
-use predicates::prelude::*;
 use support::{lx, lx_no_colour};
 use tempfile::tempdir;
-
 
 /// Helper: run lx with a given config file via LX_CONFIG env var.
 /// Automatically prepends the current config version if not present.
@@ -27,15 +26,16 @@ fn lx_with_config(config_content: &str) -> (tempfile::TempDir, assert_cmd::Comma
     (dir, cmd)
 }
 
-
 // ── The lx personality (global defaults) ─────────────────────────
 
 #[test]
 fn config_lx_personality_group_dirs() {
-    let (_dir, mut cmd) = lx_with_config(r#"
+    let (_dir, mut cmd) = lx_with_config(
+        r#"
         [personality.lx]
         group-dirs = "first"
-    "#);
+    "#,
+    );
 
     // Create a tempdir with a file and a directory
     let work = tempdir().expect("failed to create workdir");
@@ -55,10 +55,12 @@ fn config_lx_personality_group_dirs() {
 
 #[test]
 fn config_lx_overridden_by_cli() {
-    let (_dir, mut cmd) = lx_with_config(r#"
+    let (_dir, mut cmd) = lx_with_config(
+        r#"
         [personality.lx]
         group-dirs = "first"
-    "#);
+    "#,
+    );
 
     let work = tempdir().expect("failed to create workdir");
     fs::write(work.path().join("aaa_file.txt"), "").unwrap();
@@ -78,10 +80,12 @@ fn config_lx_overridden_by_cli() {
 
 #[test]
 fn config_lx_personality_time_style() {
-    let (_dir, mut cmd) = lx_with_config(r#"
+    let (_dir, mut cmd) = lx_with_config(
+        r#"
         [personality.lx]
         time-style = "long-iso"
-    "#);
+    "#,
+    );
 
     cmd.args(["-l", "Cargo.toml"])
         .assert()
@@ -90,15 +94,16 @@ fn config_lx_personality_time_style() {
         .stdout(predicate::str::is_match(r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}").unwrap());
 }
 
-
 // ── Config-defined formats ───────────────────────────────────────
 
 #[test]
 fn config_custom_format() {
-    let (_dir, mut cmd) = lx_with_config(r#"
+    let (_dir, mut cmd) = lx_with_config(
+        r#"
         [format]
         tiny = ["size", "modified"]
-    "#);
+    "#,
+    );
 
     cmd.args(["--format=tiny", "Cargo.toml"])
         .assert()
@@ -110,10 +115,12 @@ fn config_custom_format() {
 
 #[test]
 fn config_format_overrides_compiled_in() {
-    let (_dir, mut cmd) = lx_with_config(r#"
+    let (_dir, mut cmd) = lx_with_config(
+        r#"
         [format]
         long = ["size", "modified"]
-    "#);
+    "#,
+    );
 
     // -l uses "long" format, which is now overridden in config
     cmd.args(["-l", "Cargo.toml"])
@@ -123,16 +130,17 @@ fn config_format_overrides_compiled_in() {
         .stdout(predicate::str::contains(".rw").not());
 }
 
-
 // ── Config-defined personalities ─────────────────────────────────
 
 #[test]
 fn config_custom_personality() {
-    let (_dir, mut cmd) = lx_with_config(r#"
+    let (_dir, mut cmd) = lx_with_config(
+        r#"
         [personality.myview]
         columns = ["perms", "size"]
         group-dirs = "first"
-    "#);
+    "#,
+    );
 
     let work = tempdir().expect("failed to create workdir");
     fs::write(work.path().join("file.txt"), "").unwrap();
@@ -150,19 +158,20 @@ fn config_custom_personality() {
         }));
 }
 
-
 // ── Personality inheritance ───────────────────────────────────────
 
 #[test]
 fn inherit_single_level() {
-    let (_dir, mut cmd) = lx_with_config(r#"
+    let (_dir, mut cmd) = lx_with_config(
+        r#"
         [personality.base]
         group-dirs = "first"
 
         [personality.child]
         inherits = "base"
         format = "long"
-    "#);
+    "#,
+    );
 
     let work = tempdir().expect("failed to create workdir");
     fs::write(work.path().join("aaa_file.txt"), "").unwrap();
@@ -182,7 +191,8 @@ fn inherit_single_level() {
 
 #[test]
 fn inherit_multi_level() {
-    let (_dir, mut cmd) = lx_with_config(r#"
+    let (_dir, mut cmd) = lx_with_config(
+        r#"
         [personality.root]
         group-dirs = "first"
 
@@ -193,7 +203,8 @@ fn inherit_multi_level() {
         [personality.leaf]
         inherits = "mid"
         header = true
-    "#);
+    "#,
+    );
 
     cmd.args(["-pleaf", "Cargo.toml"])
         .assert()
@@ -204,7 +215,8 @@ fn inherit_multi_level() {
 
 #[test]
 fn inherit_child_overrides_parent_setting() {
-    let (_dir, mut cmd) = lx_with_config(r#"
+    let (_dir, mut cmd) = lx_with_config(
+        r#"
         [personality.parent]
         format = "long"
         sort = "name"
@@ -212,24 +224,25 @@ fn inherit_child_overrides_parent_setting() {
         [personality.child]
         inherits = "parent"
         sort = "size"
-    "#);
+    "#,
+    );
 
     // Just check it runs without error; sort=size from child wins
-    cmd.args(["-pchild", "Cargo.toml"])
-        .assert()
-        .success();
+    cmd.args(["-pchild", "Cargo.toml"]).assert().success();
 }
 
 #[test]
 fn inherit_child_overrides_format() {
-    let (_dir, mut cmd) = lx_with_config(r#"
+    let (_dir, mut cmd) = lx_with_config(
+        r#"
         [personality.parent]
         format = "long2"
 
         [personality.child]
         inherits = "parent"
         format = "long"
-    "#);
+    "#,
+    );
 
     cmd.args(["-pchild", "Cargo.toml"])
         .assert()
@@ -240,13 +253,15 @@ fn inherit_child_overrides_format() {
 
 #[test]
 fn inherit_cycle_detected() {
-    let (_dir, mut cmd) = lx_with_config(r#"
+    let (_dir, mut cmd) = lx_with_config(
+        r#"
         [personality.a]
         inherits = "b"
 
         [personality.b]
         inherits = "a"
-    "#);
+    "#,
+    );
 
     cmd.args(["-pa", "Cargo.toml"])
         .assert()
@@ -257,11 +272,13 @@ fn inherit_cycle_detected() {
 #[test]
 fn inherit_from_compiled_in() {
     // Config personality inherits from compiled-in "ll"
-    let (_dir, mut cmd) = lx_with_config(r#"
+    let (_dir, mut cmd) = lx_with_config(
+        r#"
         [personality.myll]
         inherits = "ll"
         header = true
-    "#);
+    "#,
+    );
 
     cmd.args(["-pmyll", "Cargo.toml"])
         .assert()
@@ -274,14 +291,16 @@ fn inherit_from_compiled_in() {
 #[test]
 fn standalone_no_inherits() {
     // No inherits = standalone, no inherited settings
-    let (_dir, mut cmd) = lx_with_config(r#"
+    let (_dir, mut cmd) = lx_with_config(
+        r#"
         [personality.base]
         group-dirs = "first"
         header = true
 
         [personality.standalone]
         format = "long"
-    "#);
+    "#,
+    );
 
     cmd.args(["-pstandalone", "Cargo.toml"])
         .assert()
@@ -290,16 +309,17 @@ fn standalone_no_inherits() {
         .stdout(predicate::str::contains("Permissions").not());
 }
 
-
 // ── Named settings ──────────────────────────────────────────────
 
 #[test]
 fn config_personality_bool_setting() {
-    let (_dir, mut cmd) = lx_with_config(r#"
+    let (_dir, mut cmd) = lx_with_config(
+        r#"
         [personality.hdr]
         format = "long"
         header = true
-    "#);
+    "#,
+    );
 
     cmd.args(["-phdr", "Cargo.toml"])
         .assert()
@@ -309,10 +329,12 @@ fn config_personality_bool_setting() {
 
 #[test]
 fn config_personality_columns_as_string() {
-    let (_dir, mut cmd) = lx_with_config(r#"
+    let (_dir, mut cmd) = lx_with_config(
+        r#"
         [personality.tiny]
         columns = "size,modified"
-    "#);
+    "#,
+    );
 
     cmd.args(["-ptiny", "Cargo.toml"])
         .assert()
@@ -323,18 +345,19 @@ fn config_personality_columns_as_string() {
 
 #[test]
 fn config_unknown_setting_warns() {
-    let (_dir, mut cmd) = lx_with_config(r#"
+    let (_dir, mut cmd) = lx_with_config(
+        r#"
         [personality.bad]
         format = "long"
         frobnicate = true
-    "#);
+    "#,
+    );
 
     cmd.args(["-pbad", "Cargo.toml"])
         .assert()
         .success()
         .stderr(predicate::str::contains("unknown setting 'frobnicate'"));
 }
-
 
 // ── Compiled-in personalities ────────────────────────────────────
 
@@ -396,7 +419,6 @@ fn personality_long_flag() {
         .stdout(predicate::str::contains(support::current_group()));
 }
 
-
 // ── argv[0] dispatch ─────────────────────────────────────────────
 
 #[test]
@@ -439,7 +461,6 @@ fn argv0_unknown_falls_back() {
     assert!(stdout.contains("Cargo.toml"));
 }
 
-
 // ── --init-config ────────────────────────────────────────────────
 
 #[test]
@@ -447,8 +468,7 @@ fn init_config_creates_file() {
     let dir = tempdir().expect("failed to create tempdir");
     let config_path = dir.path().join(".lxconfig.toml");
 
-    lx()
-        .args(["--init-config"])
+    lx().args(["--init-config"])
         .env("HOME", dir.path())
         .assert()
         .success()
@@ -471,14 +491,12 @@ fn init_config_refuses_overwrite() {
     let config_path = dir.path().join(".lxconfig.toml");
     fs::write(&config_path, "existing").unwrap();
 
-    lx()
-        .args(["--init-config"])
+    lx().args(["--init-config"])
         .env("HOME", dir.path())
         .assert()
         .failure()
         .stderr(predicate::str::contains("already exists"));
 }
-
 
 // ── Config file discovery ────────────────────────────────────────
 
@@ -486,11 +504,15 @@ fn init_config_refuses_overwrite() {
 fn lx_config_env_takes_priority() {
     let dir = tempdir().expect("failed to create tempdir");
     let config_path = dir.path().join("custom.toml");
-    fs::write(&config_path, r#"
+    fs::write(
+        &config_path,
+        r#"
         version = "0.3"
         [personality.lx]
         group-dirs = "first"
-    "#).unwrap();
+    "#,
+    )
+    .unwrap();
 
     let work = tempdir().expect("failed to create workdir");
     fs::write(work.path().join("aaa.txt"), "").unwrap();
@@ -525,7 +547,6 @@ fn no_config_file_is_fine() {
         .stdout(predicate::str::contains("Cargo.toml"));
 }
 
-
 // ── --dump-class ─────────────────────────────────────────────────
 
 #[test]
@@ -557,7 +578,9 @@ fn dump_class_unknown() {
         .assert()
         .failure()
         .code(2)
-        .stderr(predicate::str::contains("invalid value 'bogus' for '--dump-class"))
+        .stderr(predicate::str::contains(
+            "invalid value 'bogus' for '--dump-class",
+        ))
         .stderr(predicate::str::contains("[possible values:"));
 }
 
@@ -592,7 +615,9 @@ fn dump_format_unknown() {
         .assert()
         .failure()
         .code(2)
-        .stderr(predicate::str::contains("invalid value 'bogus' for '--dump-format"))
+        .stderr(predicate::str::contains(
+            "invalid value 'bogus' for '--dump-format",
+        ))
         .stderr(predicate::str::contains("[possible values:"));
 }
 
@@ -626,7 +651,9 @@ fn dump_personality_unknown() {
         .assert()
         .failure()
         .code(2)
-        .stderr(predicate::str::contains("invalid value 'bogus' for '--dump-personality"))
+        .stderr(predicate::str::contains(
+            "invalid value 'bogus' for '--dump-personality",
+        ))
         .stderr(predicate::str::contains("[possible values:"));
 }
 
@@ -649,7 +676,9 @@ fn dump_theme_unknown() {
         .assert()
         .failure()
         .code(2)
-        .stderr(predicate::str::contains("invalid value 'bogus' for '--dump-theme"))
+        .stderr(predicate::str::contains(
+            "invalid value 'bogus' for '--dump-theme",
+        ))
         .stderr(predicate::str::contains("[possible values:"));
 }
 
@@ -673,7 +702,9 @@ fn dump_style_unknown() {
         .assert()
         .failure()
         .code(2)
-        .stderr(predicate::str::contains("invalid value 'bogus' for '--dump-style"))
+        .stderr(predicate::str::contains(
+            "invalid value 'bogus' for '--dump-style",
+        ))
         .stderr(predicate::str::contains("[possible values:"));
 }
 
@@ -681,10 +712,12 @@ fn dump_style_unknown() {
 
 #[test]
 fn dump_class_shows_config_override() {
-    let (_dir, mut cmd) = lx_with_config(r#"
+    let (_dir, mut cmd) = lx_with_config(
+        r#"
 [class]
 temp = ["*.tmp", "*.bak"]
-"#);
+"#,
+    );
 
     cmd.arg("--dump-class=temp")
         .assert()
@@ -693,7 +726,6 @@ temp = ["*.tmp", "*.bak"]
         // Should NOT contain the compiled-in patterns that were overridden
         .stdout(predicate::str::contains("*.swp").not());
 }
-
 
 // ── --init-config invariant ──────────────────────────────────────
 //
@@ -706,8 +738,7 @@ fn init_config_does_not_change_defaults() {
     let config_path = dir.path().join(".lxconfig.toml");
 
     // Generate the default config file.
-    lx()
-        .arg("--init-config")
+    lx().arg("--init-config")
         .env("HOME", dir.path())
         .env_remove("LX_CONFIG")
         .assert()
@@ -749,7 +780,6 @@ fn init_config_does_not_change_defaults() {
     }
 }
 
-
 // ── Three-state Bool config semantics ───────────────────────────
 
 /// `key = false` in a child personality suppresses a column that
@@ -758,11 +788,13 @@ fn init_config_does_not_change_defaults() {
 /// could suppress.
 #[test]
 fn bool_false_suppresses_inherited_column() {
-    let (_dir, mut cmd) = lx_with_config(r#"
+    let (_dir, mut cmd) = lx_with_config(
+        r#"
         [personality.nosize]
         inherits = "ll"
         size = false
-    "#);
+    "#,
+    );
 
     let work = tempdir().expect("failed to create workdir");
     fs::write(work.path().join("hello.txt"), "hi").unwrap();
@@ -777,13 +809,18 @@ fn bool_false_suppresses_inherited_column() {
         .expect("failed to run lx");
     let with_size_out = String::from_utf8_lossy(&with_size.stdout);
     // ll shows sizes — verify baseline
-    assert!(with_size_out.contains("hello.txt"), "baseline: file should appear");
+    assert!(
+        with_size_out.contains("hello.txt"),
+        "baseline: file should appear"
+    );
 
-    let (_dir2, mut cmd2) = lx_with_config(r#"
+    let (_dir2, mut cmd2) = lx_with_config(
+        r#"
         [personality.nosize]
         inherits = "ll"
         size = false
-    "#);
+    "#,
+    );
     let without_size = cmd2
         .args(["-p", "nosize", "--colour=never"])
         .arg(work.path())
@@ -793,8 +830,14 @@ fn bool_false_suppresses_inherited_column() {
 
     // The size column in ll shows "2" for a 2-byte file.
     // With size suppressed, the number should be absent.
-    assert!(with_size_out.contains(" 2 "), "baseline: ll should show file size");
-    assert!(!without_size_out.contains(" 2 "), "size = false should suppress the size column");
+    assert!(
+        with_size_out.contains(" 2 "),
+        "baseline: ll should show file size"
+    );
+    assert!(
+        !without_size_out.contains(" 2 "),
+        "size = false should suppress the size column"
+    );
 }
 
 /// `permissions = false` suppresses the permissions column from an
@@ -805,11 +848,13 @@ fn bool_false_suppresses_permissions() {
     let work = tempdir().expect("failed to create workdir");
     fs::write(work.path().join("test.txt"), "").unwrap();
 
-    let (_dir, mut cmd) = lx_with_config(r#"
+    let (_dir, mut cmd) = lx_with_config(
+        r#"
         [personality.noperm]
         inherits = "ll"
         permissions = false
-    "#);
+    "#,
+    );
     cmd.args(["-p", "noperm", "--colour=never"])
         .arg(work.path())
         .assert()
@@ -826,25 +871,31 @@ fn no_key_true_equivalent_to_key_false() {
     let work = tempdir().expect("failed to create workdir");
     fs::write(work.path().join("hello.txt"), "hi").unwrap();
 
-    let (_dir1, mut cmd1) = lx_with_config(r#"
+    let (_dir1, mut cmd1) = lx_with_config(
+        r#"
         [personality.via-false]
         inherits = "ll"
         size = false
-    "#);
+    "#,
+    );
     let out_false = cmd1
         .args(["-p", "via-false", "--colour=never"])
         .arg(work.path())
-        .output().expect("failed to run lx");
+        .output()
+        .expect("failed to run lx");
 
-    let (_dir2, mut cmd2) = lx_with_config(r#"
+    let (_dir2, mut cmd2) = lx_with_config(
+        r#"
         [personality.via-no]
         inherits = "ll"
         no-size = true
-    "#);
+    "#,
+    );
     let out_no = cmd2
         .args(["-p", "via-no", "--colour=never"])
         .arg(work.path())
-        .output().expect("failed to run lx");
+        .output()
+        .expect("failed to run lx");
 
     assert_eq!(
         String::from_utf8_lossy(&out_false.stdout),
@@ -864,10 +915,12 @@ fn config_ignore_toml_array() {
     fs::write(work.path().join("notes.tmp"), "").unwrap();
     fs::write(work.path().join("old.bak"), "").unwrap();
 
-    let (_dir, mut cmd) = lx_with_config(r#"
+    let (_dir, mut cmd) = lx_with_config(
+        r#"
         [personality.lx]
         ignore = ["*.tmp", "*.bak"]
-    "#);
+    "#,
+    );
     cmd.args(["-1"])
         .arg(work.path())
         .assert()
@@ -885,10 +938,12 @@ fn config_ignore_pipe_string_still_works() {
     fs::write(work.path().join("notes.tmp"), "").unwrap();
     fs::write(work.path().join("old.bak"), "").unwrap();
 
-    let (_dir, mut cmd) = lx_with_config(r#"
+    let (_dir, mut cmd) = lx_with_config(
+        r#"
         [personality.lx]
         ignore = "*.tmp|*.bak"
-    "#);
+    "#,
+    );
     cmd.args(["-1"])
         .arg(work.path())
         .assert()
@@ -909,10 +964,12 @@ fn config_prune_toml_array() {
     fs::write(work.path().join("target/debug/binary"), "").unwrap();
     fs::write(work.path().join("node_modules/foo/index.js"), "").unwrap();
 
-    let (_dir, mut cmd) = lx_with_config(r#"
+    let (_dir, mut cmd) = lx_with_config(
+        r#"
         [personality.lx]
         prune = ["target", "node_modules"]
-    "#);
+    "#,
+    );
     cmd.args(["-T"])
         .arg(work.path())
         .assert()
@@ -922,7 +979,6 @@ fn config_prune_toml_array() {
         .stdout(predicate::str::contains("index.js").not());
 }
 
-
 /// `tree = false` has no negation counterpart (`--no-tree` doesn't
 /// exist), so `false` should be a silent no-op rather than an error.
 #[test]
@@ -930,11 +986,13 @@ fn bool_false_without_negation_is_noop() {
     let work = tempdir().expect("failed to create workdir");
     fs::write(work.path().join("test.txt"), "").unwrap();
 
-    let (_dir, mut cmd) = lx_with_config(r#"
+    let (_dir, mut cmd) = lx_with_config(
+        r#"
         [personality.notree]
         inherits = "lx"
         tree = false
-    "#);
+    "#,
+    );
     cmd.args(["-p", "notree", "--colour=never"])
         .arg(work.path())
         .assert()
@@ -951,16 +1009,19 @@ fn no_time_still_works_as_bulk_clear() {
 
     // lll includes all four timestamps.  no-time should clear them all,
     // then accessed = true adds just the accessed column back.
-    let (_dir, mut cmd) = lx_with_config(r#"
+    let (_dir, mut cmd) = lx_with_config(
+        r#"
         [personality.justaccessed]
         inherits = "lll"
         no-time = true
         accessed = true
-    "#);
+    "#,
+    );
     let out = cmd
         .args(["-p", "justaccessed", "--colour=never"])
         .arg(work.path())
-        .output().expect("failed to run lx");
+        .output()
+        .expect("failed to run lx");
     let stdout = String::from_utf8_lossy(&out.stdout);
 
     // lll normally shows modified, changed, created, accessed.

--- a/tests/cli_count.rs
+++ b/tests/cli_count.rs
@@ -2,11 +2,10 @@
 
 mod support;
 
-use std::fs;
 use predicates::prelude::*;
+use std::fs;
 use support::lx_no_colour;
 use tempfile::tempdir;
-
 
 fn count_fixture() -> tempfile::TempDir {
     let dir = tempdir().expect("failed to create tempdir");
@@ -20,7 +19,6 @@ fn count_fixture() -> tempfile::TempDir {
 
     dir
 }
-
 
 #[test]
 fn count_flat_listing() {

--- a/tests/cli_display.rs
+++ b/tests/cli_display.rs
@@ -3,12 +3,11 @@
 
 mod support;
 
+use predicates::prelude::*;
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
-use predicates::prelude::*;
 use support::lx_no_colour;
 use tempfile::tempdir;
-
 
 fn display_fixture() -> tempfile::TempDir {
     let dir = tempdir().expect("failed to create tempdir");
@@ -27,7 +26,6 @@ fn display_fixture() -> tempfile::TempDir {
     dir
 }
 
-
 // ── --absolute / -A ──────────────────────────────────────────────
 
 #[test]
@@ -39,7 +37,9 @@ fn absolute_shows_full_paths() {
         .arg(dir.path())
         .assert()
         .success()
-        .stdout(predicate::str::contains(dir.path().to_string_lossy().as_ref()));
+        .stdout(predicate::str::contains(
+            dir.path().to_string_lossy().as_ref(),
+        ));
 }
 
 #[test]
@@ -53,7 +53,6 @@ fn no_absolute_shows_relative_names() {
         .success()
         .stdout(predicate::str::contains(dir.path().to_string_lossy().as_ref()).not());
 }
-
 
 // ── --classify ───────────────────────────────────────────────────
 
@@ -83,7 +82,6 @@ fn classify_never_hides_indicators() {
         .stdout(predicate::str::contains("run.sh\n"));
 }
 
-
 // ── --octal / -o ─────────────────────────────────────────────────
 
 #[test]
@@ -110,7 +108,6 @@ fn octal_permissions_alias_works() {
         .stdout(predicate::str::is_match(r"0\d{3}").unwrap());
 }
 
-
 // ── --only-files / -f ────────────────────────────────────────────
 
 #[test]
@@ -125,7 +122,6 @@ fn only_files_hides_directories() {
         .stdout(predicate::str::contains("subdir").not())
         .stdout(predicate::str::contains("hello.rs"));
 }
-
 
 // ── --quotes ─────────────────────────────────────────────────────
 
@@ -153,7 +149,6 @@ fn quotes_never_no_wrapping() {
         .stdout(predicate::str::contains("\"space file.txt\"").not())
         .stdout(predicate::str::contains("space file.txt"));
 }
-
 
 // ── --flags / -O ─────────────────────────────────────────────────
 
@@ -260,7 +255,6 @@ fn flags_shows_uchg_on_macos() {
         .expect("failed to run chflags");
 }
 
-
 #[test]
 fn flags_short_flag() {
     let dir = display_fixture();
@@ -310,7 +304,6 @@ fn flags_shows_immutable_on_linux() {
         .status()
         .expect("failed to run chattr");
 }
-
 
 // ── --width / -w ─────────────────────────────────────────────────
 

--- a/tests/cli_dropin.rs
+++ b/tests/cli_dropin.rs
@@ -2,11 +2,10 @@
 
 mod support;
 
-use std::fs;
 use predicates::prelude::*;
+use std::fs;
 use support::lx_no_colour;
 use tempfile::tempdir;
-
 
 /// Create a config directory with a main config and optional drop-ins.
 fn config_with_dropins(
@@ -34,12 +33,11 @@ fn config_with_dropins(
 
     let mut cmd = assert_cmd::Command::cargo_bin("lx").expect("binary lx not found");
     cmd.env("HOME", "/nonexistent")
-       .env_remove("LX_CONFIG")
-       .env("XDG_CONFIG_HOME", dir.path())
-       .arg("--colour=never");
+        .env_remove("LX_CONFIG")
+        .env("XDG_CONFIG_HOME", dir.path())
+        .arg("--colour=never");
     (dir, cmd)
 }
-
 
 #[test]
 fn dropin_theme_is_loaded() {
@@ -48,11 +46,14 @@ fn dropin_theme_is_loaded() {
         [personality.lx]
         theme = "test-theme"
         "#,
-        &[("theme.toml", r#"
+        &[(
+            "theme.toml",
+            r#"
             [theme.test-theme]
             inherits = "exa"
             directory = "bold red"
-        "#)],
+        "#,
+        )],
     );
 
     cmd.args(["--show-config"])
@@ -68,14 +69,20 @@ fn dropin_files_loaded_alphabetically() {
     let (_dir, mut cmd) = config_with_dropins(
         "",
         &[
-            ("a-first.toml", r#"
+            (
+                "a-first.toml",
+                r#"
                 [class]
                 testclass = ["*.aaa"]
-            "#),
-            ("b-second.toml", r#"
+            "#,
+            ),
+            (
+                "b-second.toml",
+                r#"
                 [class]
                 testclass = ["*.bbb"]
-            "#),
+            "#,
+            ),
         ],
     );
 
@@ -90,11 +97,14 @@ fn dropin_files_loaded_alphabetically() {
 fn dropin_personality_available() {
     let (_dir, mut cmd) = config_with_dropins(
         "",
-        &[("pers.toml", r#"
+        &[(
+            "pers.toml",
+            r#"
             [personality.custom]
             long = true
             header = true
-        "#)],
+        "#,
+        )],
     );
 
     cmd.args(["--dump-personality=custom"])
@@ -110,16 +120,20 @@ fn dropin_without_main_config() {
     let dir = tempdir().expect("failed to create tempdir");
     let conf_d = dir.path().join("lx").join("conf.d");
     fs::create_dir_all(&conf_d).unwrap();
-    fs::write(conf_d.join("classes.toml"), r#"
+    fs::write(
+        conf_d.join("classes.toml"),
+        r#"
         [class]
         myclass = ["*.xyz"]
-    "#).unwrap();
+    "#,
+    )
+    .unwrap();
 
     let mut cmd = assert_cmd::Command::cargo_bin("lx").expect("binary lx not found");
     cmd.env("HOME", "/nonexistent")
-       .env_remove("LX_CONFIG")
-       .env("XDG_CONFIG_HOME", dir.path())
-       .arg("--colour=never");
+        .env_remove("LX_CONFIG")
+        .env("XDG_CONFIG_HOME", dir.path())
+        .arg("--colour=never");
 
     cmd.args(["--dump-class=myclass"])
         .assert()
@@ -131,10 +145,13 @@ fn dropin_without_main_config() {
 fn show_config_lists_dropins() {
     let (_dir, mut cmd) = config_with_dropins(
         "",
-        &[("my-theme.toml", r#"
+        &[(
+            "my-theme.toml",
+            r#"
             [theme.ocean]
             inherits = "exa"
-        "#)],
+        "#,
+        )],
     );
 
     cmd.args(["--show-config"])

--- a/tests/cli_filtering.rs
+++ b/tests/cli_filtering.rs
@@ -2,11 +2,10 @@
 
 mod support;
 
-use std::fs;
 use predicates::prelude::*;
+use std::fs;
 use support::lx_no_colour;
 use tempfile::tempdir;
-
 
 /// Create a fixture directory with subdirectories and files.
 fn filtering_fixture() -> tempfile::TempDir {
@@ -29,7 +28,6 @@ fn filtering_fixture() -> tempfile::TempDir {
 
     dir
 }
-
 
 // ── --ignore / -I ────────────────────────────────────────────────
 
@@ -70,7 +68,6 @@ fn ignore_glob_alias_still_works() {
         .success()
         .stdout(predicate::str::contains("notes.tmp").not());
 }
-
 
 // ── --prune / -P ─────────────────────────────────────────────────
 
@@ -181,7 +178,6 @@ fn ignore_and_prune_compose() {
         .stdout(predicate::str::contains("main.rs"));
 }
 
-
 // ── --symlinks ───────────────────────────────────────────────────
 
 /// Create a fixture with regular files and symlinks.
@@ -279,6 +275,9 @@ fn symlinks_follow_recurses_into_linked_dirs() {
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     // inner.txt should appear twice — once under real_dir, once under linked_dir
-    assert_eq!(stdout.matches("inner.txt").count(), 2,
-        "Expected inner.txt twice (under real_dir and linked_dir), got:\n{stdout}");
+    assert_eq!(
+        stdout.matches("inner.txt").count(),
+        2,
+        "Expected inner.txt twice (under real_dir and linked_dir), got:\n{stdout}"
+    );
 }

--- a/tests/cli_long_tiers.rs
+++ b/tests/cli_long_tiers.rs
@@ -5,7 +5,6 @@ mod support;
 use predicates::prelude::*;
 use support::lx_no_colour;
 
-
 // ── Tier 1: -l (base long view) ──────────────────────────────────
 
 #[test]
@@ -36,7 +35,6 @@ fn tier1_no_header() {
         .stdout(predicate::str::contains("Permissions").not());
 }
 
-
 // ── Tier 2: -ll (+ group, VCS status) ────────────────────────────
 
 #[test]
@@ -57,7 +55,6 @@ fn tier2_no_header() {
         .success()
         .stdout(predicate::str::contains("Permissions").not());
 }
-
 
 // ── Tier 3: -lll (+ header, all timestamps, links, blocks) ──────
 
@@ -99,7 +96,6 @@ fn tier3_has_all_timestamp_headers() {
         .stdout(predicate::str::contains("Date Accessed"))
         .stdout(predicate::str::contains("Date Created"));
 }
-
 
 // ── Overrides on top of tiers ────────────────────────────────────
 

--- a/tests/cli_sorting.rs
+++ b/tests/cli_sorting.rs
@@ -2,11 +2,10 @@
 
 mod support;
 
-use std::fs;
 use predicates::prelude::*;
+use std::fs;
 use support::lx_no_colour;
 use tempfile::tempdir;
-
 
 /// Create a tempdir with a few files for sorting tests.
 fn sorting_fixture() -> tempfile::TempDir {
@@ -16,7 +15,6 @@ fn sorting_fixture() -> tempfile::TempDir {
     fs::write(dir.path().join("cherry.txt"), "ccc").unwrap();
     dir
 }
-
 
 #[test]
 fn sort_name_case_insensitive() {
@@ -114,7 +112,6 @@ fn reverse_sort() {
         }));
 }
 
-
 // ── Dotfiles ──────────────────────────────────────────────────────
 
 #[test]
@@ -161,7 +158,6 @@ fn dot_and_dotdot_with_all_all() {
         .stdout(predicate::str::contains(".."));
 }
 
-
 // ── Ignore globs ──────────────────────────────────────────────────
 
 #[test]
@@ -198,7 +194,6 @@ fn ignore_glob_pipe_separated() {
         .stdout(predicate::str::contains("nope.tmp").not());
 }
 
-
 // ── Only dirs ─────────────────────────────────────────────────────
 
 #[test]
@@ -216,7 +211,6 @@ fn only_dirs_hides_files() {
         .stdout(predicate::str::contains("file.txt").not());
 }
 
-
 // ── Only files ────────────────────────────────────────────────────
 
 #[test]
@@ -233,7 +227,6 @@ fn only_files_hides_dirs() {
         .stdout(predicate::str::contains("file.txt"))
         .stdout(predicate::str::contains("subdir").not());
 }
-
 
 // ── Group directories ─────────────────────────────────────────────
 
@@ -307,7 +300,7 @@ fn no_dirs_first_suppresses_dirs_first() {
         .stdout(predicate::function(|output: &str| {
             let dir_pos = output.find("zzz_dir").unwrap();
             let file_pos = output.find("aaa_file.txt").unwrap();
-            file_pos < dir_pos  // sorted alphabetically, dirs no longer pulled forward
+            file_pos < dir_pos // sorted alphabetically, dirs no longer pulled forward
         }));
 }
 
@@ -328,7 +321,6 @@ fn no_dirs_last_suppresses_dirs_last() {
             file_pos < dir_pos
         }));
 }
-
 
 // ── Batch D: expanded sort fields ──────────────────────────
 

--- a/tests/cli_theme.rs
+++ b/tests/cli_theme.rs
@@ -2,11 +2,10 @@
 
 mod support;
 
-use std::fs;
 use predicates::prelude::*;
+use std::fs;
 use support::lx_no_colour;
 use tempfile::tempdir;
-
 
 /// Helper: run lx with colour enabled and a given config.
 fn lx_with_theme(config_content: &str) -> (tempfile::TempDir, assert_cmd::Command) {
@@ -16,22 +15,23 @@ fn lx_with_theme(config_content: &str) -> (tempfile::TempDir, assert_cmd::Comman
 
     let mut cmd = assert_cmd::Command::cargo_bin("lx").expect("binary lx not found");
     cmd.env("LX_CONFIG", config_path)
-       .env("HOME", "/nonexistent")
-       .env_remove("LS_COLORS")
-       .arg("--colour=always");
+        .env("HOME", "/nonexistent")
+        .env_remove("LS_COLORS")
+        .arg("--colour=always");
     (dir, cmd)
 }
-
 
 // ── UI element overrides ─────────────────────────────────────────
 
 #[test]
 fn theme_directory_colour() {
-    let (_dir, mut cmd) = lx_with_theme(r#"
+    let (_dir, mut cmd) = lx_with_theme(
+        r#"
         version = "0.3"
         [theme.test]
         directory = "bold red"
-    "#);
+    "#,
+    );
 
     let work = tempdir().expect("failed to create workdir");
     fs::create_dir(work.path().join("mydir")).unwrap();
@@ -45,11 +45,13 @@ fn theme_directory_colour() {
 
 #[test]
 fn theme_date_colour() {
-    let (_dir, mut cmd) = lx_with_theme(r#"
+    let (_dir, mut cmd) = lx_with_theme(
+        r#"
         version = "0.3"
         [theme.test]
         date = "bold cyan"
-    "#);
+    "#,
+    );
 
     cmd.args(["--theme=test", "-l", "Cargo.toml"])
         .assert()
@@ -59,11 +61,13 @@ fn theme_date_colour() {
 
 #[test]
 fn theme_x11_colour() {
-    let (_dir, mut cmd) = lx_with_theme(r#"
+    let (_dir, mut cmd) = lx_with_theme(
+        r#"
         version = "0.3"
         [theme.test]
         date = "tomato"
-    "#);
+    "#,
+    );
 
     cmd.args(["--theme=test", "-l", "Cargo.toml"])
         .assert()
@@ -73,9 +77,7 @@ fn theme_x11_colour() {
 
 #[test]
 fn theme_hex_colour() {
-    let (_dir, mut cmd) = lx_with_theme(
-        "version = \"0.3\"\n[theme.test]\ndate = \"#ff8700\"\n"
-    );
+    let (_dir, mut cmd) = lx_with_theme("version = \"0.3\"\n[theme.test]\ndate = \"#ff8700\"\n");
 
     cmd.args(["--theme=test", "-l", "Cargo.toml"])
         .assert()
@@ -83,18 +85,19 @@ fn theme_hex_colour() {
         .stdout(predicate::str::contains("\x1b[38;2;255;135;0m"));
 }
 
-
 // ── Style set overrides ─────────────────────────────────────────
 
 #[test]
 fn theme_extension_colour() {
-    let (_dir, mut cmd) = lx_with_theme(r#"
+    let (_dir, mut cmd) = lx_with_theme(
+        r#"
         version = "0.3"
         [theme.test]
         use-style = "myexts"
         [style.myexts]
         "*.txt" = "bold magenta"
-    "#);
+    "#,
+    );
 
     let work = tempdir().expect("failed to create workdir");
     fs::write(work.path().join("readme.txt"), "").unwrap();
@@ -108,13 +111,15 @@ fn theme_extension_colour() {
 
 #[test]
 fn theme_filename_colour() {
-    let (_dir, mut cmd) = lx_with_theme(r#"
+    let (_dir, mut cmd) = lx_with_theme(
+        r#"
         version = "0.3"
         [theme.test]
         use-style = "mynames"
         [style.mynames]
         Makefile = "bold underline yellow"
-    "#);
+    "#,
+    );
 
     let work = tempdir().expect("failed to create workdir");
     fs::write(work.path().join("Makefile"), "").unwrap();
@@ -126,19 +131,20 @@ fn theme_filename_colour() {
         .stdout(predicate::str::contains("\x1b[1;4;33m"));
 }
 
-
 // ── Personality integration ──────────────────────────────────────
 
 #[test]
 fn theme_via_personality() {
-    let (_dir, mut cmd) = lx_with_theme(r#"
+    let (_dir, mut cmd) = lx_with_theme(
+        r#"
         version = "0.3"
         [personality.lx]
         theme = "ocean"
 
         [theme.ocean]
         date = "bold cyan"
-    "#);
+    "#,
+    );
 
     // The lx personality should activate the ocean theme.
     cmd.args(["-l", "Cargo.toml"])
@@ -149,7 +155,8 @@ fn theme_via_personality() {
 
 #[test]
 fn theme_inherited_through_personality() {
-    let (_dir, mut cmd) = lx_with_theme(r#"
+    let (_dir, mut cmd) = lx_with_theme(
+        r#"
         version = "0.3"
         [personality.default]
         theme = "ocean"
@@ -160,7 +167,8 @@ fn theme_inherited_through_personality() {
 
         [theme.ocean]
         date = "bold cyan"
-    "#);
+    "#,
+    );
 
     cmd.args(["-pmyview", "Cargo.toml"])
         .assert()
@@ -170,7 +178,8 @@ fn theme_inherited_through_personality() {
 
 #[test]
 fn theme_cli_overrides_personality() {
-    let (_dir, mut cmd) = lx_with_theme(r#"
+    let (_dir, mut cmd) = lx_with_theme(
+        r#"
         version = "0.3"
         [personality.lx]
         theme = "ocean"
@@ -180,7 +189,8 @@ fn theme_cli_overrides_personality() {
 
         [theme.warm]
         date = "bold red"
-    "#);
+    "#,
+    );
 
     // --theme=warm should override the personality's theme = "ocean"
     cmd.args(["--theme=warm", "-l", "Cargo.toml"])
@@ -189,14 +199,14 @@ fn theme_cli_overrides_personality() {
         .stdout(predicate::str::contains("\x1b[1;31m"));
 }
 
-
 // ── Precedence over env vars ─────────────────────────────────────
 
 // ── Class references in styles ────────────────────────────────────
 
 #[test]
 fn style_class_reference() {
-    let (_dir, mut cmd) = lx_with_theme(r#"
+    let (_dir, mut cmd) = lx_with_theme(
+        r#"
         version = "0.3"
 
         [class]
@@ -208,7 +218,8 @@ fn style_class_reference() {
 
         [style.mystyle]
         class.testclass = "bold magenta"
-    "#);
+    "#,
+    );
 
     let work = tempdir().expect("failed to create workdir");
     fs::write(work.path().join("data.xyz"), "").unwrap();
@@ -225,7 +236,8 @@ fn style_class_reference() {
 fn style_class_overrides_exa_default() {
     // User style with a class reference should override the
     // compiled-in exa style for the same files.
-    let (_dir, mut cmd) = lx_with_theme(r#"
+    let (_dir, mut cmd) = lx_with_theme(
+        r#"
         version = "0.3"
 
         [theme.test]
@@ -234,7 +246,8 @@ fn style_class_overrides_exa_default() {
 
         [style.custom]
         class.compressed = "bold cyan"
-    "#);
+    "#,
+    );
 
     let work = tempdir().expect("failed to create workdir");
     fs::write(work.path().join("archive.zip"), "").unwrap();
@@ -250,7 +263,8 @@ fn style_class_overrides_exa_default() {
 #[test]
 fn style_quoted_pattern_and_class() {
     // A style can mix class references and quoted file patterns.
-    let (_dir, mut cmd) = lx_with_theme(r#"
+    let (_dir, mut cmd) = lx_with_theme(
+        r#"
         version = "0.3"
 
         [class]
@@ -263,7 +277,8 @@ fn style_quoted_pattern_and_class() {
         [style.mixed]
         class.data = "bold green"
         "Makefile" = "bold red"
-    "#);
+    "#,
+    );
 
     let work = tempdir().expect("failed to create workdir");
     fs::write(work.path().join("results.csv"), "").unwrap();
@@ -274,14 +289,15 @@ fn style_quoted_pattern_and_class() {
         .arg(work.path())
         .assert()
         .success()
-        .stdout(predicate::str::contains("\x1b[1;32m"))   // bold green
-        .stdout(predicate::str::contains("\x1b[1;31m"));   // bold red
+        .stdout(predicate::str::contains("\x1b[1;32m")) // bold green
+        .stdout(predicate::str::contains("\x1b[1;31m")); // bold red
 }
 
 #[test]
 fn user_class_overrides_compiled_in() {
     // A user-defined [class] entry overrides the compiled-in one.
-    let (_dir, mut cmd) = lx_with_theme(r#"
+    let (_dir, mut cmd) = lx_with_theme(
+        r#"
         version = "0.3"
 
         [class]
@@ -290,7 +306,8 @@ fn user_class_overrides_compiled_in() {
         [theme.test]
         inherits = "exa"
         use-style = "exa"
-    "#);
+    "#,
+    );
 
     let work = tempdir().expect("failed to create workdir");
     fs::write(work.path().join("data.myarc"), "").unwrap();
@@ -305,19 +322,20 @@ fn user_class_overrides_compiled_in() {
         .stdout(predicate::str::contains("\x1b[31m"));
 }
 
-
 // ── Theme inheritance ────────────────────────────────────────────
 
 #[test]
 fn theme_inherits_exa() {
     // A theme inheriting from "exa" should get the compiled-in
     // defaults, then override specific keys.
-    let (_dir, mut cmd) = lx_with_theme(r#"
+    let (_dir, mut cmd) = lx_with_theme(
+        r#"
         version = "0.3"
         [theme.custom]
         inherits = "exa"
         date = "bold red"
-    "#);
+    "#,
+    );
 
     // date is bold red (overridden), but directory should still be
     // bold blue (inherited from exa).
@@ -334,11 +352,13 @@ fn theme_inherits_exa() {
 fn theme_without_inherits_is_blank() {
     // A theme without inherits starts from plain — only its own
     // keys apply.
-    let (_dir, mut cmd) = lx_with_theme(r#"
+    let (_dir, mut cmd) = lx_with_theme(
+        r#"
         version = "0.3"
         [theme.bare]
         date = "bold red"
-    "#);
+    "#,
+    );
 
     // date is bold red, but directory should NOT be bold blue
     // (no exa defaults).
@@ -352,7 +372,8 @@ fn theme_without_inherits_is_blank() {
 
 #[test]
 fn theme_inherits_custom() {
-    let (_dir, mut cmd) = lx_with_theme(r#"
+    let (_dir, mut cmd) = lx_with_theme(
+        r#"
         version = "0.3"
         [theme.base]
         inherits = "exa"
@@ -361,26 +382,29 @@ fn theme_inherits_custom() {
         [theme.child]
         inherits = "base"
         directory = "bold red"
-    "#);
+    "#,
+    );
 
     // child: directory=bold red, date=bold cyan (from base),
     // everything else from exa.
     cmd.args(["--theme=child", "-l", "src"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("\x1b[1;31m"))   // bold red dir
-        .stdout(predicate::str::contains("\x1b[1;36m"));   // bold cyan date
+        .stdout(predicate::str::contains("\x1b[1;31m")) // bold red dir
+        .stdout(predicate::str::contains("\x1b[1;36m")); // bold cyan date
 }
 
 #[test]
 fn theme_inheritance_cycle_detected() {
-    let (_dir, mut cmd) = lx_with_theme(r#"
+    let (_dir, mut cmd) = lx_with_theme(
+        r#"
         version = "0.3"
         [theme.a]
         inherits = "b"
         [theme.b]
         inherits = "a"
-    "#);
+    "#,
+    );
 
     // 0.9: cycles are fatal (was: warn + continue).  A cycle in user
     // config is unambiguously broken, so silently dropping it hides
@@ -391,7 +415,6 @@ fn theme_inheritance_cycle_detected() {
         .code(3)
         .stderr(predicate::str::contains("theme inheritance cycle"));
 }
-
 
 // ── No theme is fine ─────────────────────────────────────────────
 
@@ -411,10 +434,10 @@ fn no_theme_works() {
 fn lx_clean() -> assert_cmd::Command {
     let mut cmd = assert_cmd::Command::cargo_bin("lx").expect("binary lx not found");
     cmd.env("LX_CONFIG", "/nonexistent")
-       .env("HOME", "/nonexistent")
-       .env_remove("LS_COLORS")
-       .env_remove("TERM")
-       .env_remove("COLORTERM");
+        .env("HOME", "/nonexistent")
+        .env_remove("LS_COLORS")
+        .env_remove("TERM")
+        .env_remove("COLORTERM");
     cmd
 }
 
@@ -424,39 +447,39 @@ fn default_theme_produces_colour() {
     // TERM/COLORTERM (auto-selection would pick lx-256 or lx-24bit).
     // Bold blue (1;34) for directories is the exa default.
     lx_clean()
-       .arg("--colour=always")
-       .arg("--theme=exa")
-       .args(["-l", "src"])
-       .assert()
-       .success()
-       .stdout(predicate::str::contains("\x1b[1;34m"))  // bold blue dir
-       .stdout(predicate::str::contains("\x1b[34m"));   // blue date
+        .arg("--colour=always")
+        .arg("--theme=exa")
+        .args(["-l", "src"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\x1b[1;34m")) // bold blue dir
+        .stdout(predicate::str::contains("\x1b[34m")); // blue date
 }
 
 #[test]
 fn lx_256_theme_produces_256_colour() {
     // The lx-256 theme uses Fixed(33) bold for directories.
     lx_clean()
-       .arg("--colour=always")
-       .arg("--theme=lx-256")
-       .args(["-l", "src"])
-       .assert()
-       .success()
-       // Bold soft blue directory (Fixed 33): "1;38;5;33"
-       .stdout(predicate::str::contains("\x1b[1;38;5;33m"));
+        .arg("--colour=always")
+        .arg("--theme=lx-256")
+        .args(["-l", "src"])
+        .assert()
+        .success()
+        // Bold soft blue directory (Fixed 33): "1;38;5;33"
+        .stdout(predicate::str::contains("\x1b[1;38;5;33m"));
 }
 
 #[test]
 fn lx_24bit_theme_produces_truecolour() {
     // The lx-24bit theme uses #3b8ed8 bold for directories.
     lx_clean()
-       .arg("--colour=always")
-       .arg("--theme=lx-24bit")
-       .args(["-l", "src"])
-       .assert()
-       .success()
-       // Bold #3b8ed8 directory: "1;38;2;59;142;216"
-       .stdout(predicate::str::contains("\x1b[1;38;2;59;142;216m"));
+        .arg("--colour=always")
+        .arg("--theme=lx-24bit")
+        .args(["-l", "src"])
+        .assert()
+        .success()
+        // Bold #3b8ed8 directory: "1;38;2;59;142;216"
+        .stdout(predicate::str::contains("\x1b[1;38;2;59;142;216m"));
 }
 
 #[test]
@@ -465,23 +488,23 @@ fn auto_selection_picks_exa_with_no_term() {
     // blocks in the default personality don't fire.  Should
     // get the bare-bones exa theme.
     lx_clean()
-       .arg("--colour=always")
-       .args(["-l", "src"])
-       .assert()
-       .success()
-       .stdout(predicate::str::contains("\x1b[1;34m"));  // exa bold blue
+        .arg("--colour=always")
+        .args(["-l", "src"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\x1b[1;34m")); // exa bold blue
 }
 
 #[test]
 fn auto_selection_picks_lx_256_for_256color_term() {
     // TERM=xterm-256color → matches "*-256color" → lx-256.
     lx_clean()
-       .env("TERM", "xterm-256color")
-       .arg("--colour=always")
-       .args(["-l", "src"])
-       .assert()
-       .success()
-       .stdout(predicate::str::contains("\x1b[1;38;5;33m"));  // lx-256 dir
+        .env("TERM", "xterm-256color")
+        .arg("--colour=always")
+        .args(["-l", "src"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\x1b[1;38;5;33m")); // lx-256 dir
 }
 
 #[test]
@@ -489,25 +512,25 @@ fn auto_selection_picks_lx_24bit_for_truecolor_colorterm() {
     // COLORTERM=truecolor → matches the array → lx-24bit.
     // Truecolour wins over 256-colour even if both apply.
     lx_clean()
-       .env("TERM", "xterm-256color")
-       .env("COLORTERM", "truecolor")
-       .arg("--colour=always")
-       .args(["-l", "src"])
-       .assert()
-       .success()
-       .stdout(predicate::str::contains("\x1b[1;38;2;59;142;216m"));  // lx-24bit dir
+        .env("TERM", "xterm-256color")
+        .env("COLORTERM", "truecolor")
+        .arg("--colour=always")
+        .args(["-l", "src"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\x1b[1;38;2;59;142;216m")); // lx-24bit dir
 }
 
 #[test]
 fn auto_selection_accepts_24bit_colorterm_value() {
     // COLORTERM=24bit also valid.
     lx_clean()
-       .env("COLORTERM", "24bit")
-       .arg("--colour=always")
-       .args(["-l", "src"])
-       .assert()
-       .success()
-       .stdout(predicate::str::contains("\x1b[1;38;2;59;142;216m"));
+        .env("COLORTERM", "24bit")
+        .arg("--colour=always")
+        .args(["-l", "src"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\x1b[1;38;2;59;142;216m"));
 }
 
 #[test]
@@ -515,9 +538,9 @@ fn default_theme_colours_filetypes() {
     // The compiled-in exa style should colour compressed files red.
     let mut cmd = assert_cmd::Command::cargo_bin("lx").expect("binary lx not found");
     cmd.env("LX_CONFIG", "/nonexistent")
-       .env("HOME", "/nonexistent")
-       .env_remove("LS_COLORS")
-       .arg("--colour=always");
+        .env("HOME", "/nonexistent")
+        .env_remove("LS_COLORS")
+        .arg("--colour=always");
 
     let work = tempdir().expect("failed to create workdir");
     fs::write(work.path().join("archive.zip"), "").unwrap();
@@ -551,9 +574,9 @@ fn init_config_preserves_default_colours() {
     // Common args / env for both runs.
     fn common(cmd: &mut assert_cmd::Command, dir: &std::path::Path) {
         cmd.env("HOME", dir)
-           .env_remove("LS_COLORS")
-           .arg("--colour=always")
-           .args(["-l", "src"]);
+            .env_remove("LS_COLORS")
+            .arg("--colour=always")
+            .args(["-l", "src"]);
     }
 
     // Run without config.
@@ -574,7 +597,6 @@ fn init_config_preserves_default_colours() {
     );
 }
 
-
 // ── Per-timestamp-column theme keys ──────────────────────────────
 
 /// The 32 per-timestamp-column theme keys (4 columns × 8 slots)
@@ -583,7 +605,8 @@ fn init_config_preserves_default_colours() {
 /// arms, key-name drift, and regressions in the dump output.
 #[test]
 fn per_column_date_keys_round_trip_through_dump_theme() {
-    let (_dir, mut cmd) = lx_with_theme(r#"
+    let (_dir, mut cmd) = lx_with_theme(
+        r#"
         version = "0.3"
         [theme.full-fat]
         inherits = "exa"
@@ -594,12 +617,10 @@ fn per_column_date_keys_round_trip_through_dump_theme() {
         date-accessed-today = "magenta"
         date-changed-flat = "dim"
         date-created-old  = "red"
-    "#);
+    "#,
+    );
 
-    let assertion = cmd
-        .args(["--dump-theme=full-fat"])
-        .assert()
-        .success();
+    let assertion = cmd.args(["--dump-theme=full-fat"]).assert().success();
     let dump = String::from_utf8(assertion.get_output().stdout.clone()).unwrap();
 
     // Every key written to the theme must appear in the dump.
@@ -629,7 +650,8 @@ fn per_column_date_keys_round_trip_through_dump_theme() {
 /// fall.
 #[test]
 fn dump_theme_groups_date_keys_by_column() {
-    let (_dir, mut cmd) = lx_with_theme(r#"
+    let (_dir, mut cmd) = lx_with_theme(
+        r#"
         version = "0.3"
         [theme.grouped]
         inherits = "exa"
@@ -641,17 +663,16 @@ fn dump_theme_groups_date_keys_by_column() {
         date-accessed-flat = "green"
         date-today         = "magenta"
         date-changed-now   = "orange"
-    "#);
+    "#,
+    );
 
-    let assertion = cmd
-        .args(["--dump-theme=grouped"])
-        .assert()
-        .success();
+    let assertion = cmd.args(["--dump-theme=grouped"]).assert().success();
     let dump = String::from_utf8(assertion.get_output().stdout.clone()).unwrap();
 
     // Strip the header lines and the [theme.grouped]/inherits/use-style
     // preamble so we can assert on the body alone.
-    let body: Vec<&str> = dump.lines()
+    let body: Vec<&str> = dump
+        .lines()
         .skip_while(|l| !l.starts_with("date") && !l.starts_with("directory"))
         .collect();
 
@@ -680,7 +701,6 @@ fn dump_theme_groups_date_keys_by_column() {
     );
 }
 
-
 /// Spot-check the rendered-output side: running `lx -lll --theme=X`
 /// with per-column overrides produces an output whose ANSI escapes
 /// contain the expected per-column colours.  This exercises the
@@ -693,7 +713,8 @@ fn per_column_gradient_tokens_reach_the_renderer() {
     let file = work.path().join("fresh.txt");
     fs::write(&file, "hi").unwrap();
 
-    let (_dir, mut cmd) = lx_with_theme(r#"
+    let (_dir, mut cmd) = lx_with_theme(
+        r#"
         version = "0.3"
         [theme.rainbow]
         inherits = "exa"
@@ -701,7 +722,8 @@ fn per_column_gradient_tokens_reach_the_renderer() {
         date-accessed-now = "green"
         date-changed-now  = "blue"
         date-created-now  = "magenta"
-    "#);
+    "#,
+    );
 
     // `-lll` shows all four timestamp columns.
     let assertion = cmd
@@ -719,9 +741,9 @@ fn per_column_gradient_tokens_reach_the_renderer() {
     //   blue    → ESC[34m
     //   magenta → ESC[35m
     for (colour, code) in [
-        ("red",     "\x1b[31m"),
-        ("green",   "\x1b[32m"),
-        ("blue",    "\x1b[34m"),
+        ("red", "\x1b[31m"),
+        ("green", "\x1b[32m"),
+        ("blue", "\x1b[34m"),
         ("magenta", "\x1b[35m"),
     ] {
         assert!(
@@ -740,16 +762,22 @@ fn new_gradient_tokens_are_accepted() {
     let work = tempdir().expect("failed to create workdir");
     fs::write(work.path().join("file.txt"), "hi").unwrap();
 
-    for tok in ["modified", "accessed", "changed", "created",
-                "size,modified", "accessed,created"] {
+    for tok in [
+        "modified",
+        "accessed",
+        "changed",
+        "created",
+        "size,modified",
+        "accessed,created",
+    ] {
         let mut cmd = assert_cmd::Command::cargo_bin("lx").expect("binary lx not found");
         cmd.env("LX_CONFIG", "/nonexistent")
-           .env("HOME", "/nonexistent")
-           .env_remove("LS_COLORS")
-           .args(["-lll", "--colour=always", &format!("--gradient={tok}")])
-           .arg(work.path())
-           .assert()
-           .success();
+            .env("HOME", "/nonexistent")
+            .env_remove("LS_COLORS")
+            .args(["-lll", "--colour=always", &format!("--gradient={tok}")])
+            .arg(work.path())
+            .assert()
+            .success();
     }
 }
 
@@ -763,23 +791,28 @@ fn hidden_gradient_aliases_match_canonical() {
     let run = |value: &str| -> Vec<u8> {
         let mut cmd = assert_cmd::Command::cargo_bin("lx").expect("binary lx not found");
         cmd.env("LX_CONFIG", "/nonexistent")
-           .env("HOME", "/nonexistent")
-           .env_remove("LS_COLORS")
-           .args(["-l", "--colour=always", &format!("--gradient={value}")])
-           .arg(work.path())
-           .assert()
-           .success()
-           .get_output()
-           .stdout
-           .clone()
+            .env("HOME", "/nonexistent")
+            .env_remove("LS_COLORS")
+            .args(["-l", "--colour=always", &format!("--gradient={value}")])
+            .arg(work.path())
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone()
     };
 
-    assert_eq!(run("size"), run("filesize"),
-        "--gradient=filesize should match --gradient=size");
-    assert_eq!(run("date"), run("timestamp"),
-        "--gradient=timestamp should match --gradient=date");
+    assert_eq!(
+        run("size"),
+        run("filesize"),
+        "--gradient=filesize should match --gradient=size"
+    );
+    assert_eq!(
+        run("date"),
+        run("timestamp"),
+        "--gradient=timestamp should match --gradient=date"
+    );
 }
-
 
 // ── --smooth ─────────────────────────────────────────────────────
 
@@ -799,11 +832,11 @@ fn run_with_varied_mtimes(theme: &str, extra_args: &[&str]) -> Vec<u8> {
     // anchors so smooth mode lands in between buckets rather
     // than on the same bucket as the discrete tier lookup.
     let fixtures = [
-        ("a_half_hour",  Duration::from_secs(1800)),           // between now and today
-        ("a_half_day",   Duration::from_secs(43_200)),         // between today and week
-        ("three_days",   Duration::from_secs(3 * 86_400)),     // between week and month
-        ("two_weeks",    Duration::from_secs(14 * 86_400)),    // between month and year
-        ("three_months", Duration::from_secs(90 * 86_400)),    // between year and old
+        ("a_half_hour", Duration::from_secs(1800)), // between now and today
+        ("a_half_day", Duration::from_secs(43_200)), // between today and week
+        ("three_days", Duration::from_secs(3 * 86_400)), // between week and month
+        ("two_weeks", Duration::from_secs(14 * 86_400)), // between month and year
+        ("three_months", Duration::from_secs(90 * 86_400)), // between year and old
     ];
     for (name, age) in fixtures {
         let path = work.path().join(name);
@@ -819,22 +852,22 @@ fn run_with_varied_mtimes(theme: &str, extra_args: &[&str]) -> Vec<u8> {
 
     let mut cmd = assert_cmd::Command::cargo_bin("lx").expect("binary lx not found");
     cmd.env("LX_CONFIG", "/nonexistent")
-       .env("HOME", "/nonexistent")
-       .env_remove("LS_COLORS")
-       .args(["-l", "--colour=always", &format!("--theme={theme}")])
-       .args(extra_args)
-       .arg(work.path())
-       .assert()
-       .success()
-       .get_output()
-       .stdout
-       .clone()
+        .env("HOME", "/nonexistent")
+        .env_remove("LS_COLORS")
+        .args(["-l", "--colour=always", &format!("--theme={theme}")])
+        .args(extra_args)
+        .arg(work.path())
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone()
 }
 
 #[test]
 fn smooth_changes_24bit_output() {
     let discrete = run_with_varied_mtimes("lx-24bit", &[]);
-    let smooth   = run_with_varied_mtimes("lx-24bit", &["--smooth"]);
+    let smooth = run_with_varied_mtimes("lx-24bit", &["--smooth"]);
     assert_ne!(
         discrete, smooth,
         "--smooth should change lx-24bit output (interpolating between anchors)",
@@ -847,7 +880,7 @@ fn smooth_is_noop_on_256_palette_theme() {
     // returns false, so the LUT is never built and the output
     // must match the discrete render byte-for-byte.
     let discrete = run_with_varied_mtimes("lx-256", &[]);
-    let smooth   = run_with_varied_mtimes("lx-256", &["--smooth"]);
+    let smooth = run_with_varied_mtimes("lx-256", &["--smooth"]);
     assert_eq!(
         discrete, smooth,
         "--smooth should be a no-op on lx-256 (palette anchors gate it out)",
@@ -858,7 +891,7 @@ fn smooth_is_noop_on_256_palette_theme() {
 fn smooth_is_noop_on_ansi_exa_theme() {
     // The builtin exa theme uses basic ANSI colours; same gate.
     let discrete = run_with_varied_mtimes("exa", &[]);
-    let smooth   = run_with_varied_mtimes("exa", &["--smooth"]);
+    let smooth = run_with_varied_mtimes("exa", &["--smooth"]);
     assert_eq!(
         discrete, smooth,
         "--smooth should be a no-op on the exa theme (basic ANSI anchors)",
@@ -871,7 +904,7 @@ fn smooth_with_no_gradient_is_harmless() {
     // colour, so there's nothing to smooth.  --smooth on top of
     // that must not error and must not differ from --no-gradient
     // alone.
-    let flat        = run_with_varied_mtimes("lx-24bit", &["--no-gradient"]);
+    let flat = run_with_varied_mtimes("lx-24bit", &["--no-gradient"]);
     let flat_smooth = run_with_varied_mtimes("lx-24bit", &["--no-gradient", "--smooth"]);
     assert_eq!(
         flat, flat_smooth,
@@ -887,12 +920,16 @@ fn no_smooth_suppresses_personality_smooth() {
     // no CLI override is given, then drop out under --no-smooth.
     let dir = tempdir().expect("failed to create tempdir");
     let config_path = dir.path().join("config.toml");
-    fs::write(&config_path, r#"
+    fs::write(
+        &config_path,
+        r#"
         version = "0.5"
         [personality.lx]
         theme = "lx-24bit"
         smooth = true
-    "#).unwrap();
+    "#,
+    )
+    .unwrap();
 
     let run = |extra: &[&str]| -> Vec<u8> {
         use std::time::{Duration, SystemTime};
@@ -903,24 +940,29 @@ fn no_smooth_suppresses_personality_smooth() {
         // Land strictly between anchors so smooth ≠ discrete.
         let t = std::fs::FileTimes::new()
             .set_modified(SystemTime::now() - Duration::from_secs(3 * 86_400));
-        fs::File::options().write(true).open(&path).unwrap().set_times(t).unwrap();
+        fs::File::options()
+            .write(true)
+            .open(&path)
+            .unwrap()
+            .set_times(t)
+            .unwrap();
 
         let mut cmd = assert_cmd::Command::cargo_bin("lx").expect("binary lx not found");
         cmd.env("LX_CONFIG", &config_path)
-           .env("HOME", "/nonexistent")
-           .env_remove("LS_COLORS")
-           .args(["-l", "--colour=always"])
-           .args(extra)
-           .arg(work.path())
-           .assert()
-           .success()
-           .get_output()
-           .stdout
-           .clone()
+            .env("HOME", "/nonexistent")
+            .env_remove("LS_COLORS")
+            .args(["-l", "--colour=always"])
+            .args(extra)
+            .arg(work.path())
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone()
     };
 
-    let with_personality  = run(&[]);               // smooth on (via personality)
-    let forced_off        = run(&["--no-smooth"]);  // smooth off (CLI wins)
+    let with_personality = run(&[]); // smooth on (via personality)
+    let forced_off = run(&["--no-smooth"]); // smooth off (CLI wins)
     assert_ne!(
         with_personality, forced_off,
         "--no-smooth should override a personality that enables smooth",

--- a/tests/cli_time.rs
+++ b/tests/cli_time.rs
@@ -2,11 +2,10 @@
 
 mod support;
 
-use std::fs;
 use predicates::prelude::*;
+use std::fs;
 use support::lx_no_colour;
 use tempfile::tempdir;
-
 
 #[test]
 fn time_style_default() {
@@ -65,7 +64,6 @@ fn time_style_flag_overrides_env() {
         .success()
         .stdout(predicate::str::contains("Cargo.toml"));
 }
-
 
 // ── Timestamp field selection ─────────────────────────────────────
 
@@ -139,7 +137,11 @@ fn no_time_suppresses_date() {
         .arg(dir.path().join("file.txt"))
         .assert()
         .success()
-        .stdout(predicate::str::is_match(r"\d{4}-\d{2}-\d{2}").unwrap().not());
+        .stdout(
+            predicate::str::is_match(r"\d{4}-\d{2}-\d{2}")
+                .unwrap()
+                .not(),
+        );
 }
 
 #[test]

--- a/tests/cli_total_size.rs
+++ b/tests/cli_total_size.rs
@@ -2,19 +2,18 @@
 
 mod support;
 
-use std::fs;
 use predicates::prelude::*;
+use std::fs;
 use support::lx_no_colour;
 use tempfile::tempdir;
-
 
 #[test]
 fn total_size_shows_for_directories() {
     let dir = tempdir().expect("failed to create tempdir");
     let sub = dir.path().join("subdir");
     fs::create_dir(&sub).unwrap();
-    fs::write(sub.join("file1.txt"), "hello").unwrap();      // 5 bytes
-    fs::write(sub.join("file2.txt"), "world!!!").unwrap();    // 8 bytes
+    fs::write(sub.join("file1.txt"), "hello").unwrap(); // 5 bytes
+    fs::write(sub.join("file2.txt"), "world!!!").unwrap(); // 8 bytes
 
     lx_no_colour()
         .args(["-l", "--total-size"])
@@ -106,8 +105,7 @@ fn stree_style() {
     fs::write(b.join("small.txt"), "hi").unwrap();
 
     lx_no_colour()
-        .args(["-DT", "-L1", "--columns=size",
-               "-rs", "size", "-Z"])
+        .args(["-DT", "-L1", "--columns=size", "-rs", "size", "-Z"])
         .arg(dir.path())
         .assert()
         .success()

--- a/tests/cli_vcs.rs
+++ b/tests/cli_vcs.rs
@@ -6,12 +6,11 @@
 
 mod support;
 
+use predicates::prelude::*;
 use std::fs;
 use std::process::Command as StdCommand;
-use predicates::prelude::*;
 use support::{lx, lx_no_colour};
 use tempfile::tempdir;
-
 
 /// Create a temporary git repo with a tracked file and an untracked file.
 fn git_fixture() -> tempfile::TempDir {
@@ -79,13 +78,11 @@ fn jj_feature_enabled() -> bool {
     !stderr.contains("disabled")
 }
 
-
 // ── --vcs flag validation ─────────────────────────────────────────
 
 #[test]
 fn vcs_invalid_value() {
-    lx()
-        .arg("--vcs=svn")
+    lx().arg("--vcs=svn")
         .assert()
         .failure()
         .stderr(predicate::str::contains("invalid value"));
@@ -105,7 +102,6 @@ fn vcs_none_disables_status() {
         .stdout(predicate::str::contains(" M ").not())
         .stdout(predicate::str::contains(" N ").not());
 }
-
 
 // ── Git backend ───────────────────────────────────────────────────
 
@@ -169,9 +165,6 @@ fn git_vcs_ignore_hides_ignored_files() {
         .stdout(predicate::str::contains("tracked.txt"));
 }
 
-
-
-
 // ── --vcs-status without --long (silently ignored) ────────────────
 
 #[test]
@@ -181,7 +174,6 @@ fn vcs_status_without_long_is_fine() {
         .assert()
         .success();
 }
-
 
 // ── jj backend (only runs if jj is installed) ─────────────────────
 
@@ -234,7 +226,6 @@ fn jj_auto_detection() {
         .success()
         .stdout(predicate::str::contains("MM").not());
 }
-
 
 // ── --vcs=auto fallback to git ────────────────────────────────────
 

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -6,7 +6,7 @@ use assert_cmd::Command;
 pub fn lx() -> Command {
     let mut cmd = Command::cargo_bin("lx").expect("binary lx not found");
     cmd.env("LX_CONFIG", "/nonexistent")
-       .env("HOME", "/nonexistent");
+        .env("HOME", "/nonexistent");
     cmd
 }
 


### PR DESCRIPTION
Replace `disable_all_formatting = true` with `edition = "2024"` in `.rustfmt.toml` and format the entire codebase.

Hand-formatted alignment blocks are preserved with `#[rustfmt::skip]`:

- `config/settings.rs` SETTING_FLAGS table (one-line-per-entry data table)
- `theme/default_theme.rs` compiled-in theme functions (aligned struct initialisers for visual scanning)
- `theme/ui_styles.rs` UiStyles, Permissions, DateAge struct definitions and DateAge::for_age (aligned fields and if-else chains)

The `after_help` multi-line string in `options/parser.rs` is rewritten with `concat!()` for rustfmt-proof readability.

Closes wjv/lx#11.