### PR TITLE
Updates display of long view format in `--show-config`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ All notable changes to lx are documented here. lx is forked from
   the full inheritance chain (leaf to root) with source annotations
   (builtin/config/override), `[[when]]` block counts and active
   status, and resolved format columns.  Fixes wjv/lx#21.
+- **`--show-config` gains a top-level `Format:` section.**  Shows
+  the active long-view format, its source (`personality` or
+  `implicit, selected by -lll`), and the resolved column list.
+  Appears whenever a long format is in effect — declared by the
+  personality chain or implied by `-l`/`-ll`/`-lll`.  The
+  Personality section now lists the format name only when the
+  chain declares one, keeping the two cases visually distinct.
+  Fixes wjv/lx#25.
 - **`--dump-theme` works for compiled-in themes** (`exa`,
   `lx-256`, `lx-24bit`).  Output is real, copy-pasteable TOML
   produced by walking the new theme key registry.  Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2091,7 +2091,7 @@ dependencies = [
 
 [[package]]
 name = "lx-ls"
-version = "0.10.0-pre.15"
+version = "0.10.0-pre.16"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ rust-version = "1.94"
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/wjv/lx"
-version = "0.10.0-pre.15"
+version = "0.10.0-pre.16"
 
 [[bin]]
 name = "lx"

--- a/src/config/show.rs
+++ b/src/config/show.rs
@@ -39,7 +39,12 @@ impl Styles {
 ///
 /// Shows the resolved personality, format, theme, style, and classes,
 /// indicating for each whether it's compiled-in or from the config file.
-pub fn show_config(personality_name: &str, activated_by: &str, cli_theme_override: Option<&str>) {
+pub fn show_config(
+    personality_name: &str,
+    activated_by: &str,
+    cli_theme_override: Option<&str>,
+    implicit_format: Option<&str>,
+) {
     let s = Styles::new();
     let config_path = find_config_path();
     let cfg = config();
@@ -49,6 +54,7 @@ pub fn show_config(personality_name: &str, activated_by: &str, cli_theme_overrid
 
     show_config_file(&s, config_path.as_ref(), cfg);
     let theme_name = show_personality(&s, personality_name, activated_by, cli_theme_override, cfg);
+    show_format(&s, personality_name, implicit_format);
     let style_name = show_theme(&s, theme_name.as_deref(), cfg);
     show_style(&s, style_name.as_deref(), cfg);
     show_classes(&s, cfg);
@@ -153,18 +159,11 @@ fn show_personality(
     }
 
     let p = &resolved.def;
+    // Format declared directly by the personality chain.  Implicit
+    // `-l` tier and the column resolution live in their own
+    // top-level Format section — see `show_format`.
     if let Some(ref fmt) = p.format {
-        println!("  {}", s.label.paint("format:"));
-        let formats = super::formats::resolve_formats();
-        if let Some(cols) = formats.get(fmt.as_str()) {
-            println!(
-                "    {} {}",
-                s.name.paint(fmt),
-                s.dimmed.paint(format!("({})", cols.join(", "))),
-            );
-        } else {
-            println!("    {}", s.name.paint(fmt));
-        }
+        println!("  {} {}", s.label.paint("format:"), s.name.paint(fmt));
     }
     if let Some(ref cols) = p.columns {
         println!(
@@ -197,6 +196,59 @@ fn show_personality(
             }
         })
     })
+}
+
+// ── Format section ─────────────────────────────────────────────
+
+/// Show the active long-view format, if any.
+///
+/// The format may come from one of two sources:
+/// - a `format = "..."` declaration anywhere in the personality
+///   chain
+/// - the implicit `-l`/`-ll`/`-lll` tier when the user invoked
+///   `--show-config` alongside `-l` and no personality declared a
+///   format (or columns)
+///
+/// When neither applies (e.g. a grid-view default invocation),
+/// the section is omitted entirely.  The personality may still
+/// declare `columns` directly — that's surfaced under the
+/// Personality section, not here.
+fn show_format(s: &Styles, personality_name: &str, implicit_format: Option<&str>) {
+    let resolved = resolve_personality_full(personality_name).ok().flatten();
+    let p = resolved.as_ref().map(|r| &r.def);
+
+    // Skip if the personality declares `columns` directly — there
+    // is no named format to display, and the columns already
+    // appear under Personality.
+    if p.is_some_and(|p| p.columns.is_some() && p.format.is_none()) {
+        return;
+    }
+
+    let (fmt_name, source) = match p.and_then(|p| p.format.as_deref()) {
+        Some(name) => (name, "personality".to_string()),
+        None => match implicit_format {
+            Some(name) => {
+                let flag = match name {
+                    "long" => "-l",
+                    "long2" => "-ll",
+                    "long3" => "-lll",
+                    _ => "-l",
+                };
+                (name, format!("implicit, selected by {flag}"))
+            }
+            None => return,
+        },
+    };
+
+    let formats = super::formats::resolve_formats();
+    let columns = formats.get(fmt_name).map(|cols| cols.join(", "));
+
+    println!("{} {}", s.label.paint("Format:"), s.name.paint(fmt_name));
+    println!("  {} {}", s.label.paint("source:"), s.dimmed.paint(&source));
+    if let Some(cols) = columns {
+        println!("  {} {}", s.label.paint("columns:"), s.value.paint(cols));
+    }
+    println!();
 }
 
 // ── Theme section ──────────────────────────────────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -375,10 +375,17 @@ fn try_main() -> Result<i32, LxError> {
             eprintln!("Wrote default config to {}", path.display());
         }
 
-        OptionsResult::ShowConfig => {
+        OptionsResult::ShowConfig {
+            ref implicit_format,
+        } => {
             let name = active_personality.as_deref().unwrap_or("lx");
             let cli_theme = find_theme_arg(&cli_args);
-            config::show_config(name, personality_source, cli_theme.as_deref());
+            config::show_config(
+                name,
+                personality_source,
+                cli_theme.as_deref(),
+                implicit_format.as_deref(),
+            );
         }
 
         OptionsResult::SaveAs(ref name, _, _) => {

--- a/src/options/mod.rs
+++ b/src/options/mod.rs
@@ -105,7 +105,31 @@ impl Options {
                 }
 
                 if clap_matches.get_flag("show-config") {
-                    return OptionsResult::ShowConfig;
+                    // Detect the implicit `-l` tier so `--show-config`
+                    // can show the effective format when no personality
+                    // declares one.  An explicit `--columns` or
+                    // `--format` overrides the tier in `deduce_columns`,
+                    // so we suppress the hint when either is present.
+                    let long_count = clap_matches.get_count("long");
+                    let has_columns = clap_matches
+                        .value_source(flags::COLUMNS)
+                        .is_some_and(|src| src == clap::parser::ValueSource::CommandLine);
+                    let has_format = clap_matches
+                        .value_source(flags::FORMAT)
+                        .is_some_and(|src| src == clap::parser::ValueSource::CommandLine);
+                    let implicit_format = if long_count > 0 && !has_columns && !has_format {
+                        Some(
+                            match long_count {
+                                1 => "long",
+                                2 => "long2",
+                                _ => "long3",
+                            }
+                            .to_string(),
+                        )
+                    } else {
+                        None
+                    };
+                    return OptionsResult::ShowConfig { implicit_format };
                 }
 
                 if clap_matches.contains_id("dump-class")
@@ -413,7 +437,14 @@ pub enum OptionsResult {
     Completions(clap_complete::Shell),
 
     /// The user wants to see the active configuration.
-    ShowConfig,
+    ///
+    /// `implicit_format` carries the `-l` tier name (`"long"`,
+    /// `"long2"`, `"long3"`) when the user invoked `--show-config`
+    /// alongside `-l` and neither `--columns` nor `--format` would
+    /// override it.  `--show-config` displays this as the effective
+    /// format when the active personality declares neither
+    /// `format` nor `columns`.
+    ShowConfig { implicit_format: Option<String> },
 
     /// The user wants to see class definitions as TOML.
     /// Empty string means all classes; otherwise a specific class name.

--- a/tests/cli_config.rs
+++ b/tests/cli_config.rs
@@ -745,6 +745,64 @@ fn dump_personality_valid_toml() {
         .expect("--dump-personality output is not valid TOML");
 }
 
+// ── --show-config implicit format ────────────────────────────────
+
+// `--show-config` currently emits ANSI escapes regardless of
+// `--colour=never` (a pre-existing UX nit), so the assertions
+// below match around the escape sequences rather than against
+// fully-formed substrings.
+
+#[test]
+fn show_config_implicit_format_long_with_l() {
+    // No personality declares a format, but `-l` is on the
+    // command line — surface the implicit `long` tier in its
+    // own top-level Format section.
+    lx_no_colour()
+        .args(["-l", "--show-config"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Format:"))
+        .stdout(predicate::str::contains("implicit, selected by -l"))
+        .stdout(predicate::str::is_match(r"long\b").unwrap());
+}
+
+#[test]
+fn show_config_implicit_format_long3_with_lll() {
+    lx_no_colour()
+        .args(["-lll", "--show-config"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Format:"))
+        .stdout(predicate::str::contains("implicit, selected by -lll"))
+        .stdout(predicate::str::contains("long3"));
+}
+
+#[test]
+fn show_config_no_format_section_without_l() {
+    // Without `-l` and no personality-declared format, the
+    // top-level Format section is omitted entirely.  The
+    // "implicit, selected by" marker (specific to the Format
+    // section) must not appear.  Note that "(implicit)" is
+    // also used by the Theme section's `use-style` line, so
+    // we match the more specific source-line phrasing.
+    lx_no_colour()
+        .args(["--show-config"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("implicit, selected by").not());
+}
+
+#[test]
+fn show_config_explicit_columns_suppresses_implicit() {
+    // `--columns` overrides the tier in `deduce_columns`, so the
+    // implicit hint must not appear even with `-l`.
+    lx_no_colour()
+        .args(["-l", "--columns=size", "--show-config"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("implicit, selected by").not());
+}
+
 // ── --dump-theme ─────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
- Adds a top-level `Format:` section to `--show-config` that shows the active long-view format, its source, and the resolved column list. The section only appears when a long format is actually active.
- The Personality section now lists `format: NAME` only when the personality inheritance chain declares one.

Closes wjv/lx#25.