### PR TITLE
Add available-catalogue half to `--show-config`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,16 @@ All notable changes to lx are documented here. lx is forked from
   Personality section now lists the format name only when the
   chain declares one, keeping the two cases visually distinct.
   Fixes wjv/lx#25.
+- **`--show-config` gains an "available catalogue" half**, listing
+  every defined personality, format, theme, style, and class
+  with its source and a one-line summary (or `description` key
+  where defined).  The new `--show-config=MODE` selector
+  controls how much to show: `active` (default — just what's
+  running), `full` (active + catalogue, with a horizontal-rule
+  divider), or `available` (catalogue only).  Bare
+  `--show-config` keeps its previous compact behaviour; reach
+  for `=full` when you want the complete picture.  Fixes
+  wjv/lx#24.
 - **`--dump-theme` works for compiled-in themes** (`exa`,
   `lx-256`, `lx-24bit`).  Output is real, copy-pasteable TOML
   produced by walking the new theme key registry.  Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2091,7 +2091,7 @@ dependencies = [
 
 [[package]]
 name = "lx-ls"
-version = "0.10.0-pre.19"
+version = "0.10.0-pre.20"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ rust-version = "1.94"
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/wjv/lx"
-version = "0.10.0-pre.19"
+version = "0.10.0-pre.20"
 
 [[bin]]
 name = "lx"

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -1519,8 +1519,25 @@ Two families of flags help you inspect what `lx` is doing.
 
 ### `--show-config`
 
-Prints a human-friendly, coloured overview of the active
-configuration.  The personality section is the most detailed:
+Prints a human-friendly, coloured overview of the configuration.
+Output divides into two halves:
+
+- **Active** (default) — what's currently running: where the
+  config came from, the resolved personality with inheritance
+  chain, the active format, theme, and style.
+- **Available** — a catalogue of every defined personality,
+  format, theme, style, and class, each with its source and a
+  one-line summary or `description`.
+
+`--show-config[=MODE]` controls which halves to emit:
+
+| Form                       | Shows               |
+|----------------------------|---------------------|
+| `--show-config`            | Active half (default) |
+| `--show-config=full`       | Both, separated by a horizontal rule |
+| `--show-config=available`  | Catalogue only      |
+
+The personality section in the active half is the most detailed:
 
 ```
 Personality: la
@@ -1530,12 +1547,14 @@ Personality: la
     ll (builtin)
     lx (builtin)                    1 [[when]] block, 0 active
     default (builtin)               2 [[when]] blocks, 2 active
-  format:
-    long2 (perms, size, user, group, modified, vcs)
   settings:
     all = true
     classify = "never"
     ...
+
+Format: long2
+  source: personality
+  columns: perms, size, user, group, modified, vcs
 ```
 
 The **inheritance** list shows the full chain from the requested
@@ -1549,11 +1568,9 @@ personality down to its root ancestor.  Each entry shows:
   working as expected — if `0 active` appears where you expect a
   match, the environment variable condition isn't being met.
 
-The **format** line shows the active format name and the columns
+The **Format** section shows the active format name, its source
+(`personality` or `implicit, selected by -lll`), and the columns
 it resolves to.
-
-The remaining sections show the active theme, style, available
-classes, and available formats.
 
 ### `--dump-*`
 

--- a/man/lx.1
+++ b/man/lx.1
@@ -937,13 +937,16 @@ block syntax for environment-based personality overrides, and the
 complete theme/style/class vocabulary \(em see
 .Xr lxconfig.toml 5 .
 .Bl -tag -width Ds
-.It Fl -show-config
-Show a coloured summary of the active configuration and exit.
-Includes the personality inheritance chain with sources
-.Pq builtin vs config ,
-.Ql [[when]]
-block counts and match status, resolved format columns,
-theme, style, classes, and formats.
+.It Fl -show-config Ns Op = Ns Ar MODE
+Show a coloured summary of the configuration and exit.
+.Ar MODE
+selects how much to emit:
+.Cm active
+(default — what's running: personality chain, format, theme, style),
+.Cm full
+(active plus the available catalogue, separated by a horizontal rule), or
+.Cm available
+(catalogue only — every defined personality, format, theme, style, and class).
 .It Fl -init-config
 Generate a commented starter config file at
 .Pa ~/.lxconfig.toml .

--- a/src/config/personality.rs
+++ b/src/config/personality.rs
@@ -293,6 +293,20 @@ fn format_toml_kv(key: &str, value: &toml::Value) -> String {
 /// Names of all compiled-in personalities.
 const COMPILED_PERSONALITIES: &[&str] = &["default", "lx", "ll", "lll", "la", "tree", "ls"];
 
+/// True iff `name` is a compiled-in personality.  A user-defined
+/// personality with the same name shadows the compiled-in one but
+/// is still considered to "exist as a builtin" by this predicate.
+pub fn is_compiled_personality(name: &str) -> bool {
+    COMPILED_PERSONALITIES.contains(&name)
+}
+
+/// Look up a personality's `description` field, preferring the
+/// user's config when both shadow.  Returns `None` if the
+/// personality has no description (or no definition at all).
+pub fn personality_description(name: &str) -> Option<String> {
+    lookup_personality(name).and_then(|d| d.description)
+}
+
 /// Return the names of all known personalities (compiled-in + config).
 pub fn all_personality_names() -> Vec<String> {
     let mut names: Vec<String> = COMPILED_PERSONALITIES.iter().map(|s| (*s).into()).collect();

--- a/src/config/show.rs
+++ b/src/config/show.rs
@@ -40,11 +40,14 @@ impl Styles {
 /// Shows the resolved personality, format, theme, style, and classes,
 /// indicating for each whether it's compiled-in or from the config file.
 pub fn show_config(
+    mode: crate::options::ShowConfigMode,
     personality_name: &str,
     activated_by: &str,
     cli_theme_override: Option<&str>,
     implicit_format: Option<&str>,
 ) {
+    use crate::options::ShowConfigMode::{Active, Available, Full};
+
     let s = Styles::new();
     let config_path = find_config_path();
     let cfg = config();
@@ -52,13 +55,38 @@ pub fn show_config(
     println!("{}", s.heading.paint("lx configuration"));
     println!();
 
-    show_config_file(&s, config_path.as_ref(), cfg);
-    let theme_name = show_personality(&s, personality_name, activated_by, cli_theme_override, cfg);
-    show_format(&s, personality_name, implicit_format);
-    let style_name = show_theme(&s, theme_name.as_deref(), cfg);
-    show_style(&s, style_name.as_deref(), cfg);
-    show_classes(&s, cfg);
-    show_formats(&s, cfg);
+    // Active half: where config comes from + what's currently
+    // running.
+    if matches!(mode, Active | Full) {
+        show_config_file(&s, config_path.as_ref(), cfg);
+        let theme_name =
+            show_personality(&s, personality_name, activated_by, cli_theme_override, cfg);
+        show_format(&s, personality_name, implicit_format);
+        let style_name = show_theme(&s, theme_name.as_deref(), cfg);
+        show_style(&s, style_name.as_deref(), cfg);
+    }
+
+    // Divider only when both halves are present.
+    if matches!(mode, Full) {
+        show_divider(&s);
+    }
+
+    // Available half: catalogue of every defined personality,
+    // format, theme, style, and class.
+    if matches!(mode, Available | Full) {
+        show_available_personalities(&s, cfg);
+        show_formats(&s, cfg);
+        show_available_themes(&s, cfg);
+        show_available_styles(&s, cfg);
+        show_classes(&s, cfg);
+    }
+}
+
+/// Dimmed horizontal rule that separates the Active half (top)
+/// from the Available catalogue (bottom).
+fn show_divider(s: &Styles) {
+    println!("{}", s.dimmed.paint("─".repeat(64)));
+    println!();
 }
 
 // ── Config file section ────────────────────────────────────────
@@ -385,21 +413,173 @@ fn show_classes(s: &Styles, cfg: Option<&super::schema::Config>) {
 // ── Formats section ────────────────────────────────────────────
 
 fn show_formats(s: &Styles, cfg: Option<&super::schema::Config>) {
-    println!("{}", s.label.paint("Formats:"));
-    let compiled = vec!["long", "long2", "long3"];
-    for fname in &compiled {
-        let source = if cfg.is_some_and(|c| c.format.contains_key(*fname)) {
-            "config (overrides builtin)"
-        } else {
-            "builtin"
-        };
-        println!("  {}: {}", s.name.paint(*fname), s.dimmed.paint(source));
-    }
+    let formats = super::formats::resolve_formats();
+    let compiled = ["long", "long2", "long3"];
+
+    let mut names: Vec<String> = compiled.iter().map(|s| (*s).to_string()).collect();
     if let Some(cfg) = cfg {
         for fname in cfg.format.keys() {
-            if !compiled.contains(&fname.as_str()) {
-                println!("  {}: {}", s.name.paint(fname), s.dimmed.paint("config"));
+            if !names.iter().any(|n| n == fname) {
+                names.push(fname.clone());
             }
         }
     }
+    names.sort();
+
+    println!(
+        "{} {} defined",
+        s.label.paint("Formats:"),
+        s.value.paint(names.len().to_string())
+    );
+    for fname in &names {
+        let in_compiled = compiled.contains(&fname.as_str());
+        let in_config = cfg.is_some_and(|c| c.format.contains_key(fname));
+        let source = match (in_config, in_compiled) {
+            (true, true) => "config, overrides builtin",
+            (true, false) => "config",
+            (false, true) => "builtin",
+            (false, false) => "?",
+        };
+        let column_count = formats.get(fname.as_str()).map_or(0, Vec::len);
+        let summary = if column_count == 1 {
+            "1 column".to_string()
+        } else {
+            format!("{column_count} columns")
+        };
+        println!(
+            "  {} {}: {}",
+            s.name.paint(fname),
+            s.dimmed.paint(format!("({source})")),
+            s.value.paint(summary),
+        );
+    }
+    println!();
+}
+
+// ── Available catalogue: personalities ─────────────────────────
+
+fn show_available_personalities(s: &Styles, cfg: Option<&super::schema::Config>) {
+    use super::personality::{is_compiled_personality, personality_description};
+
+    let names = super::personality::all_personality_names();
+    println!(
+        "{} {} defined",
+        s.label.paint("Personalities:"),
+        s.value.paint(names.len().to_string())
+    );
+    for name in &names {
+        let in_config = cfg.is_some_and(|c| c.personality.contains_key(name));
+        let in_builtin = is_compiled_personality(name);
+        let source = match (in_config, in_builtin) {
+            (true, true) => "config, overrides builtin",
+            (true, false) => "config",
+            (false, true) => "builtin",
+            (false, false) => "?",
+        };
+        let desc = personality_description(name);
+        match desc.as_deref() {
+            Some(d) if !d.is_empty() => println!(
+                "  {} {}: {}",
+                s.name.paint(name),
+                s.dimmed.paint(format!("({source})")),
+                s.value.paint(d),
+            ),
+            _ => println!(
+                "  {} {}",
+                s.name.paint(name),
+                s.dimmed.paint(format!("({source})")),
+            ),
+        }
+    }
+    println!();
+}
+
+// ── Available catalogue: themes ────────────────────────────────
+
+fn show_available_themes(s: &Styles, cfg: Option<&super::schema::Config>) {
+    use super::themes::{all_theme_names, builtin_theme_description, is_builtin_theme};
+
+    let names = all_theme_names();
+    println!(
+        "{} {} defined",
+        s.label.paint("Themes:"),
+        s.value.paint(names.len().to_string())
+    );
+    for name in &names {
+        let in_config = cfg.is_some_and(|c| c.theme.contains_key(name));
+        let in_builtin = is_builtin_theme(name);
+        let source = match (in_config, in_builtin) {
+            (true, true) => "config, overrides builtin",
+            (true, false) => "config",
+            (false, true) => "builtin",
+            (false, false) => "?",
+        };
+        // User-defined description wins over builtin when the
+        // user shadows a builtin name with their own block.
+        let user_desc = cfg
+            .and_then(|c| c.theme.get(name))
+            .and_then(|t| t.description.as_deref());
+        let desc = user_desc.or_else(|| builtin_theme_description(name));
+        match desc {
+            Some(d) if !d.is_empty() => println!(
+                "  {} {}: {}",
+                s.name.paint(name),
+                s.dimmed.paint(format!("({source})")),
+                s.value.paint(d),
+            ),
+            _ => println!(
+                "  {} {}",
+                s.name.paint(name),
+                s.dimmed.paint(format!("({source})")),
+            ),
+        }
+    }
+    println!();
+}
+
+// ── Available catalogue: styles ────────────────────────────────
+
+fn show_available_styles(s: &Styles, cfg: Option<&super::schema::Config>) {
+    let names = super::styles::all_style_names();
+    println!(
+        "{} {} defined",
+        s.label.paint("Styles:"),
+        s.value.paint(names.len().to_string())
+    );
+    for name in &names {
+        let in_config = cfg.is_some_and(|c| c.style.contains_key(name));
+        let in_builtin = name == "exa";
+        let source = match (in_config, in_builtin) {
+            (true, true) => "config, overrides builtin",
+            (true, false) => "config",
+            (false, true) => "builtin",
+            (false, false) => "?",
+        };
+        // Summary: count of class references and patterns, mirroring
+        // the Classes section's "N patterns" shape.
+        let resolved = resolve_style(name);
+        let summary = match resolved {
+            Some(style) => {
+                let cls = style.classes.len();
+                let pat = style.patterns.len();
+                format!("{cls} class refs, {pat} patterns")
+            }
+            None => String::new(),
+        };
+        if summary.is_empty() {
+            println!(
+                "  {} {}",
+                s.name.paint(name),
+                s.dimmed.paint(format!("({source})")),
+            );
+        } else {
+            println!(
+                "  {} {}: {}",
+                s.name.paint(name),
+                s.dimmed.paint(format!("({source})")),
+                s.value.paint(summary),
+            );
+        }
+    }
+    println!();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -376,11 +376,13 @@ fn try_main() -> Result<i32, LxError> {
         }
 
         OptionsResult::ShowConfig {
+            mode,
             ref implicit_format,
         } => {
             let name = active_personality.as_deref().unwrap_or("lx");
             let cli_theme = find_theme_arg(&cli_args);
             config::show_config(
+                mode,
                 name,
                 personality_source,
                 cli_theme.as_deref(),

--- a/src/options/mod.rs
+++ b/src/options/mod.rs
@@ -104,7 +104,18 @@ impl Options {
                     return OptionsResult::Completions(*shell);
                 }
 
-                if clap_matches.get_flag("show-config") {
+                if clap_matches.contains_id("show-config")
+                    && clap_matches.value_source("show-config")
+                        == Some(clap::parser::ValueSource::CommandLine)
+                {
+                    let mode = match clap_matches
+                        .get_one::<String>("show-config")
+                        .map(String::as_str)
+                    {
+                        Some("full") => ShowConfigMode::Full,
+                        Some("available") => ShowConfigMode::Available,
+                        _ => ShowConfigMode::Active,
+                    };
                     // Detect the implicit `-l` tier so `--show-config`
                     // can show the effective format when no personality
                     // declares one.  An explicit `--columns` or
@@ -129,7 +140,10 @@ impl Options {
                     } else {
                         None
                     };
-                    return OptionsResult::ShowConfig { implicit_format };
+                    return OptionsResult::ShowConfig {
+                        mode,
+                        implicit_format,
+                    };
                 }
 
                 if clap_matches.contains_id("dump-class")
@@ -418,6 +432,20 @@ impl Options {
     }
 }
 
+/// Which sections of `--show-config` to emit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShowConfigMode {
+    /// Just the active half: what's currently running.  The default
+    /// when `--show-config` is given without an explicit mode.
+    Active,
+    /// Both halves: active + the available catalogue, separated by
+    /// a horizontal rule.
+    Full,
+    /// Just the catalogue half: every defined personality, format,
+    /// theme, style, and class.
+    Available,
+}
+
 /// The result of the `Options::parse` function.
 #[derive(Debug)]
 pub enum OptionsResult {
@@ -438,13 +466,20 @@ pub enum OptionsResult {
 
     /// The user wants to see the active configuration.
     ///
+    /// `mode` selects how much to show: just the active half
+    /// ("what's running"), the full output including the
+    /// available catalogue, or the catalogue alone.
+    ///
     /// `implicit_format` carries the `-l` tier name (`"long"`,
     /// `"long2"`, `"long3"`) when the user invoked `--show-config`
     /// alongside `-l` and neither `--columns` nor `--format` would
     /// override it.  `--show-config` displays this as the effective
     /// format when the active personality declares neither
     /// `format` nor `columns`.
-    ShowConfig { implicit_format: Option<String> },
+    ShowConfig {
+        mode: ShowConfigMode,
+        implicit_format: Option<String>,
+    },
 
     /// The user wants to see class definitions as TOML.
     /// Empty string means all classes; otherwise a specific class name.

--- a/src/options/parser.rs
+++ b/src/options/parser.rs
@@ -1400,9 +1400,20 @@ pub fn build_command() -> Command {
         .arg(
             Arg::new("show-config")
                 .long("show-config")
-                .help("Show the active configuration and exit")
+                .help(
+                    "Show configuration and exit\n\
+                     [active (default), full, available]",
+                )
                 .help_heading("Configuration")
-                .action(ArgAction::SetTrue),
+                .value_name("MODE")
+                .num_args(0..=1)
+                .default_missing_value("active")
+                .hide_possible_values(true)
+                .value_parser([
+                    PossibleValue::new("active"),
+                    PossibleValue::new("full"),
+                    PossibleValue::new("available"),
+                ]),
         )
         .arg(
             Arg::new("dump-class")

--- a/tests/cli_config.rs
+++ b/tests/cli_config.rs
@@ -828,6 +828,50 @@ fn show_config_explicit_columns_suppresses_implicit() {
         .stdout(predicate::str::contains("implicit, selected by").not());
 }
 
+// ── --show-config modes (active / full / available) ─────────────
+
+#[test]
+fn show_config_default_omits_catalogue() {
+    // Bare `--show-config` shows only the active half.  No
+    // `Personalities:`, `Themes:`, `Styles:`, `Classes:`, or
+    // `Formats:` catalogue headers should appear.
+    lx_no_colour()
+        .arg("--show-config")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Personality:"))
+        .stdout(predicate::str::contains("Personalities:").not())
+        .stdout(predicate::str::contains("Themes:").not())
+        .stdout(predicate::str::contains("Classes:").not());
+}
+
+#[test]
+fn show_config_full_shows_both_halves() {
+    lx_no_colour()
+        .arg("--show-config=full")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Personality:"))
+        .stdout(predicate::str::contains("Personalities:"))
+        .stdout(predicate::str::contains("Themes:"))
+        .stdout(predicate::str::contains("Classes:"));
+}
+
+#[test]
+fn show_config_available_omits_active() {
+    // `--show-config=available` shows only the catalogue.  No
+    // `Personality:`/`Format:`/`Theme:`/`Style:` singular headers.
+    lx_no_colour()
+        .arg("--show-config=available")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Personalities:"))
+        .stdout(predicate::str::contains("Themes:"))
+        .stdout(predicate::str::contains("Classes:"))
+        .stdout(predicate::str::contains("Personality:").not())
+        .stdout(predicate::str::contains("Theme:").not());
+}
+
 // ── --dump-theme ─────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
Closes wjv/lx#24.

- New `--show-config[=MODE]` selector with three values: `active` (default — just what's running), `full` (active + catalogue, separated by a horizontal rule), `available` (catalogue only).
- The catalogue lists every defined personality, format, theme, style, and class with its source and a one-line summary or `description`.
- Bare `--show-config` keeps its compact behaviour, so invocations that just want "what's running" don't get flooded with reference material that doesn't change between runs.